### PR TITLE
Application Data and Parts Paths on Linux

### DIFF
--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -118,6 +118,23 @@ QDir FolderUtils::getAppPartsSubFolder(QString search) {
 
 QDir FolderUtils::getAppPartsSubFolder2(QString search) {
 	if (m_partsPath.isEmpty()) {
+#ifdef PKGDATADIR
+		QStringList candidates;
+		candidates.append(QDir::homePath() + "/.local/share/fritzing");
+		candidates.append("/usr/local/share/fritzing");
+		candidates.append(m_appPath);
+		foreach (const QString &candidate, candidates) {
+			QList<QDir> dirList;
+			dirList.append(QDir(candidate + "/fritzing-parts"));
+			dirList.append(QDir(candidate + "/parts"));
+			foreach (const QDir &dir, dirList) {
+				m_partsPath = dir.absolutePath();
+				if (dir.exists()) {
+					goto setpath;
+				}
+			}
+		}
+#else
 		QDir dir = getApplicationSubFolder("fritzing-parts");
 		if (dir.exists()) {
 			m_partsPath = dir.absolutePath();
@@ -128,9 +145,10 @@ QDir FolderUtils::getAppPartsSubFolder2(QString search) {
 				m_partsPath = dir.absolutePath();
 			}
 		}
+#endif
 	}
 
-
+setpath:
 	QString path = search.isEmpty() ? m_partsPath : m_partsPath + "/" + search;
 	//DebugDialog::debug(QString("path %1").arg(path) );
 	QDir dir(path);

--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -74,6 +74,7 @@ QDir  FolderUtils::getApplicationSubFolder(QString search) {
 	path += "/" + search;
 	//DebugDialog::debug(QString("path %1").arg(path) );
 	QDir dir(path);
+#ifndef PKGDATADIR
 	while (!dir.exists()) {
 		// if we're running from the debug or release folder, try go up one to find things
 		dir.cdUp();
@@ -85,7 +86,7 @@ QDir  FolderUtils::getApplicationSubFolder(QString search) {
 
 		dir.setPath(dir.absolutePath() + "/" + search);
 	}
-
+#endif
 	return dir;
 }
 
@@ -215,8 +216,15 @@ const QString FolderUtils::applicationDirPath() {
 #ifdef Q_OS_WIN
 		m_appPath = QCoreApplication::applicationDirPath();
 #else
-		// look in standard Fritzing location (applicationDirPath and parent folders) then in standard linux locations
 		QStringList candidates;
+		// Look in standard Linux user and local administrator locations
+		candidates.append(QDir::homePath() + "/.local/share/fritzing");
+		candidates.append("/usr/local/share/fritzing");
+#ifdef PKGDATADIR
+		// look in installed location
+		candidates.append(QLatin1String(PKGDATADIR));
+#else
+		// look in standard Fritzing location (applicationDirPath and parent folders)
 		candidates.append(QCoreApplication::applicationDirPath());
 		QDir dir(QCoreApplication::applicationDirPath());
 		if (dir.cdUp()) {
@@ -229,13 +237,8 @@ const QString FolderUtils::applicationDirPath() {
 			}
 		}
 
-#ifdef PKGDATADIR
-		candidates.append(QLatin1String(PKGDATADIR));
-#else
 		candidates.append("/usr/share/fritzing");
-		candidates.append("/usr/local/share/fritzing");
 #endif
-		candidates.append(QDir::homePath() + "/.local/share/fritzing");
 		foreach (QString candidate, candidates) {
 			//DebugDialog::debug(QString("candidate:%1").arg(candidate));
 			QDir dir(candidate);

--- a/tools/deploy_fritzing_mac.sh
+++ b/tools/deploy_fritzing_mac.sh
@@ -19,6 +19,9 @@ builddir=$workingdir/../release64  # this is pre-defined by Qt
 echo ">> build directory"
 echo "$builddir"
 
+# not building for installation into filesystem
+sed -i 's:PKGDATADIR=\\\\\\"\$\$PKGDATADIR\\\\\\"::' phoenix.pro || exit 1
+
 echo ">> building fritzing from working directory"
 $QTBIN/qmake -o Makefile phoenix.pro
 make "-j$(sysctl -n machdep.cpu.thread_count)" release  # release is the type of build

--- a/tools/linux_release_script/release.sh
+++ b/tools/linux_release_script/release.sh
@@ -54,6 +54,9 @@ else
   arch='i386'
 fi
 
+# not building for installation into filesystem
+sed -i 's:PKGDATADIR=\\\\\\"\$\$PKGDATADIR\\\\\\"::' phoenix.pro || exit 1
+
 quazip='QUAZIP_LIB'
 echo "using src/lib/quazip"
 

--- a/tools/user_parts_clone.sh
+++ b/tools/user_parts_clone.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# enable user to override installed parts library with GitHub clone
+
+REPODIR="${HOME}/.local/share/fritzing/fritzing-parts"
+mkdir -p "${REPODIR}"
+git clone --branch master --single-branch https://github.com/fritzing/fritzing-parts.git "${REPODIR}" || exit 1
+Fritzing -db "${REPODIR}/parts.db"


### PR DESCRIPTION
Something for discussion. Trying to solve issues having built and installed Fritzing 0.9.3b on Linux.

By installed I mean using make install (PREFIX=/usr).

Two issues:

1) If no parts library installed:

```
$ cd /
$ Fritzing
```

effectively hangs on the splash screen, because it is scanning the entire filesystem.

2) Where to put a GitHub clone of fritzing-parts that is user updateable? /usr/share/fritzing is read-only.

Suggestions:

Choose ~/.local/share/fritzing for the user clone, a directory already in the code.

Use PKGDATA to indicate building an installed Fritzing (would mean tools/linux_release_script/release.sh needs to do something different?)

At runtime look for fritzing-parts, then parts in each of (in order):
~/.local/share/fritzing
/usr/local/share/fritzing
$PKGDATA/fritzing

If none is found default to $PKGDATA/fritzing/parts. This still appears to be necessary to stop the scanning?

In this way a user can override a parts directory for themselves (with ~/.local),
also an administrator can override an installation for all users (with /usr/local).

N.B. application data directory and parts directory are independent in the local cases.

Do the same with the application directory for consistency. Will users want to install other types of files? Maybe:
https://github.com/fritzing/fritzing-app/issues/3237

Add a helper script, tools/user_parts_clone.sh, for users to create their own clone.

There may well be other ways to solve this. Maybe the directory scanning could be just for debug builds? But this seemed the simplest way to keep the current behaviour intact (OK looking in the local directories for the application path before $PKGDATA is a small change).
