### PR TITLE
Align to locked items (if any), otherwise align as usual.

### DIFF
--- a/src/sketch/fgraphicsscene.cpp
+++ b/src/sketch/fgraphicsscene.cpp
@@ -84,3 +84,15 @@ void FGraphicsScene::setDisplayHandles(bool displayHandles) {
 bool FGraphicsScene::displayHandles() {
     return m_displayHandles;
 }
+
+QList<ItemBase *> FGraphicsScene::lockedItems() {
+    QList<ItemBase *> items;
+    foreach (QGraphicsItem * gitem,  this->selectedItems()) {
+        ItemBase *itemBase = dynamic_cast<ItemBase *>(gitem);
+        if (itemBase == NULL) continue;
+        if (itemBase->moveLock()) {
+            items.append(itemBase);
+        }
+    }
+    return items;
+}

--- a/src/sketch/fgraphicsscene.cpp
+++ b/src/sketch/fgraphicsscene.cpp
@@ -85,7 +85,7 @@ bool FGraphicsScene::displayHandles() {
     return m_displayHandles;
 }
 
-QList<ItemBase *> FGraphicsScene::lockedItems() {
+QList<ItemBase *> FGraphicsScene::lockedSelectedItems() {
     QList<ItemBase *> items;
     foreach (QGraphicsItem * gitem,  this->selectedItems()) {
         ItemBase *itemBase = dynamic_cast<ItemBase *>(gitem);

--- a/src/sketch/fgraphicsscene.h
+++ b/src/sketch/fgraphicsscene.h
@@ -43,7 +43,7 @@ public:
 	QPointF lastContextMenuPos();
     void setDisplayHandles(bool);
     bool displayHandles();
-    QList<ItemBase *> lockedItems();
+    QList<ItemBase *> lockedSelectedItems();
 
 protected:
 	QPointF m_lastContextMenuPos;

--- a/src/sketch/fgraphicsscene.h
+++ b/src/sketch/fgraphicsscene.h
@@ -30,6 +30,7 @@ $Date: 2013-02-26 16:26:03 +0100 (Di, 26. Feb 2013) $
 #include <QGraphicsScene>
 #include <QPainter>
 #include <QGraphicsSceneHelpEvent>
+#include "../items/itembase.h"
 
 class FGraphicsScene : public QGraphicsScene
 {
@@ -42,6 +43,7 @@ public:
 	QPointF lastContextMenuPos();
     void setDisplayHandles(bool);
     bool displayHandles();
+    QList<ItemBase *> lockedItems();
 
 protected:
 	QPointF m_lastContextMenuPos;

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -9712,6 +9712,14 @@ void SketchWidget::alignItems(Qt::Alignment alignment) {
 
     foreach (Wire * w, unsavedSet) m_savedItems.remove(w->id());
 
+    // If locked items are included, use them as the basis for finding
+    // the bounding box wherein remaining (unlocked) items will be aligned
+    QList<ItemBase *> lockedItems = qobject_cast<FGraphicsScene *>(this->scene())->lockedItems();
+    QList<ItemBase *> boundingItems = lockedItems.count() > 0 ?
+        lockedItems : m_savedItems.values();
+
+    if (boundingItems.count() < 1 || m_savedItems.count() < 2) return;
+
     int count = 0;
     double left = std::numeric_limits<int>::max();
     double top = std::numeric_limits<int>::max();
@@ -9719,7 +9727,7 @@ void SketchWidget::alignItems(Qt::Alignment alignment) {
     double bottom = std::numeric_limits<int>::min();
     double hcTotal = 0;
     double vcTotal = 0;
-    foreach (ItemBase * itemBase, m_savedItems) {
+    foreach (ItemBase * itemBase, boundingItems) {
         QRectF r = itemBase->sceneBoundingRect();
         if (r.left() < left) left = r.left();
         if (r.right() > right) right = r.right();
@@ -9731,7 +9739,10 @@ void SketchWidget::alignItems(Qt::Alignment alignment) {
         vcTotal += center.y();
     }
 
-    if (count < 2) return;
+    if (count < 1) {
+        DebugDialog::debug("no items for alignment bounding box");
+        return;
+    }
 
     hcTotal /= count;
     vcTotal /= count;

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -9714,7 +9714,7 @@ void SketchWidget::alignItems(Qt::Alignment alignment) {
 
     // If locked items are included, use them as the basis for finding
     // the bounding box wherein remaining (unlocked) items will be aligned
-    QList<ItemBase *> lockedItems = qobject_cast<FGraphicsScene *>(this->scene())->lockedItems();
+    QList<ItemBase *> lockedItems = qobject_cast<FGraphicsScene *>(this->scene())->lockedSelectedItems();
     QList<ItemBase *> boundingItems = lockedItems.count() > 0 ?
         lockedItems : m_savedItems.values();
 


### PR DESCRIPTION
This allows users to align items to one or more locked items. For example, if the user locks the PCB in the background, and then selects several components INCLUDING the locked PCB, all components will be (left | right | center) aligned to the PCB. If no selected items are locked, the aligning functions work as before.