### PR TITLE
change paths for compiling

### DIFF
--- a/src/program/platform.cpp
+++ b/src/program/platform.cpp
@@ -23,7 +23,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <QDir>
 
-#include <src/utils/folderutils.h>
+#include <../../utils/folderutils.h>
 
 Platform::Platform(const QString &name) : QObject()
 {

--- a/src/program/programtab.cpp
+++ b/src/program/programtab.cpp
@@ -41,7 +41,7 @@ $Date: 2013-02-26 16:26:03 +0100 (Di, 26. Feb 2013) $
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 
-#include <src/sketchtoolbutton.h>
+#include <../../sketchtoolbutton.h>
 
 
 static const QChar Quote91Char(0x91);

--- a/src/program/programtab.h
+++ b/src/program/programtab.h
@@ -44,7 +44,7 @@ $Date: 2012-06-28 00:18:10 +0200 (Do, 28. Jun 2012) $
 #include <QPrinter>
 #include <QHBoxLayout>
 
-#include <src/sketchtoolbutton.h>
+#include <../../sketchtoolbutton.h>
 
 #include "programwindow.h"
 

--- a/src/program/programwindow.cpp
+++ b/src/program/programwindow.cpp
@@ -62,8 +62,9 @@ $Date: 2013-02-26 16:26:03 +0100 (Di, 26. Feb 2013) $
 #include <QCloseEvent>
 #include <QPrinter>
 #include <QPrintDialog>
-#include <QtSerialPort/QSerialPortInfo>
-
+//#include <QtSerialPort/QSerialPortInfo>
+#include <QtSerialPort/qserialportinfo.h>
+#include <QtSerialPort/qserialport.h>
 
 ///////////////////////////////////////////////
 

--- a/src/program/programwindow.h
+++ b/src/program/programwindow.h
@@ -37,7 +37,9 @@ $Date: 2013-02-26 16:26:03 +0100 (Di, 26. Feb 2013) $
 #include <QTabWidget>
 #include <QComboBox>
 #include <QActionGroup>
-#include <QSerialPortInfo>
+// #include <QSerialPort>
+#include <QtSerialPort/qserialportinfo.h>
+#include <QtSerialPort/qserialport.h>
 
 #include "platform.h"
 #include "syntaxer.h"


### PR DESCRIPTION
i have to change some paths. QT Creator could not find the files during compiling.
i do not know if this can be a regular fix. i do not use specific paths.
the same for the QTSerialPort files.
