### PR TITLE
Adjusting phoenix.pro to accept shadow build

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -131,7 +131,7 @@ unix {
         manpage.files += Fritzing.1
 
         icon.path = $$DATADIR/icons
-        icon.extra = install -D -m 0644 resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/icons/fritzing.png
+        icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/icons/fritzing.png
 
         parts.path = $$PKGDATADIR
         parts.files += parts
@@ -149,7 +149,7 @@ unix {
         bins.files += bins
 
         translations.path = $$PKGDATADIR/translations
-        translations.extra = find translations -name "*.qm" -size +128c -exec cp -pr {} $(INSTALL_ROOT)$$PKGDATADIR/translations \\;
+        translations.extra = find $$PWD/translations -name "*.qm" -size +128c -exec cp -pr {} $(INSTALL_ROOT)$$PKGDATADIR/translations \\;
 
         syntax.path = $$PKGDATADIR/translations/syntax
         syntax.files += translations/syntax/*.xml


### PR DESCRIPTION
When trying to install the application after a shadow building (i.e., _mkdir build; cd build; qmake .._), we got errors while installing image resources (_install: cannot stat ‘/resources/images/fritzing_icon.png’: No such file or directory_) and translations (_find: 'translations': No such file or directory'_).

This change is intended to fix it.

Reference: http://qt-project.org/wiki/QMake-top-level-srcdir-and-builddir
