### PR TITLE
Add 'Wire' to distinguish 'Raise and Lower' menus

### DIFF
--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -1339,7 +1339,7 @@ void MainWindow::createZOrderSubmenu(QMenu * parentMenu) {
 }
 
 void MainWindow::createZOrderWireSubmenu(QMenu * parentMenu) {
-    QMenu *zOrderWireMenu = parentMenu->addMenu(tr("Raise and Lower"));
+    QMenu *zOrderWireMenu = parentMenu->addMenu(tr("Raise and Lower Wire"));
     zOrderWireMenu->addAction(m_bringToFrontWireAct);
     zOrderWireMenu->addAction(m_bringForwardWireAct);
     zOrderWireMenu->addAction(m_sendBackwardWireAct);


### PR DESCRIPTION
I'm uncertain about the reason for having two "Raise and Lower" menus, but we should at least distinguish the visible names in the menu so they don't look like mistaken duplication.