### PR TITLE
use MIME database XML file and install_fritzing.sh

### DIFF
--- a/install_fritzing.sh
+++ b/install_fritzing.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 #
 # this is a rough beginning of a linux install script for fritzing
-# sets up document icons and file associations using mime types
+# sets up document icons and file associations using MIME types
+#
+# first ensure fritzing is unpacked in its final destination
+# and then run this script
 
 APPLICATIONSDIR="${HOME}/.local/share/applications"
 MIMEDIR="${HOME}/.local/share/mime"
@@ -16,7 +19,7 @@ then
 	touch ~/.mime.types
 fi
 
-# add mime types for fritzing file formats
+# add MIME types for fritzing file formats
 grep -q application/x-fritzing ~/.mime.types
 if [ $? -eq 0 ]
 then
@@ -33,11 +36,11 @@ fi
 
 cd $APPDIR
 
-# install fritzing into user mime packages directory
+# install fritzing into user MIME packages directory
 mkdir -p "${PACKAGESDIR}"
 cp icons/fritzing.xml "${PACKAGESDIR}" || exit 1
 
-# install fritzing desktop entry for user (includes mime associations)
+# install fritzing desktop entry for user (includes MIME associations)
 desktop-file-edit --set-key=Exec --set-value="$(pwd)/Fritzing" fritzing.desktop
 xdg-desktop-menu install --novendor --mode user fritzing.desktop
 

--- a/install_fritzing.sh
+++ b/install_fritzing.sh
@@ -37,14 +37,9 @@ cd $APPDIR
 mkdir -p "${PACKAGESDIR}"
 cp icons/fritzing.xml "${PACKAGESDIR}" || exit 1
 
-# set the default application to fritzing.desktop
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fz
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fzz
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fzp
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fzpz
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fzb
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fzbz
-xdg-mime default 'fritzing.desktop' application/x-fritzing-fzm
+# install fritzing desktop entry for user (includes mime associations)
+desktop-file-edit --set-key=Exec --set-value="$(pwd)/Fritzing" fritzing.desktop
+xdg-desktop-menu install --novendor --mode user fritzing.desktop
 
 # install image-files into user mime system with specified size
 # ~/.local/share/icons/hicolor/*size*

--- a/install_fritzing.sh
+++ b/install_fritzing.sh
@@ -49,23 +49,19 @@ xdg-mime default 'fritzing.desktop' application/x-fritzing-fzm
 
 # install image-files into user mime system with specified size
 # ~/.local/share/icons/hicolor/*size*
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fz_icon128.png' application-x-fritzing-fz
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fz_icon256.png' application-x-fritzing-fz
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fzz_icon128.png' application-x-fritzing-fzz
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fzz_icon256.png' application-x-fritzing-fzz
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fzp_icon128.png' application-x-fritzing-fzp
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fzp_icon256.png' application-x-fritzing-fzp
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fzpz_icon128.png' application-x-fritzing-fzpz
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fzpz_icon256.png' application-x-fritzing-fzpz
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fzb_icon128.png' application-x-fritzing-fzb
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fzb_icon256.png' application-x-fritzing-fzb
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fzbz_icon128.png' application-x-fritzing-fzbz
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fzbz_icon256.png' application-x-fritzing-fzbz
-xdg-icon-resource install --mode user --context mimetypes --size 128 'icons/fzm_icon128.png' application-x-fritzing-fzm
-xdg-icon-resource install --mode user --context mimetypes --size 256 'icons/fzm_icon256.png' application-x-fritzing-fzm
+ICON_SIZES="128 256"
+FILE_EXTENSIONS="fz fzz fzb fzbz fzp fzpz fzm"
+for size in ${ICON_SIZES}; do
+	for extension in ${FILE_EXTENSIONS}; do
+		xdg-icon-resource install --noupdate --mode user --context mimetypes \
+			--size ${size} "icons/${extension}_icon${size}.png" \
+			"application-x-fritzing-${extension}"
+	done
+done
 
 # update user databases
 update-desktop-database ~/.local/share/applications
 update-mime-database ~/.local/share/mime
+xdg-icon-resource forceupdate --mode user
 
 echo "installed fritzing system icons"

--- a/install_fritzing.sh
+++ b/install_fritzing.sh
@@ -41,8 +41,12 @@ cp icons/fritzing.xml "${PACKAGESDIR}" || exit 1
 desktop-file-edit --set-key=Exec --set-value="$(pwd)/Fritzing" fritzing.desktop
 xdg-desktop-menu install --novendor --mode user fritzing.desktop
 
-# install image-files into user mime system with specified size
+# install image-files into user hicolor theme with specified size
 # ~/.local/share/icons/hicolor/*size*
+#    /apps
+xdg-icon-resource install --noupdate --novendor --mode user --context apps \
+	--size 256 icons/fritzing_icon.png fritzing
+#    /mimetypes
 ICON_SIZES="128 256"
 FILE_EXTENSIONS="fz fzz fzb fzbz fzp fzpz fzm"
 for size in ${ICON_SIZES}; do

--- a/install_fritzing.sh
+++ b/install_fritzing.sh
@@ -3,6 +3,10 @@
 # this is a rough beginning of a linux install script for fritzing
 # sets up document icons and file associations using mime types
 
+APPLICATIONSDIR="${HOME}/.local/share/applications"
+MIMEDIR="${HOME}/.local/share/mime"
+PACKAGESDIR="${MIMEDIR}/packages"
+
 APPDIR=$(dirname "$0")
 
 # check if user .mime.types file exists, otherwise create it
@@ -29,14 +33,9 @@ fi
 
 cd $APPDIR
 
-# install fritzing into mime user directory
-xdg-mime install --mode user 'icons/x-fritzing-fz.xml'
-xdg-mime install --mode user 'icons/x-fritzing-fzz.xml'
-xdg-mime install --mode user 'icons/x-fritzing-fzp.xml'
-xdg-mime install --mode user 'icons/x-fritzing-fzpz.xml'
-xdg-mime install --mode user 'icons/x-fritzing-fzb.xml'
-xdg-mime install --mode user 'icons/x-fritzing-fzbz.xml'
-xdg-mime install --mode user 'icons/x-fritzing-fzm.xml'
+# install fritzing into user mime packages directory
+mkdir -p "${PACKAGESDIR}"
+cp icons/fritzing.xml "${PACKAGESDIR}" || exit 1
 
 # set the default application to fritzing.desktop
 xdg-mime default 'fritzing.desktop' application/x-fritzing-fz
@@ -60,8 +59,8 @@ for size in ${ICON_SIZES}; do
 done
 
 # update user databases
-update-desktop-database ~/.local/share/applications
-update-mime-database ~/.local/share/mime
+update-desktop-database "${APPLICATIONSDIR}"
+update-mime-database "${MIMEDIR}"
 xdg-icon-resource forceupdate --mode user
 
 echo "installed fritzing system icons"

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -115,6 +115,9 @@ unix {
         desktop.path = $$DATADIR/applications
         desktop.files += fritzing.desktop
 
+        mimedb.path = $$DATADIR/mime/packages
+        mimedb.files += resources/system_icons/linux/fritzing.xml
+
         manpage.path = $$DATADIR/man/man1
         manpage.files += Fritzing.1
 
@@ -139,7 +142,7 @@ unix {
         syntax.path = $$PKGDATADIR/translations/syntax
         syntax.files += translations/syntax/*.xml
 
-        INSTALLS += target desktop manpage icon parts sketches bins translations syntax help
+        INSTALLS += target desktop mimedb manpage icon parts sketches bins translations syntax help
 }
 
 ICON = resources/system_icons/macosx/fritzing_icon.icns

--- a/resources/system_icons/linux/fritzing.xml
+++ b/resources/system_icons/linux/fritzing.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+<mime-type type="application/x-fritzing-fzb">  
+<comment>Fritzing Parts Bin</comment>
+<glob pattern="*.fzb"/>
+</mime-type>
+<mime-type type="application/x-fritzing-fzbz">
+<comment>Fritzing Parts Bin Bundle</comment>
+<glob pattern="*.fzbz"/>
+</mime-type>
+<mime-type type="application/x-fritzing-fzm">
+<comment>Fritzing Module</comment>
+<glob pattern="*.fzm"/>
+</mime-type>
+<mime-type type="application/x-fritzing-fzp">
+<comment>Fritzing Part Definition</comment>
+<glob pattern="*.fzp"/>
+</mime-type>
+<mime-type type="application/x-fritzing-fzpz">
+<comment>Fritzing Part Bundle</comment>
+<glob pattern="*.fzpz"/>
+</mime-type>
+<mime-type type="application/x-fritzing-fz">
+<comment>Fritzing Sketch</comment>
+<glob pattern="*.fz"/>
+</mime-type>
+<mime-type type="application/x-fritzing-fzz">
+<comment>Fritzing Sketch Bundle</comment>
+<glob pattern="*.fzz"/>
+</mime-type>
+</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fz.xml
+++ b/resources/system_icons/linux/x-fritzing-fz.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fz">  
-<comment>Fritzing Sketch</comment>
-<generic-icon name="application-x-fritzing-fz"/>
-<glob pattern="*.fz"/>
-</mime-type>
-</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fzb.xml
+++ b/resources/system_icons/linux/x-fritzing-fzb.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fzb">  
-<comment>Fritzing Parts Bin</comment>
-<generic-icon name="application-x-fritzing-fzb"/>
-<glob pattern="*.fzb"/>
-</mime-type>
-</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fzbz.xml
+++ b/resources/system_icons/linux/x-fritzing-fzbz.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fzbz">
-<comment>Fritzing Parts Bin Bundle</comment>
-<generic-icon name="application-x-fritzing-fzbz"/>
-<glob pattern="*.fzbz"/>
-</mime-type>
-</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fzm.xml
+++ b/resources/system_icons/linux/x-fritzing-fzm.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fzm">
-<comment>Fritzing Module</comment>
-<generic-icon name="application-x-fritzing-fzm"/>
-<glob pattern="*.fzm"/>
-</mime-type>
-</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fzp.xml
+++ b/resources/system_icons/linux/x-fritzing-fzp.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fzp">
-<comment>Fritzing Part Definition</comment>
-<generic-icon name="application-x-fritzing-fzp"/>
-<glob pattern="*.fzp"/>
-</mime-type>
-</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fzpz.xml
+++ b/resources/system_icons/linux/x-fritzing-fzpz.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fzpz">
-<comment>Fritzing Part Bundle</comment>
-<generic-icon name="application-x-fritzing-fzpz"/>
-<glob pattern="*.fzpz"/>
-</mime-type>
-</mime-info>

--- a/resources/system_icons/linux/x-fritzing-fzz.xml
+++ b/resources/system_icons/linux/x-fritzing-fzz.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
-<mime-type type="application/x-fritzing-fzz">
-<comment>Fritzing Sketch Bundle</comment>
-<generic-icon name="application-x-fritzing-fzz"/>
-<glob pattern="*.fzz"/>
-</mime-type>
-</mime-info>


### PR DESCRIPTION
I started this because I wanted to propose that a single fritzing.xml MIME database file is better to manage and package. Then realised it would break install_fritzing.sh, and ended up suggesting a number of changes to that.
Comments on individual commits.

I was tempted to include removing the `~/.mime.types` code. But maybe it was installed with a particular desktop environment or window manager in mind?
