### PR TITLE
Support System Boost and libgit2

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -46,8 +46,7 @@ win32 {
         RELDIR = ../release64
         DEBDIR = ../debug64
         DEFINES += WIN64
-    }
-    !contains(QMAKE_TARGET.arch, x86_64) {
+    } else {
         RELDIR = ../release32
         DEBDIR = ../debug32
     }
@@ -169,8 +168,7 @@ RESOURCES += phoenixresources.qrc
 LIBGIT2INCLUDE = ../libgit2/include
 exists($$LIBGIT2INCLUDE/git2.h) {
     message("found libgit2 include path at $$LIBGIT2INCLUDE")
-}
-else {
+} else {
     message("Fritzing requires libgit2")
     message("Build it from the repo at https://github.com/libgit2")
     message("See https://github.com/fritzing/fritzing-app/wiki for details.")
@@ -183,15 +181,13 @@ INCLUDEPATH += $$LIBGIT2INCLUDE
 win32 {
     contains(QMAKE_TARGET.arch, x86_64) {
         LIBGIT2LIB = ../libgit2/build64
-    }
-    else {
+    } else {
         LIBGIT2LIB = ../libgit2/build32
     }
 
     exists($$LIBGIT2LIB/git2.lib) {
         message("found libgit2 library in $$LIBGIT2LIB")
-    }
-    else {
+    } else {
         error("libgit2 library not found in $$LIBGIT2LIB")
     }
 }
@@ -201,16 +197,13 @@ unix {
     macx {
         exists($$LIBGIT2LIB/libgit2.dylib) {
             message("found libgit2 library in $$LIBGIT2LIB")
-        }
-        else {
+        } else {
             error("libgit2 library not found in $$LIBGIT2LIB")
         }
-    }
-    !macx {
+    } else {
         exists($$LIBGIT2LIB/libgit2.so) {
             message("found libgit2 library in $$LIBGIT2LIB")
-        }
-        else {
+        } else {
             error("libgit2 library not found in $$LIBGIT2LIB")
         }
     }
@@ -240,12 +233,11 @@ include(pri/translations.pri)
 include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
-!contains(DEFINES, QUAZIP_INSTALLED) {
-    include(pri/quazip.pri)
-}
 contains(DEFINES, QUAZIP_INSTALLED) {
     INCLUDEPATH += /usr/include/quazip
     LIBS += -lquazip
+} else {
+    include(pri/quazip.pri)
 }
 
 TARGET = Fritzing

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -30,70 +30,69 @@
 #
 # QTPLUGIN  += qjpeg qsqlite
 
-
 CONFIG += debug_and_release
 
 win32 {
 # release build using msvc 2010 needs to use Multi-threaded (/MT) for the code generation/runtime library option
 # release build using msvc 2010 needs to add msvcrt.lib;%(IgnoreSpecificDefaultLibraries) to the linker/no default libraries option
-        CONFIG -= embed_manifest_exe
-        INCLUDEPATH += $$[QT_INSTALL_HEADERS]/QtZlib
-        DEFINES += _CRT_SECURE_NO_DEPRECATE
-        DEFINES += _WINDOWS
-	RELEASE_SCRIPT = $$(RELEASE_SCRIPT)			# environment variable set from release script
+    CONFIG -= embed_manifest_exe
+    INCLUDEPATH += $$[QT_INSTALL_HEADERS]/QtZlib
+    DEFINES += _CRT_SECURE_NO_DEPRECATE
+    DEFINES += _WINDOWS
+    RELEASE_SCRIPT = $$(RELEASE_SCRIPT)    # environment variable set from release script
 
-        message("target arch: $${QMAKE_TARGET.arch}")
-        contains(QMAKE_TARGET.arch, x86_64) {
-                RELDIR = ../release64
-                DEBDIR = ../debug64
-                DEFINES += WIN64
-       }
-       !contains(QMAKE_TARGET.arch, x86_64) {
-                RELDIR = ../release32
-                DEBDIR = ../debug32
-        }
-
-	Release:DESTDIR = $${RELDIR}
-	Release:OBJECTS_DIR = $${RELDIR}
-	Release:MOC_DIR = $${RELDIR}
-	Release:RCC_DIR = $${RELDIR}
-	Release:UI_DIR = $${RELDIR}
-
-	Debug:DESTDIR = $${DEBDIR}
-	Debug:OBJECTS_DIR = $${DEBDIR}
-	Debug:MOC_DIR = $${DEBDIR}
-	Debug:RCC_DIR = $${DEBDIR}
-	Debug:UI_DIR = $${DEBDIR}
-}
-macx {
+    message("target arch: $${QMAKE_TARGET.arch}")
+    contains(QMAKE_TARGET.arch, x86_64) {
         RELDIR = ../release64
         DEBDIR = ../debug64
-        Release:DESTDIR = $${RELDIR}
-        Release:OBJECTS_DIR = $${RELDIR}
-        Release:MOC_DIR = $${RELDIR}
-        Release:RCC_DIR = $${RELDIR}
-        Release:UI_DIR = $${RELDIR}
+        DEFINES += WIN64
+    }
+    !contains(QMAKE_TARGET.arch, x86_64) {
+        RELDIR = ../release32
+        DEBDIR = ../debug32
+    }
 
-        Debug:DESTDIR = $${DEBDIR}
-        Debug:OBJECTS_DIR = $${DEBDIR}
-        Debug:MOC_DIR = $${DEBDIR}
-        Debug:RCC_DIR = $${DEBDIR}
-        Debug:UI_DIR = $${DEBDIR}
+    Release:DESTDIR = $${RELDIR}
+    Release:OBJECTS_DIR = $${RELDIR}
+    Release:MOC_DIR = $${RELDIR}
+    Release:RCC_DIR = $${RELDIR}
+    Release:UI_DIR = $${RELDIR}
 
-        QMAKE_MAC_SDK = macosx10.11             # uncomment/adapt for your version of OSX
-        CONFIG += x86_64 # x86 ppc
-        QMAKE_INFO_PLIST = FritzingInfo.plist
-        #DEFINES += QT_NO_DEBUG   		# uncomment this for xcode
-        LIBS += -lz
-        LIBS += /usr/lib/libz.dylib
-        LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
-        LIBS += /System/Library/Frameworks/Carbon.framework/Carbon
-        LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+    Debug:DESTDIR = $${DEBDIR}
+    Debug:OBJECTS_DIR = $${DEBDIR}
+    Debug:MOC_DIR = $${DEBDIR}
+    Debug:RCC_DIR = $${DEBDIR}
+    Debug:UI_DIR = $${DEBDIR}
+}
+macx {
+    RELDIR = ../release64
+    DEBDIR = ../debug64
+    Release:DESTDIR = $${RELDIR}
+    Release:OBJECTS_DIR = $${RELDIR}
+    Release:MOC_DIR = $${RELDIR}
+    Release:RCC_DIR = $${RELDIR}
+    Release:UI_DIR = $${RELDIR}
+
+    Debug:DESTDIR = $${DEBDIR}
+    Debug:OBJECTS_DIR = $${DEBDIR}
+    Debug:MOC_DIR = $${DEBDIR}
+    Debug:RCC_DIR = $${DEBDIR}
+    Debug:UI_DIR = $${DEBDIR}
+
+    QMAKE_MAC_SDK = macosx10.11            # uncomment/adapt for your version of OSX
+    CONFIG += x86_64 # x86 ppc
+    QMAKE_INFO_PLIST = FritzingInfo.plist
+    #DEFINES += QT_NO_DEBUG                # uncomment this for xcode
+    LIBS += -lz
+    LIBS += /usr/lib/libz.dylib
+    LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
+    LIBS += /System/Library/Frameworks/Carbon.framework/Carbon
+    LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
 }
 unix {
     !macx { # unix is defined on mac
         HARDWARE_PLATFORM = $$system(uname -m)
-        contains( HARDWARE_PLATFORM, x86_64 ) {
+        contains(HARDWARE_PLATFORM, x86_64) {
             DEFINES += LINUX_64
         } else {
             DEFINES += LINUX_32
@@ -103,48 +102,48 @@ unix {
         }
     }
 
-        isEmpty(PREFIX) {
-                PREFIX = /usr
-        }
-        BINDIR = $$PREFIX/bin
-        DATADIR = $$PREFIX/share
-        PKGDATADIR = $$DATADIR/fritzing
+    isEmpty(PREFIX) {
+        PREFIX = /usr
+    }
+    BINDIR = $$PREFIX/bin
+    DATADIR = $$PREFIX/share
+    PKGDATADIR = $$DATADIR/fritzing
 
-        DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
+    DEFINES += DATADIR=\\\"$$DATADIR\\\" PKGDATADIR=\\\"$$PKGDATADIR\\\"
 
-        target.path =$$BINDIR
+    target.path = $$BINDIR
 
-        desktop.path = $$DATADIR/applications
-        desktop.files += fritzing.desktop
+    desktop.path = $$DATADIR/applications
+    desktop.files += fritzing.desktop
 
-        mimedb.path = $$DATADIR/mime/packages
-        mimedb.files += resources/system_icons/linux/fritzing.xml
+    mimedb.path = $$DATADIR/mime/packages
+    mimedb.files += resources/system_icons/linux/fritzing.xml
 
-        manpage.path = $$DATADIR/man/man1
-        manpage.files += Fritzing.1
+    manpage.path = $$DATADIR/man/man1
+    manpage.files += Fritzing.1
 
-        icon.path = $$DATADIR/icons
-        icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/icons/fritzing.png
+    icon.path = $$DATADIR/icons
+    icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/icons/fritzing.png
 
-        parts.path = $$PKGDATADIR
-        parts.files += parts
+    parts.path = $$PKGDATADIR
+    parts.files += parts
 
-        help.path = $$PKGDATADIR
-        help.files += help
+    help.path = $$PKGDATADIR
+    help.files += help
 
-        sketches.path = $$PKGDATADIR
-        sketches.files += sketches
+    sketches.path = $$PKGDATADIR
+    sketches.files += sketches
 
-        bins.path = $$PKGDATADIR
-        bins.files += bins
+    bins.path = $$PKGDATADIR
+    bins.files += bins
 
-        translations.path = $$PKGDATADIR/translations
-        translations.extra = find $$PWD/translations -name "*.qm" -size +128c -exec cp -pr {} $(INSTALL_ROOT)$$PKGDATADIR/translations \\;
+    translations.path = $$PKGDATADIR/translations
+    translations.extra = find $$PWD/translations -name "*.qm" -size +128c -exec cp -pr {} $(INSTALL_ROOT)$$PKGDATADIR/translations \\;
 
-        syntax.path = $$PKGDATADIR/translations/syntax
-        syntax.files += translations/syntax/*.xml
+    syntax.path = $$PKGDATADIR/translations/syntax
+    syntax.files += translations/syntax/*.xml
 
-        INSTALLS += target desktop mimedb manpage icon parts sketches bins translations syntax help
+    INSTALLS += target desktop mimedb manpage icon parts sketches bins translations syntax help
 }
 
 ICON = resources/system_icons/macosx/fritzing_icon.icns
@@ -165,7 +164,6 @@ greaterThan(QT_MAJOR_VERSION, 4) {
 RC_FILE = fritzing.rc
 RESOURCES += phoenixresources.qrc
 
-
 # Fritzing is using libgit2 since version 0.9.3
 
 LIBGIT2INCLUDE = ../libgit2/include
@@ -184,10 +182,10 @@ INCLUDEPATH += $$LIBGIT2INCLUDE
 
 win32 {
     contains(QMAKE_TARGET.arch, x86_64) {
-            LIBGIT2LIB = ../libgit2/build64
+        LIBGIT2LIB = ../libgit2/build64
     }
     else {
-            LIBGIT2LIB = ../libgit2/build32
+        LIBGIT2LIB = ../libgit2/build32
     }
 
     exists($$LIBGIT2LIB/git2.lib) {
@@ -243,15 +241,14 @@ include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
 !contains(DEFINES, QUAZIP_INSTALLED) {
-        include(pri/quazip.pri)
+    include(pri/quazip.pri)
 }
 contains(DEFINES, QUAZIP_INSTALLED) {
-        INCLUDEPATH += /usr/include/quazip
-        LIBS += -lquazip
+    INCLUDEPATH += /usr/include/quazip
+    LIBS += -lquazip
 }
 
 TARGET = Fritzing
 TEMPLATE = app
-
 
 message("libs $$LIBS")

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -233,6 +233,10 @@ include(pri/translations.pri)
 include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
+!contains(DEFINES, BOOST_INSTALLED) {
+    include(pri/boostdetect.pri)
+}
+
 contains(DEFINES, QUAZIP_INSTALLED) {
     INCLUDEPATH += /usr/include/quazip
     LIBS += -lquazip

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -1,7 +1,7 @@
 # /*******************************************************************
 #
 # Part of the Fritzing project - http://fritzing.org
-# Copyright (c) 2007-08 Fritzing
+# Copyright (c) 2007-16 Fritzing
 #
 # Fritzing is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,6 +31,10 @@
 # QTPLUGIN  += qjpeg qsqlite
 
 CONFIG += debug_and_release
+
+unix:!macx {
+    CONFIG += link_pkgconfig
+}
 
 win32 {
 # release build using msvc 2010 needs to use Multi-threaded (/MT) for the code generation/runtime library option
@@ -164,52 +168,11 @@ RC_FILE = fritzing.rc
 RESOURCES += phoenixresources.qrc
 
 # Fritzing is using libgit2 since version 0.9.3
-
-LIBGIT2INCLUDE = ../libgit2/include
-exists($$LIBGIT2INCLUDE/git2.h) {
-    message("found libgit2 include path at $$LIBGIT2INCLUDE")
+packagesExist(libgit2) {
+    PKGCONFIG += libgit2
 } else {
-    message("Fritzing requires libgit2")
-    message("Build it from the repo at https://github.com/libgit2")
-    message("See https://github.com/fritzing/fritzing-app/wiki for details.")
-
-    error("libgit2 include path not found in $$LIBGIT2INCLUDE")
+    include(pri/libgit2detect.pri)
 }
-
-INCLUDEPATH += $$LIBGIT2INCLUDE
-
-win32 {
-    contains(QMAKE_TARGET.arch, x86_64) {
-        LIBGIT2LIB = ../libgit2/build64
-    } else {
-        LIBGIT2LIB = ../libgit2/build32
-    }
-
-    exists($$LIBGIT2LIB/git2.lib) {
-        message("found libgit2 library in $$LIBGIT2LIB")
-    } else {
-        error("libgit2 library not found in $$LIBGIT2LIB")
-    }
-}
-
-unix {
-    LIBGIT2LIB = ../libgit2/build
-    macx {
-        exists($$LIBGIT2LIB/libgit2.dylib) {
-            message("found libgit2 library in $$LIBGIT2LIB")
-        } else {
-            error("libgit2 library not found in $$LIBGIT2LIB")
-        }
-    } else {
-        exists($$LIBGIT2LIB/libgit2.so) {
-            message("found libgit2 library in $$LIBGIT2LIB")
-        } else {
-            error("libgit2 library not found in $$LIBGIT2LIB")
-        }
-    }
-}
-
-LIBS += -L$$LIBGIT2LIB -lgit2
 
 include(pri/kitchensink.pri)
 include(pri/mainwindow.pri)

--- a/pri/boostdetect.pri
+++ b/pri/boostdetect.pri
@@ -1,0 +1,58 @@
+# /*******************************************************************
+# Part of the Fritzing project - http://fritzing.org
+# Copyright (c) 2007-16 Fritzing
+# Fritzing is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# Fritzing is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
+# ********************************************************************
+# $Revision: 6796 $:
+# $Author: irascibl@gmail.com $:
+# $Date: 2013-01-12 07:45:08 +0100 (Sa, 12. Jan 2013) $
+# ********************************************************************/
+
+# boost_1_54_0 is buggy
+BOOSTS = 43 44 45 46 47 48 49 50 51 52 53 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99
+LATESTBOOST = 0
+for(boost, BOOSTS) {
+    exists(../src/lib/boost_1_$${boost}_0) {
+        LATESTBOOST = $$boost
+    }
+}
+
+contains(LATESTBOOST, 0) {
+    unix {
+        !macx {
+            BOOSTINFO = $$system(dpkg -s libboost-dev | grep 'Version')
+            BADVERSION = $$find(BOOSTINFO, 1\.54)
+            !isEmpty(BADVERSION) {
+                message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
+                error("Easiest to copy the boost library to .../src/lib/, so that you have .../src/lib/boost_1_xx_0")
+            }
+            isEmpty(BADVERSION) {
+                BOOSTVERSION = $$find(BOOSTINFO, 1\...\.0)
+                !isEmpty(BOOSTVERSION) {
+                    LATESTBOOST = installed
+                    message("using installed BOOST library")
+                }
+            }
+        }
+    }
+}
+
+contains(LATESTBOOST, 0) {
+    message("Please download the boost library--you can find it at http://www.boost.org/")
+    message("Note that boost 1.54 has a bug in a function that Fritzing uses, so download some other version")
+    error("Copy the boost library to .../src/lib/, so that you have .../src/lib/boost_1_xx_0")
+}
+
+!contains(LATESTBOOST, installed) {
+    message("using boost from src/lib/boost_1_$${LATESTBOOST}_0")
+    INCLUDEPATH += src/lib/boost_1_$${LATESTBOOST}_0
+}

--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -1,0 +1,60 @@
+# /*******************************************************************
+# Part of the Fritzing project - http://fritzing.org
+# Copyright (c) 2016 Fritzing
+# Fritzing is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# Fritzing is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
+# ********************************************************************
+
+LIBGIT2INCLUDE = ../libgit2/include
+exists($$LIBGIT2INCLUDE/git2.h) {
+    message("found libgit2 include path at $$LIBGIT2INCLUDE")
+} else {
+    message("Fritzing requires libgit2")
+    message("Build it from the repo at https://github.com/libgit2")
+    message("See https://github.com/fritzing/fritzing-app/wiki for details.")
+
+    error("libgit2 include path not found in $$LIBGIT2INCLUDE")
+}
+
+INCLUDEPATH += $$LIBGIT2INCLUDE
+
+win32 {
+    contains(QMAKE_TARGET.arch, x86_64) {
+        LIBGIT2LIB = ../libgit2/build64
+    } else {
+        LIBGIT2LIB = ../libgit2/build32
+    }
+
+    exists($$LIBGIT2LIB/git2.lib) {
+        message("found libgit2 library in $$LIBGIT2LIB")
+    } else {
+        error("libgit2 library not found in $$LIBGIT2LIB")
+    }
+}
+
+unix {
+    LIBGIT2LIB = ../libgit2/build
+    macx {
+        exists($$LIBGIT2LIB/libgit2.dylib) {
+            message("found libgit2 library in $$LIBGIT2LIB")
+        } else {
+            error("libgit2 library not found in $$LIBGIT2LIB")
+        }
+    } else {
+        exists($$LIBGIT2LIB/libgit2.so) {
+            message("found libgit2 library in $$LIBGIT2LIB")
+        } else {
+            error("libgit2 library not found in $$LIBGIT2LIB")
+        }
+    }
+}
+
+LIBS += -L$$LIBGIT2LIB -lgit2

--- a/pri/utils.pri
+++ b/pri/utils.pri
@@ -1,6 +1,6 @@
 # /*******************************************************************
 # Part of the Fritzing project - http://fritzing.org
-# Copyright (c) 2007-08 Fritzing
+# Copyright (c) 2007-16 Fritzing
 # Fritzing is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -16,46 +16,6 @@
 # $Author: irascibl@gmail.com $:
 # $Date: 2013-01-12 07:45:08 +0100 (Sa, 12. Jan 2013) $
 # ********************************************************************/
-
-# boost_1_54_0 is buggy
-BOOSTS = 43 44 45 46 47 48 49 50 51 52 53 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99
-LATESTBOOST = 0
-for(boost, BOOSTS) {
-        exists(../src/lib/boost_1_$${boost}_0) {
-                LATESTBOOST = $$boost
-        }
-}
-
-contains(LATESTBOOST, 0) {
-    unix {
-        !macx {
-             BOOSTINFO = $$system(dpkg -s libboost-dev | grep 'Version')
-             BADVERSION = $$find(BOOSTINFO, 1\.54)
-             !isEmpty(BADVERSION) {
-                 message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
-                 error("Easiest to copy the boost library to .../src/lib/, so that you have .../src/lib/boost_1_xx_0")
-             }
-             isEmpty(BADVERSION) {
-                 BOOSTVERSION = $$find(BOOSTINFO, 1\...\.0)
-                 !isEmpty(BOOSTVERSION) {
-                     LATESTBOOST = installed
-                     message("using installed BOOST library")
-                 }
-             }
-        }
-    }
-}
-
-contains(LATESTBOOST, 0) {
-        message("Please download the boost library--you can find it at http://www.boost.org/")
-        message("Note that boost 1.54 has a bug in a function that Fritzing uses, so download some other version")
-        error("Copy the boost library to .../src/lib/, so that you have .../src/lib/boost_1_xx_0")
-}
-
-!contains(LATESTBOOST, installed) {
-    message("using boost from src/lib/boost_1_$${LATESTBOOST}_0")
-    INCLUDEPATH += src/lib/boost_1_$${LATESTBOOST}_0
-}
 
 HEADERS += \
 src/utils/abstractstatesbutton.h \
@@ -110,6 +70,3 @@ src/utils/schematicrectconstants.cpp \
 src/utils/s2s.cpp \
 src/utils/textutils.cpp \
 src/utils/zoomslider.cpp 
-
-
-


### PR DESCRIPTION
Here's a start on making phoenix.pro usable with system libgit2 and non-deb Boost.

**\* I've only tested on Linux with system Boost and libgit2.

First some tidy-ups on indentation etc. in phoenix.pro.

Moves the detection of out into separate .pri files to keep phoenix.pro as small as possible and make the testing for installed versions clear.

libgit2 detection is OK I think, thanks to its and qmake's support of pkg-config (I assume it doesn't run on macx?). As long as packagesExist() doesn't cause an error on win32 or macx.

The change for Boost just optionally skips the Boost detection and checking using a new BOOST_INSTALLED definition.

BOOST_INSTALLED constant isn't actually needed in the code (unlike QUAZIP_INSTALLED), so defining a SYSTEM_BOOST and a SYSTEM_QUAZIP to match might be better. On the other hand maybe BOOST_INSTALLED should be used in the code to force the use of the non-installed Boost version (although that may not be so simple).

A few ideas for boost detection that I haven't tried:
- adding compile time detection to graphutils.cpp, exiting with #error
- use qtCompileTest(test) in phoenix.pro
