### PR TITLE
Fix unicode 'degrees' symbol in Rotate menu

### DIFF
--- a/src/items/partlabel.cpp
+++ b/src/items/partlabel.cpp
@@ -447,37 +447,37 @@ void PartLabel::initMenu()
 	bool include45 = (m_owner != NULL) && (m_owner->viewID() == ViewLayer::PCBView);
 
 	if (include45) {
-		QAction *rotate45cwAct = rlmenu->addAction(tr("Rotate 45\x00B0 Clockwise"));
+		QAction *rotate45cwAct = rlmenu->addAction(tr("Rotate 45\u00B0 Clockwise"));
 		rotate45cwAct->setData(QVariant(PartLabelRotate45CW));
 		rotate45cwAct->setStatusTip(tr("Rotate the label by 45 degrees clockwise"));
 	}
 
-    QAction *rotate90cwAct = rlmenu->addAction(tr("Rotate 90\x00B0 Clockwise"));
+    QAction *rotate90cwAct = rlmenu->addAction(tr("Rotate 90\u00B0 Clockwise"));
 	rotate90cwAct->setData(QVariant(PartLabelRotate90CW));
 	rotate90cwAct->setStatusTip(tr("Rotate the label by 90 degrees clockwise"));
 
 	if (include45) {
-		QAction *rotate135cwAct = rlmenu->addAction(tr("Rotate 135\x00B0 Clockwise"));
+		QAction *rotate135cwAct = rlmenu->addAction(tr("Rotate 135\u00B0 Clockwise"));
 		rotate135cwAct->setData(QVariant(PartLabelRotate135CW));
 		rotate135cwAct->setStatusTip(tr("Rotate the label by 135 degrees clockwise"));
 	}
 
- 	QAction *rotate180Act = rlmenu->addAction(tr("Rotate 180\x00B0"));
+ 	QAction *rotate180Act = rlmenu->addAction(tr("Rotate 180\u00B0"));
 	rotate180Act->setData(QVariant(PartLabelRotate180));
 	rotate180Act->setStatusTip(tr("Rotate the label by 180 degrees"));
   
 	if (include45) {
-		QAction *rotate135ccwAct = rlmenu->addAction(tr("Rotate 135\x00B0 Counter Clockwise"));
+		QAction *rotate135ccwAct = rlmenu->addAction(tr("Rotate 135\u00B0 Counter Clockwise"));
 		rotate135ccwAct->setData(QVariant(PartLabelRotate135CCW));
 		rotate135ccwAct->setStatusTip(tr("Rotate the label by 135 degrees counter clockwise"));
 	}
 
-	QAction *rotate90ccwAct = rlmenu->addAction(tr("Rotate 90\x00B0 Counter Clockwise"));
+	QAction *rotate90ccwAct = rlmenu->addAction(tr("Rotate 90\u00B0 Counter Clockwise"));
 	rotate90ccwAct->setData(QVariant(PartLabelRotate90CCW));
 	rotate90ccwAct->setStatusTip(tr("Rotate current selection 90 degrees counter clockwise"));
 		
 	if (include45) {
-		QAction *rotate45ccwAct = rlmenu->addAction(tr("Rotate 45\x00B0 Counter Clockwise"));
+		QAction *rotate45ccwAct = rlmenu->addAction(tr("Rotate 45\u00B0 Counter Clockwise"));
 		rotate45ccwAct->setData(QVariant(PartLabelRotate45CCW));
 		rotate45ccwAct->setStatusTip(tr("Rotate the label by 45 degrees counter clockwise"));
 	}

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -973,23 +973,23 @@ void MainWindow::createPartMenuActions() {
 #endif
 
 
-	m_rotate45cwAct = new QAction(tr("Rotate 45\x00B0 Clockwise"), this);
+	m_rotate45cwAct = new QAction(tr("Rotate 45\u00B0 Clockwise"), this);
 	m_rotate45cwAct->setStatusTip(tr("Rotate current selection 45 degrees clockwise"));
 	connect(m_rotate45cwAct, SIGNAL(triggered()), this, SLOT(rotate45cw()));
 
-	m_rotate90cwAct = new QAction(tr("Rotate 90\x00B0 Clockwise"), this);
+	m_rotate90cwAct = new QAction(tr("Rotate 90\u00B0 Clockwise"), this);
 	m_rotate90cwAct->setStatusTip(tr("Rotate the selected parts by 90 degrees clockwise"));
 	connect(m_rotate90cwAct, SIGNAL(triggered()), this, SLOT(rotate90cw()));
 
-	m_rotate180Act = new QAction(tr("Rotate 180\x00B0"), this);
+	m_rotate180Act = new QAction(tr("Rotate 180\u00B0"), this);
 	m_rotate180Act->setStatusTip(tr("Rotate the selected parts by 180 degrees"));
 	connect(m_rotate180Act, SIGNAL(triggered()), this, SLOT(rotate180()));
 
-	m_rotate90ccwAct = new QAction(tr("Rotate 90\x00B0 Counter Clockwise"), this);
+	m_rotate90ccwAct = new QAction(tr("Rotate 90\u00B0 Counter Clockwise"), this);
 	m_rotate90ccwAct->setStatusTip(tr("Rotate current selection 90 degrees counter clockwise"));
 	connect(m_rotate90ccwAct, SIGNAL(triggered()), this, SLOT(rotate90ccw()));
 
-	m_rotate45ccwAct = new QAction(tr("Rotate 45\x00B0 Counter Clockwise"), this);
+	m_rotate45ccwAct = new QAction(tr("Rotate 45\u00B0 Counter Clockwise"), this);
 	m_rotate45ccwAct->setStatusTip(tr("Rotate current selection 45 degrees counter clockwise"));
 	connect(m_rotate45ccwAct, SIGNAL(triggered()), this, SLOT(rotate45ccw()));
 


### PR DESCRIPTION
At least on Mac OS, the 'degrees' symbol in the Rotate menu was showing up as a diamond-question-mark character. It appears the cause was a '\x' being used to describe unicode characters where '\u' would do.

https://dl.dropboxusercontent.com/u/118766/fritzing-unicode-before-after.png