### PR TITLE
Use ldconfig for boost detection

### DIFF
--- a/pri/boostdetect.pri
+++ b/pri/boostdetect.pri
@@ -29,14 +29,12 @@ for(boost, BOOSTS) {
 contains(LATESTBOOST, 0) {
     unix {
         !macx {
-            BOOSTINFO = $$system(dpkg -s libboost-dev | grep 'Version')
-            BADVERSION = $$find(BOOSTINFO, 1\.54)
+            BOOSTVERSION = $$system(ldconfig -p | grep libboost_filesystem.so | grep -o 1\...\.0 | head -n1)
+            BADVERSION = $$find(BOOSTVERSION, 1\.54)
             !isEmpty(BADVERSION) {
                 message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
                 error("Easiest to copy the boost library to .../src/lib/, so that you have .../src/lib/boost_1_xx_0")
-            }
-            isEmpty(BADVERSION) {
-                BOOSTVERSION = $$find(BOOSTINFO, 1\...\.0)
+            } else {
                 !isEmpty(BOOSTVERSION) {
                     LATESTBOOST = installed
                     message("using installed BOOST library")


### PR DESCRIPTION
dpkg is only available on debian based systems. Use ldconfig to determine the installed version of boost.

This addresses #3228. I only tested it on Arch Linux with a recent version of boost installed. It should be tested on a debian based system to make sure it does not introduce a regression.

libboost_filesystem.so is an arbitrary choice -- it just needs to be one of the installed boost .so files.