### PR TITLE
Load/Save as uncompressed fz file

### DIFF
--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -2475,12 +2475,7 @@ bool MainWindow::saveAs() {
     }
 
 	bool result = false;
-	if (m_fwFilename.endsWith(FritzingSketchExtension)) {
-		result = FritzingWindow::saveAs(m_fwFilename + 'z', false);
-	}
-	else {
-		result = FritzingWindow::saveAs();
-	}
+	result = FritzingWindow::saveAs();
 	if (result) {
 		QSettings settings;
 		settings.setValue("lastOpenSketch", m_fwFilename);
@@ -2676,12 +2671,14 @@ bool MainWindow::hasLinkedProgramFiles(const QString & filename, QStringList & l
 }
 
 QString MainWindow::getExtensionString() {
-	return tr("Fritzing (*%1)").arg(fileExtension());
+	return tr("Fritzing (*%1)").arg(FritzingBundleExtension) + ";;" + \
+	       tr("Fritzing uncompressed (*%1)").arg(FritzingSketchExtension);
 }
 
 QStringList MainWindow::getExtensions() {
 	QStringList extensions;
-	extensions.append(fileExtension());
+	extensions.append(FritzingBundleExtension);
+	extensions.append(FritzingSketchExtension);
 	return extensions;
 }
 

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -307,46 +307,18 @@ bool MainWindow::loadWhich(const QString & fileName, bool setAsLastOpened, bool 
 	bool result = false;
     if (fileName.endsWith(FritzingSketchExtension)) {
 		QFileInfo info(fileName);
-		FMessageBox messageBox(NULL);
-		messageBox.setWindowTitle(tr("the .fz file format is obsolete"));
-		messageBox.setText(tr("The .fz file format has been deprecated.\n\nWould you like to convert '%1' to the .fzz format now or open it read-only?\n").arg(info.fileName()));
-		messageBox.setInformativeText(tr("The conversion process will not modify '%1'.").arg(info.fileName()));
-		messageBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-		messageBox.setDefaultButton(QMessageBox::Yes);
-		messageBox.setIcon(QMessageBox::Question);
-		messageBox.setWindowModality(Qt::WindowModal);
-		messageBox.setButtonText(QMessageBox::Yes, tr("Convert"));
-		messageBox.setButtonText(QMessageBox::No, tr("Read-only"));
-		messageBox.setButtonText(QMessageBox::Cancel, tr("Cancel"));
-		QMessageBox::StandardButton answer = (QMessageBox::StandardButton) messageBox.exec();
-
-		if (answer == QMessageBox::Cancel) return false;
 
 		QString bundledFileName;
-		if (answer == QMessageBox::Yes) {
-			QString fileExt;
-			bundledFileName = FolderUtils::getSaveFileName(this, tr("Please specify an .fzz file name to save '%1' to").arg(info.fileName()), fileName + "z", tr("Fritzing (*%1)").arg(FritzingBundleExtension), &fileExt);
-			if (bundledFileName.isEmpty()) return false;	
-		}
-
-    	mainLoad(fileName, displayName, checkObsolete);
+		mainLoad(fileName, displayName, checkObsolete);
 		result = true;
 
 		QFile file(fileName);
 		QDir dest(m_fzzFolder);
 		FolderUtils::slamCopy(file, dest.absoluteFilePath(info.fileName()));			// copy the .fz file directly
-
-		if (answer == QMessageBox::Yes) {
-			saveAsShareable(bundledFileName, false);					// false to prevent saving a bundle inside the bundle
-			setCurrentFile(bundledFileName, addToRecent, setAsLastOpened);
-		}
-		else {
-			this->setReadOnly(true);
-			setCurrentFile(fileName, false, false);
-		}
+		setCurrentFile(fileName, false, false);
     } 
 	else if(fileName.endsWith(FritzingBundleExtension)) {
-    	loadBundledSketch(fileName, addToRecent, setAsLastOpened, checkObsolete);
+		loadBundledSketch(fileName, addToRecent, setAsLastOpened, checkObsolete);
 		result = true;
     } 
 	else if (

--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -341,15 +341,51 @@ void FolderUtils::rmdir(QDir & dir) {
 }
 
 
-bool shouldFakeCompression(const QString &filepath) {
-	return true;
+bool FolderUtils::createFZAndSaveTo(const QDir &dirToCompress, const QString &filepath, const QStringList & skipSuffixes) {
+	DebugDialog::debug("saveASfz "+dirToCompress.path()+" into "+filepath);
+
+	QFileInfoList files=dirToCompress.entryInfoList();
+	QFile inFile;
 	
+	char c;
+
+	QString currFolderBU = QDir::currentPath();
+	QDir::setCurrent(dirToCompress.path());
+	foreach(QFileInfo file, files) {
+		if(!file.isFile()||file.fileName()==filepath) continue;
+		if (file.fileName().contains(LockManager::LockedFileName)) continue;
+
+        bool skip = false;
+        foreach (QString suffix, skipSuffixes) {
+            if (file.fileName().endsWith(suffix)) {
+                skip = true;
+                break;
+            }
+        }
+        if (skip) continue;
+
+		inFile.setFileName(file.fileName());
+
+		if(!inFile.open(QIODevice::ReadOnly)) {
+			qWarning("inFile.open(): %s", inFile.errorString().toLocal8Bit().constData());
+			return false;
+		}
+		QString destination = QFileInfo(filepath).dir().filePath(inFile.fileName());
+		if (QFileInfo(destination).exists())
+			QFile::remove(destination);
+		DebugDialog::debug("Destination " + destination);
+		inFile.copy(destination);
+
+		inFile.close();
+	}
+	QDir::setCurrent(currFolderBU);
+
+	return true;
 }
+
 
 bool FolderUtils::createZipAndSaveTo(const QDir &dirToCompress, const QString &filepath, const QStringList & skipSuffixes) {
 	DebugDialog::debug("zipping "+dirToCompress.path()+" into "+filepath);
-
-	bool fakeCompression = shouldFakeCompression(filepath);
 
 	QString tempZipFile = QDir::temp().path()+"/"+TextUtils::getRandText()+".zip";
 	DebugDialog::debug("temp file: "+tempZipFile);
@@ -361,13 +397,12 @@ bool FolderUtils::createZipAndSaveTo(const QDir &dirToCompress, const QString &f
 
 	QFileInfoList files=dirToCompress.entryInfoList();
 	QFile inFile;
-	
+	QuaZipFile outFile(&zip);
 	char c;
 
 	QString currFolderBU = QDir::currentPath();
 	QDir::setCurrent(dirToCompress.path());
 	foreach(QFileInfo file, files) {
-		DebugDialog::debug("Examining " + file.fileName());
 		if(!file.isFile()||file.fileName()==filepath) continue;
 		if (file.fileName().contains(LockManager::LockedFileName)) continue;
 
@@ -389,32 +424,21 @@ bool FolderUtils::createZipAndSaveTo(const QDir &dirToCompress, const QString &f
 			qWarning("inFile.open(): %s", inFile.errorString().toLocal8Bit().constData());
 			return false;
 		}
-		if (!fakeCompression) {
-			QuaZipFile outFile(&zip);
-			if (!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(inFile.fileName(), inFile.fileName()))) {
-				qWarning("outFile.open(): %d", outFile.getZipError());
-				return false;
-			}
-
-			while (inFile.getChar(&c) && outFile.putChar(c)) {}
-
-			if (outFile.getZipError() != UNZ_OK) {
-				qWarning("outFile.putChar(): %d", outFile.getZipError());
-				return false;
-			}
-			outFile.close();
-			if (outFile.getZipError() != UNZ_OK) {
-				qWarning("outFile.close(): %d", outFile.getZipError());
-				return false;
-			}
+		if(!outFile.open(QIODevice::WriteOnly, QuaZipNewInfo(inFile.fileName(), inFile.fileName()))) {
+			qWarning("outFile.open(): %d", outFile.getZipError());
+			return false;
 		}
-		else {
-			QString destination = QFileInfo(filepath).dir().filePath(inFile.fileName());
-			if (QFileInfo(destination).exists())
-				QFile::remove(destination);
-			DebugDialog::debug("Destination " + destination);
-			inFile.copy(destination);
-			
+
+		while(inFile.getChar(&c)&&outFile.putChar(c)){}
+
+		if(outFile.getZipError()!=UNZ_OK) {
+			qWarning("outFile.putChar(): %d", outFile.getZipError());
+			return false;
+		}
+		outFile.close();
+		if(outFile.getZipError()!=UNZ_OK) {
+			qWarning("outFile.close(): %d", outFile.getZipError());
+			return false;
 		}
 		inFile.close();
 	}
@@ -425,173 +449,124 @@ bool FolderUtils::createZipAndSaveTo(const QDir &dirToCompress, const QString &f
 		// if we're here the usr has already accepted to overwrite
 		QFile::remove(filepath);
 	}
-	if (fakeCompression) {
-		QFile fzzFile(filepath);
-		fzzFile.open(QIODevice::WriteOnly);
-		fzzFile.write("This file needs to be opened with the special version of Fritzing that allows uncompressed files.\n");
+	QFile file(tempZipFile);
+	FolderUtils::slamCopy(file, filepath);
+	file.remove();
 
-		foreach(QFileInfo file, files) {
-			DebugDialog::debug("Examining " + file.fileName());
-			if (!file.isFile() || file.fileName() == filepath) continue;
-			if (file.fileName().contains(LockManager::LockedFileName)) continue;
-
-			bool skip = false;
-			foreach(QString suffix, skipSuffixes) {
-				if (file.fileName().endsWith(suffix)) {
-					skip = true;
-					break;
-				}
-			}
-			if (!skip) {
-				fzzFile.write(file.fileName().toLocal8Bit());
-				fzzFile.write("\n");
-			}
-		}
-		fzzFile.close();
-	}
-	else {
-		QFile file(tempZipFile);
-		FolderUtils::slamCopy(file, filepath);
-		file.remove();
-
-		if (zip.getZipError() != 0) {
-			qWarning("zip.close(): %d", zip.getZipError());
-			return false;
-		}
+	if(zip.getZipError()!=0) {
+		qWarning("zip.close(): %d", zip.getZipError());
+		return false;
 	}
 	return true;
 }
+
 
 
 bool FolderUtils::unzipTo(const QString &filepath, const QString &dirToDecompress, QString & error) {
     static QChar badCharacters[] = { '\\', '/', ':', '*', '?', '"', '<', '>', '|' };
     static QChar underscore('_');
 
-	bool fakeCompression = shouldFakeCompression(filepath);
-	if (fakeCompression) {
-		QFile fzz(filepath);
-		fzz.open(QIODevice::ReadOnly);
-		auto message = fzz.readLine();
-		QByteArray fileToCopy;
-		while ((fileToCopy = fzz.readLine()).length() > 0) {
-			fileToCopy = fileToCopy.remove(fileToCopy.length() - 1, 1);//Remove \n
-			QString sourcePath = QFileInfo(filepath).dir().filePath(fileToCopy);
-
-			QFile source(sourcePath);
-			QDir destDir(dirToDecompress);
-			QString destFilename = destDir.filePath(fileToCopy);
-			DebugDialog::debug("Copying file " + sourcePath + " to " + destFilename);
-			if (QFileInfo(destFilename).exists())
-				QFile::remove(destFilename);
-			if (!source.copy(destFilename)) {
-				error = QString("Copy failed ");
-				DebugDialog::debug(error);
-				return false;
-			}
-		}
+	QuaZip zip(filepath);
+	if(!zip.open(QuaZip::mdUnzip)) {
+        error = QString("zip.open(): %d").arg(zip.getZipError());
+		DebugDialog::debug(error);
+		return false;
 	}
-	else {
-		QuaZip zip(filepath);
-		if (!zip.open(QuaZip::mdUnzip)) {
-			error = QString("zip.open(): %d").arg(zip.getZipError());
+
+	zip.setFileNameCodec("IBM866");
+	DebugDialog::debug(QString("unzipping %1 entries from %2").arg(zip.getEntriesCount()).arg(filepath));
+	QuaZipFileInfo info;
+	QuaZipFile file(&zip);
+	QFile out;
+	QString name;
+	char c;
+	for(bool more=zip.goToFirstFile(); more; more=zip.goToNextFile()) {
+		if(!zip.getCurrentFileInfo(&info)) {
+			error = QString("getCurrentFileInfo(): %d\n").arg(zip.getZipError());
 			DebugDialog::debug(error);
 			return false;
 		}
 
-		zip.setFileNameCodec("IBM866");
-		DebugDialog::debug(QString("unzipping %1 entries from %2").arg(zip.getEntriesCount()).arg(filepath));
-		QuaZipFileInfo info;
-		QuaZipFile file(&zip);
-		QFile out;
-		QString name;
-		char c;
-		for (bool more = zip.goToFirstFile(); more; more = zip.goToNextFile()) {
-			if (!zip.getCurrentFileInfo(&info)) {
-				error = QString("getCurrentFileInfo(): %d\n").arg(zip.getZipError());
-				DebugDialog::debug(error);
-				return false;
-			}
+		if(!file.open(QIODevice::ReadOnly)) {
+			error = QString("file.open(): %d").arg(file.getZipError());
+			DebugDialog::debug(error);
+			return false;
+		}
+		name=file.getActualFileName();
+		if(file.getZipError()!=UNZ_OK) {
+			error = QString("file.getFileName(): %d").arg(file.getZipError());
+			DebugDialog::debug(error);
+			return false;
+		}
 
-			if (!file.open(QIODevice::ReadOnly)) {
-				error = QString("file.open(): %d").arg(file.getZipError());
-				DebugDialog::debug(error);
-				return false;
-			}
-			name = file.getActualFileName();
-			if (file.getZipError() != UNZ_OK) {
-				error = QString("file.getFileName(): %d").arg(file.getZipError());
-				DebugDialog::debug(error);
-				return false;
-			}
+		out.setFileName(dirToDecompress+"/"+name);
+		// this will fail if "name" contains subdirectories, but we don't mind that
+		if(!out.open(QIODevice::WriteOnly)) {
+            for (int i = 0; i < name.length(); i++) {
+                if (name[i].unicode() < 32) {
+                    name.replace(i, 1, &underscore, 1);
+                }
+                else for (unsigned int j = 0; j < (sizeof(badCharacters) / sizeof(QChar)); j++) {
+                    if (name[i] == badCharacters[j]) {
+                        name.replace(i, 1, &underscore, 1);
+                        break;
+                    }
+                }
+            }
+            out.setFileName(dirToDecompress+"/"+name);
+            if(!out.open(QIODevice::WriteOnly)) {
+                error = QString("out.open(): %s").arg(out.errorString().toLocal8Bit().constData());
+			    DebugDialog::debug(error);
+			    return false;
+            }
+		}
 
-			out.setFileName(dirToDecompress + "/" + name);
-			// this will fail if "name" contains subdirectories, but we don't mind that
-			if (!out.open(QIODevice::WriteOnly)) {
-				for (int i = 0; i < name.length(); i++) {
-					if (name[i].unicode() < 32) {
-						name.replace(i, 1, &underscore, 1);
-					}
-					else for (unsigned int j = 0; j < (sizeof(badCharacters) / sizeof(QChar)); j++) {
-						if (name[i] == badCharacters[j]) {
-							name.replace(i, 1, &underscore, 1);
-							break;
-						}
-					}
-				}
-				out.setFileName(dirToDecompress + "/" + name);
-				if (!out.open(QIODevice::WriteOnly)) {
-					error = QString("out.open(): %s").arg(out.errorString().toLocal8Bit().constData());
-					DebugDialog::debug(error);
-					return false;
-				}
-			}
-
-			// Slow like hell (on GNU/Linux at least), but it is not my fault.
-			// Not ZIP/UNZIP package's fault either.
-			// The slowest thing here is out.putChar(c).
-			// TODO: now that out.putChar has been replaced with a buffered write, is it still slow under Linux?
+		// Slow like hell (on GNU/Linux at least), but it is not my fault.
+		// Not ZIP/UNZIP package's fault either.
+		// The slowest thing here is out.putChar(c).
+		// TODO: now that out.putChar has been replaced with a buffered write, is it still slow under Linux?
 
 #define BUFFERSIZE 1024
-			char buffer[BUFFERSIZE];
-			int ix = 0;
-			while (file.getChar(&c)) {
-				buffer[ix++] = c;
-				if (ix == BUFFERSIZE) {
-					out.write(buffer, ix);
-					ix = 0;
-				}
-			}
-			if (ix > 0) {
+		char buffer[BUFFERSIZE];
+		int ix = 0;
+		while(file.getChar(&c)) {
+			buffer[ix++] = c;
+			if (ix == BUFFERSIZE) {
 				out.write(buffer, ix);
-			}
-
-			out.close();
-			if (file.getZipError() != UNZ_OK) {
-				error = QString("file.getFileName(): %d").arg(file.getZipError());
-				DebugDialog::debug(error);
-				return false;
-			}
-			if (!file.atEnd()) {
-				error = "read all but not EOF";
-				DebugDialog::debug(error);
-				return false;
-			}
-			file.close();
-			if (file.getZipError() != UNZ_OK) {
-				error = QString("file.close(): %d").arg(file.getZipError());
-				DebugDialog::debug(error);
-				return false;
+				ix = 0;
 			}
 		}
-		zip.close();
-		if (zip.getZipError() != UNZ_OK) {
-			error = QString("zip.close(): %d").arg(zip.getZipError());
+		if (ix > 0) {
+			out.write(buffer, ix);
+		}
+
+		out.close();
+		if(file.getZipError()!=UNZ_OK) {
+			error = QString("file.getFileName(): %d").arg(file.getZipError());
 			DebugDialog::debug(error);
 			return false;
 		}
+		if(!file.atEnd()) {
+			error = "read all but not EOF";
+			DebugDialog::debug(error);
+			return false;
+		}
+		file.close();
+		if(file.getZipError()!=UNZ_OK) {
+			error = QString("file.close(): %d").arg(file.getZipError());
+			DebugDialog::debug(error);
+			return false;
+		}
+	}
+	zip.close();
+	if(zip.getZipError()!=UNZ_OK) {
+		error = QString("zip.close(): %d").arg(zip.getZipError());
+		DebugDialog::debug(error);
+		return false;
 	}
 	return true;
 }
+
 
 void FolderUtils::collectFiles(const QDir & parent, QStringList & filters, QStringList & files, bool recursive)
 {

--- a/src/utils/folderutils.h
+++ b/src/utils/folderutils.h
@@ -55,6 +55,7 @@ public:
 	static void rmdir(const QString &dirPath);
 	static void rmdir(QDir & dir);
 	static bool createZipAndSaveTo(const QDir &dirToCompress, const QString &filename, const QStringList & skipSuffixes);
+	static bool createFZAndSaveTo(const QDir &dirToCompress, const QString &filename, const QStringList & skipSuffixes);
 	static bool unzipTo(const QString &filepath, const QString &dirToDecompress, QString & error);
 	static void replicateDir(QDir srcDir, QDir targDir);
 	static void cleanup();

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -33,18 +33,32 @@ $Date: 2012-07-18 15:52:11 +0200 (Mi, 18. Jul 2012) $
 #include <QTextStream>
 #include <QSet>
 
-static QStringList ___fritzingExtensions___;
+static QStringList p_fritzingExtensions;
+static QStringList p_fritzingBundleExtensions;
 
-const QStringList & fritzingExtensions() {
-	if (___fritzingExtensions___.count() == 0) {
-		___fritzingExtensions___
+static inline void initializeExtensionList() {
+	if (p_fritzingExtensions.count() == 0) {
+		p_fritzingExtensions
 			<< FritzingSketchExtension << FritzingBinExtension
 			<< FritzingPartExtension
 			<< FritzingBundleExtension << FritzingBundledPartExtension
 			<< FritzingBundledBinExtension;
+                p_fritzingBundleExtensions
+			<< FritzingBundleExtension 
+                        << FritzingBundledPartExtension
+			<< FritzingBundledBinExtension;
 	}
+        return;
+}
 
-	return ___fritzingExtensions___;
+const QStringList & fritzingExtensions() {
+	initializeExtensionList();
+	return p_fritzingExtensions;
+}
+
+const QStringList & fritzingBundleExtensions() {
+	initializeExtensionList();
+	return p_fritzingBundleExtensions;
 }
 
 bool isParent(QObject * candidateParent, QObject * candidateChild) {

--- a/src/utils/misc.h
+++ b/src/utils/misc.h
@@ -81,11 +81,11 @@ static const QString ResourcePath(":/resources/");
 bool isParent(QObject * candidateParent, QObject * candidateChild);
 
 static const QString FritzingSketchExtension(".fz");
+static const QString FritzingBundleExtension(".fzz");
 static const QString FritzingBinExtension(".fzb");
 static const QString FritzingBundledBinExtension(".fzbz");
 static const QString FritzingPartExtension(".fzp");
 static const QString FritzingBundledPartExtension(".fzpz");
-static const QString FritzingBundleExtension(".fzz");
 
 inline double qMin(float f, double d) {
     return qMin((double) f, d);
@@ -104,6 +104,7 @@ inline double qMax(double d, float f) {
 }
 
 const QStringList & fritzingExtensions();
+const QStringList & fritzingBundleExtensions();
 
 static const QString FemaleSymbolString = QString("%1").arg(QChar(0x2640));
 static const QString MaleSymbolString = QString("%1").arg(QChar(0x2642));


### PR DESCRIPTION
This pull request starts dealing with issue #3132.


* Allow to save as *.fz file type:
  - Show "Fritzing uncompressed (*.fz)" in the "Save As" file type dialog.
  - saveBundledNonAtomicEntity function allows to save an *.fz 'bundle' by
    skipping the compression step (saves all files in the same directory).

* Allow to load a *.fz file:
  - Drop readonly warning.

* Rename private variable ___fritzingExtensions___ to p_fritzingExtensions as
  variables starting with underscore are compiler reserved in misc.cc.

TO DO:
  - Deal with overwriting existing auxiliary files. Maybe using a file +
    subdirectory approach would be safer?
     * mysketch.fz
     * mysketch.fz_FILES/
  - Should the save as uncompressed option be extended to other bundled types
    (such as uncompressed custom parts...)
  - Should loaded files be copied to another directory just like *.fzz files
    are extracted to another directory?
  - Thorough testing and code review. Saving and loading are delicate parts of the code and I do not want to be hold responsible of any bug...