### PR TITLE
minimise initial size of cloned parts repository in releases

### DIFF
--- a/tools/deploy_fritzing_mac.sh
+++ b/tools/deploy_fritzing_mac.sh
@@ -42,7 +42,7 @@ rm ./translations/*.ts  			# remove translation xml files, since we only need th
 find ./translations -name "*.qm" -size -128c -delete   # delete empty translation binaries
 
 echo ">> clone parts repository"
-git clone https://github.com/fritzing/fritzing-parts.git
+git clone --branch master --single-branch https://github.com/fritzing/fritzing-parts.git
 echo ">> build parts database and run fritzing"
 ./Fritzing -db "fritzing-parts/parts.db"  # -pp "fritzing-parts" -f "."
 

--- a/tools/linux_release_script/release.sh
+++ b/tools/linux_release_script/release.sh
@@ -64,7 +64,7 @@ echo "cleaning translations"
 rm ./translations/*.ts  			# remove translation xml files, since we only need the binaries in the release
 find ./translations -name "*.qm" -size -128c -delete   # delete empty translation binaries
 
-git clone https://github.com/fritzing/fritzing-parts.git
+git clone --branch master --single-branch https://github.com/fritzing/fritzing-parts.git
 
 echo "making library folders"
 mkdir lib

--- a/tools/release_fritzing.bat
+++ b/tools/release_fritzing.bat
@@ -157,7 +157,7 @@ set CURRENTDIR=%cd%
 cd %DESTDIR%
 cd deploy
 
-git clone https://github.com/fritzing/fritzing-parts.git
+git clone --branch master --single-branch https://github.com/fritzing/fritzing-parts.git
 
 del/s placeholder.txt
 cd translations


### PR DESCRIPTION
Don't include the history or alternate branches.
