### PR TITLE
add option to choose installed translations using LINGUAS

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -143,7 +143,12 @@ unix {
     bins.files += bins
 
     translations.path = $$PKGDATADIR/translations
-    translations.extra = find $$PWD/translations -name "*.qm" -size +128c -exec cp -pr {} $(INSTALL_ROOT)$$PKGDATADIR/translations \\;
+    isEmpty(LINGUAS) {
+        translations.files += $$system(find $$PWD/translations -name "*.qm" -size +128c)
+    } else {
+        for(lang, LINGUAS):translations.files += $$system(find $$PWD/translations -name "fritzing_$${lang}.qm" -size +128c)
+        isEmpty(translations.files):error("No translations found for $$L10N")
+    }
 
     syntax.path = $$PKGDATADIR/translations/syntax
     syntax.files += translations/syntax/*.xml


### PR DESCRIPTION
Saves a lot of code in downstream packaging with selected translations only e.g.:
https://github.com/gentoo/gentoo/commit/53c843126785b377f6cbca9d2ea03001f9153dbd#diff-13ffa73c7e68e1ac2f92e7aa89c68cc2R50
