### PR TITLE
Cursor-centered zooming, trackpad support on Mac OS X

### DIFF
--- a/src/autoroute/zoomcontrols.cpp
+++ b/src/autoroute/zoomcontrols.cpp
@@ -49,7 +49,7 @@ ZoomButton::ZoomButton(QBoxLayout::Direction dir, ZoomButton::ZoomType type, Zoo
 
 void ZoomButton::zoom() {
 	int inOrOut = m_type == ZoomButton::ZoomIn? 1: -1;
-	m_owner->relativeZoom(inOrOut*m_step, false);
+	m_owner->relativeZoom(inOrOut*m_step, QPoint());
 	m_owner->ensureFixedToBottomRightItems();
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -3168,11 +3168,11 @@ void MainWindow::initZoom() {
         parts = true;
         break;
     }
-			
+
     if (parts) {
         m_currentGraphicsView->fitInWindow();
     }
-		
+
     m_currentGraphicsView->setEverZoomed(true);
 }
 

--- a/src/sketch/zoomablegraphicsview.cpp
+++ b/src/sketch/zoomablegraphicsview.cpp
@@ -33,166 +33,221 @@ $Date: 2013-04-21 09:50:09 +0200 (So, 21. Apr 2013) $
 #include "../utils/zoomslider.h"
 #include "../utils/misc.h"
 
+const int ZoomableGraphicsView::MinScaleValue = 5;
 const int ZoomableGraphicsView::MaxScaleValue = 3000;
-
 
 ZoomableGraphicsView::WheelMapping ZoomableGraphicsView::m_wheelMapping =
 #ifdef Q_OS_WIN
-	ZoomPrimary;
+    ZoomPrimary;
 #else
-	ScrollPrimary;
+    ScrollPrimary;
 #endif
 
 bool FirstTime = true;
 
 ZoomableGraphicsView::ZoomableGraphicsView( QWidget * parent )
-	: QGraphicsView(parent)
+    : QGraphicsView(parent)
 {
     m_viewFromBelow = false;
-	m_scaleValue = 100;
-	m_maxScaleValue = MaxScaleValue;
-	m_minScaleValue = 1;
-	m_acceptWheelEvents = true;
-	if (FirstTime) {
-		FirstTime = false;
-		QSettings settings;
-		m_wheelMapping = (WheelMapping) settings.value("wheelMapping", m_wheelMapping).toInt();
-		if (m_wheelMapping >= WheelMappingCount) {
-			m_wheelMapping = ScrollPrimary;
-		}
-	}
-	//setViewport(new QGLWidget);
+    m_scaleValue = 100;
+    m_minScaleValue = MinScaleValue;
+    m_maxScaleValue = MaxScaleValue;
+    m_acceptWheelEvents = true;
+    m_initialModifiers = 0;
+    m_stuckModifierTimer = new QTimer(this);
+    m_stuckModifierTimer->setSingleShot(true);
+    connect(m_stuckModifierTimer, SIGNAL(timeout()), this, SLOT(unstickModifiers()));
+
+    if (FirstTime) {
+        FirstTime = false;
+        QSettings settings;
+        m_wheelMapping = (WheelMapping) settings.value("wheelMapping", m_wheelMapping).toInt();
+        if (m_wheelMapping >= WheelMappingCount) {
+            m_wheelMapping = ScrollPrimary;
+        }
+    }
+    //setViewport(new QGLWidget);
+}
+
+void ZoomableGraphicsView::unstickModifiers() {
+    m_initialModifiers = 0;
 }
 
 void ZoomableGraphicsView::wheelEvent(QWheelEvent* event) {
-	if (!m_acceptWheelEvents) {
-		QGraphicsView::wheelEvent(event);
-		return;
-	}
-    if ((event->modifiers() & Qt::ShiftModifier) != 0) {
-		QGraphicsView::wheelEvent(event);
-		return;
+    if (!m_acceptWheelEvents) {
+        QGraphicsView::wheelEvent(event);
+        return;
     }
 
-	bool doZoom = false;
-	bool doHorizontal = false;
-	bool doVertical = false;
+#ifdef Q_OS_MAC
+    // On Mac OS, wheel events can have inertia, so we should only honor the
+    // modifier key state at the beginning of the "scroll phase".
+    if (event->phase() == Qt::ScrollBegin) {
+        m_initialModifiers = event->modifiers();
+    }
+    else if (m_initialModifiers == 0) {
+        m_initialModifiers = event->modifiers();
+    }
+    // Unfortunately, due to some issues in QT 5.2.x, the scroll phase can
+    // go unreported or trigger incorrectly. In order to relieve "stuck" states,
+    // we use a timer to "unstick" the modifier state. This should be fixed in
+    // QT 5.5.x.
+    if (m_stuckModifierTimer->isActive()) {
+        m_stuckModifierTimer->stop();
+    }
+    // 100 msec wait after wheel events should suffice
+    m_stuckModifierTimer->start(100);
+#else
+    m_initialModifiers = event->modifiers();
+#endif
 
-	bool control = event->modifiers() & Qt::ControlModifier;
-	bool alt = event->modifiers() & altOrMetaModifier();
-	bool shift = event->modifiers() & Qt::ShiftModifier;
+    bool control = m_initialModifiers & Qt::ControlModifier;
+    bool alt = m_initialModifiers & altOrMetaModifier();
+    bool shift = m_initialModifiers & Qt::ShiftModifier;
 
-	switch (m_wheelMapping) {
-		case ScrollPrimary:
-			if (control || alt) doZoom = true;
-			else {
-				if (event->orientation() == Qt::Horizontal) {
-					doHorizontal = true;
-				}
-				else {
-					doVertical = true;
-				}
-			}
-			break;
-		case ZoomPrimary:
-			if (control || alt) {
-				if (event->orientation() == Qt::Horizontal) {
-					doHorizontal = true;
-				}
-				else {
-					doVertical = true;
-				}
-			}
-			else doZoom = true;
-			break;
-		default:
-			// shouldn't happen
-			return;
-	}
+    if (shift) {
+        QGraphicsView::wheelEvent(event);
+        return;
+    }
 
-	if (shift && (doVertical || doHorizontal)) {
-		if (doVertical) {
-			doVertical = false;
-			doHorizontal = true;
-		}
-		else {
-			doVertical = true;
-			doHorizontal = false;
-		}
-	}
+    bool doZoom = false;
+    bool doHorizontal = false;
+    bool doVertical = false;
 
-	int numSteps = event->delta() / 8;
-	if (doZoom) {
-		double delta = ((double) event->delta() / 120) * ZoomSlider::ZoomStep;
-		if (delta == 0) return;
+    // doZoom = true;
+    switch (m_wheelMapping) {
+     case ScrollPrimary:
+         if (control || alt) doZoom = true;
+         else {
+             if (event->orientation() == Qt::Horizontal) {
+                 doHorizontal = true;
+             }
+             else {
+                 doVertical = true;
+             }
+         }
+         break;
+     case ZoomPrimary:
+         if (control || alt) {
+             if (event->orientation() == Qt::Horizontal) {
+                 doHorizontal = true;
+             }
+             else {
+                 doVertical = true;
+             }
+         }
+         else doZoom = true;
+         break;
+     default:
+         // shouldn't happen
+         return;
+    }
 
-		// Scroll zooming relative to the current size
-		relativeZoom(2*delta, true);
+    if (shift && (doVertical || doHorizontal)) {
+        if (doVertical) {
+            doVertical = false;
+            doHorizontal = true;
+        }
+        else {
+            doVertical = true;
+            doHorizontal = false;
+        }
+    }
 
-		emit wheelSignal();
-	}
-	else if (doVertical) {
-		verticalScrollBar()->setValue( verticalScrollBar()->value() - numSteps);
-	}
-	else if (doHorizontal) {
-		horizontalScrollBar()->setValue( horizontalScrollBar()->value() - numSteps);
-	}
+    int numSteps = event->delta() / 8;
+    if (doZoom) {
+        double delta = ((double) event->delta() / 120) * ZoomSlider::ZoomStep;
+        if (delta == 0) return;
+
+        // Scroll zooming relative to the current size
+        relativeZoom(delta, event->pos());
+
+        emit wheelSignal();
+    }
+    else if (doVertical) {
+        verticalScrollBar()->setValue( verticalScrollBar()->value() - numSteps);
+    }
+    else if (doHorizontal) {
+        horizontalScrollBar()->setValue( horizontalScrollBar()->value() - numSteps);
+    }
 }
 
-void ZoomableGraphicsView::relativeZoom(double step, bool centerOnCursor) {
-	double tempSize = m_scaleValue + step;
-	if (tempSize < m_minScaleValue) {
-		m_scaleValue = m_minScaleValue;
-		emit zoomOutOfRange(m_scaleValue);
-		return;
-	}
-	if (tempSize > m_maxScaleValue) {
-		m_scaleValue = m_maxScaleValue;
-		emit zoomOutOfRange(m_scaleValue);
-		return;
-	}
-	double tempScaleValue = tempSize/100;
+void ZoomableGraphicsView::relativeZoom(double step, QPoint viewCenterPos) {
+    double newScaleValue = m_scaleValue + step;
 
-	m_scaleValue = tempSize;
+    // Prevent zooming out too much
+    if (newScaleValue < m_minScaleValue) {
+        m_scaleValue = m_minScaleValue;
+        emit zoomOutOfRange(m_scaleValue);
+        return;
+    }
 
-	//QPoint p = QCursor::pos();
-	//QPoint q = this->mapFromGlobal(p);
-	//QPointF r = this->mapToScene(q);
+    // Prevent zooming in too much
+    if (newScaleValue > m_maxScaleValue) {
+        m_scaleValue = m_maxScaleValue;
+        emit zoomOutOfRange(m_scaleValue);
+        return;
+    }
 
-	QMatrix matrix;
-    double multiplier = 1;
-    if (m_viewFromBelow) multiplier = -1;
-	matrix.scale(multiplier * tempScaleValue, tempScaleValue);
-	if (centerOnCursor) {
-		//this->setMatrix(QMatrix().translate(-r.x(), -r.y()) * matrix * QMatrix().translate(r.x(), r.y()));
-        this->setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
-	}
-	else {
-		this->setTransformationAnchor(QGraphicsView::AnchorViewCenter);
-	}
-	this->setMatrix(matrix);
+    // Zoom Factor
+    QPointF oldPos;
 
-	emit zoomChanged(m_scaleValue);
+    // We'll be doing the job that anchors are supposed to do, so use NoAnchor
+    this->setTransformationAnchor(QGraphicsView::NoAnchor);
+    this->setResizeAnchor(QGraphicsView::NoAnchor);
+
+    if (!viewCenterPos.isNull()) {
+        // Save the scene position prior to zooming
+        oldPos = this->mapToScene(viewCenterPos);
+    }
+
+    // Zoom
+    double zoomFactor = newScaleValue / m_scaleValue;
+    this->scale(zoomFactor, zoomFactor);
+
+    // Translate viewport back to the place we should be centered on (usually
+    // the mouse), if the position is given.
+    if (!viewCenterPos.isNull()) { 
+        // Get the scene position after zooming
+        QPointF newPos = this->mapToScene(viewCenterPos);
+        QPointF delta = newPos - oldPos;
+
+        if (this->horizontalScrollBar()->isVisible()) {
+            // If scroll bars are visible, we just translate the viewport
+            this->translate(delta.x(), delta.y());
+        } else {
+            // Otherwise, we need to resize the scene to keep its center on point
+            QRectF sr = this->sceneRect();
+            this->setSceneRect(
+                sr.left() - delta.x(),
+                sr.top() - delta.y(),
+                sr.width(),
+                sr.height());
+        }
+    }
+
+    m_scaleValue = newScaleValue;
+    emit zoomChanged(m_scaleValue);
 }
 
 void ZoomableGraphicsView::absoluteZoom(double percent) {
-	relativeZoom(percent-m_scaleValue, false);
+    relativeZoom(percent - m_scaleValue, QPoint());
 }
 
 double ZoomableGraphicsView::currentZoom() {
-	return m_scaleValue;
+    return m_scaleValue;
 }
 
 void ZoomableGraphicsView::setAcceptWheelEvents(bool accept) {
-	m_acceptWheelEvents = accept;
+    m_acceptWheelEvents = accept;
 }
 
 void ZoomableGraphicsView::setWheelMapping(WheelMapping wm) {
-	m_wheelMapping = wm;
+    m_wheelMapping = wm;
 }
 
 ZoomableGraphicsView::WheelMapping ZoomableGraphicsView::wheelMapping() {
-	return m_wheelMapping;
+    return m_wheelMapping;
 }
 
 bool ZoomableGraphicsView::viewFromBelow() {

--- a/src/sketch/zoomablegraphicsview.h
+++ b/src/sketch/zoomablegraphicsview.h
@@ -31,52 +31,59 @@ $Date: 2013-04-21 09:50:09 +0200 (So, 21. Apr 2013) $
 #include <QMenu>
 #include <QHash>
 #include <QList>
+#include <QTimer>
 
 
 class ZoomableGraphicsView : public QGraphicsView
 {
-	Q_OBJECT
+    Q_OBJECT
 
 public:
-	ZoomableGraphicsView(QWidget* parent = 0);
+    ZoomableGraphicsView(QWidget* parent = 0);
 
-    void relativeZoom(double step, bool centerToCursor);
+    void relativeZoom(double step, QPoint viewCenterPos);
     void absoluteZoom(double percent);
- 	double currentZoom();
-	void setAcceptWheelEvents(bool);
-	virtual void ensureFixedToBottomRightItems() {}
+    double currentZoom();
+    void setAcceptWheelEvents(bool);
+    virtual void ensureFixedToBottomRightItems() {}
     bool viewFromBelow();
     virtual void setViewFromBelow(bool);
 
+    static const int MinScaleValue;
     static const int MaxScaleValue;
-	
-public:	
-	enum WheelMapping {
-		ScrollPrimary,
-		ZoomPrimary,
-		WheelMappingCount
-	};
 
-	static WheelMapping wheelMapping();
-	static void setWheelMapping(WheelMapping);
+public: 
+    enum WheelMapping {
+        ScrollPrimary,
+        ZoomPrimary,
+        WheelMappingCount
+    };
+
+    static WheelMapping wheelMapping();
+    static void setWheelMapping(WheelMapping);
 
 signals:
-	void zoomChanged(double zoom);
-	void zoomOutOfRange(double zoom);
-	void wheelSignal();
+    void zoomChanged(double zoom);
+    void zoomOutOfRange(double zoom);
+    void wheelSignal();
+
+protected slots:
+    void unstickModifiers();
 
 protected:
-	virtual void wheelEvent(QWheelEvent* event);
+    virtual void wheelEvent(QWheelEvent* event);
 
 protected:
-	double m_scaleValue;
-	int m_maxScaleValue;
-	int m_minScaleValue;
-	bool m_acceptWheelEvents;
+    double m_scaleValue;
+    int m_maxScaleValue;
+    int m_minScaleValue;
+    bool m_acceptWheelEvents;
     bool m_viewFromBelow;
+    int m_initialModifiers;
+    QTimer *m_stuckModifierTimer;
 
 protected:
-	static WheelMapping m_wheelMapping;
+    static WheelMapping m_wheelMapping;
 };
 
 #endif


### PR DESCRIPTION
This fixes some scrolling & zooming issues I was seeing, specifically on Mac OS X. It may also improve zooming accuracy on all platforms--the method that tracks where the mouse cursor is, and zooms/pans to that location is improved with this patch set.

See https://vimeo.com/133090520 for a demo of before/after.