### PR TITLE
install application icon in /usr/share/pixmaps

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -127,8 +127,8 @@ unix {
     manpage.path = $$DATADIR/man/man1
     manpage.files += Fritzing.1
 
-    icon.path = $$DATADIR/icons
-    icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/icons/fritzing.png
+    icon.path = $$DATADIR/pixmaps
+    icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/pixmaps/fritzing.png
 
     parts.path = $$PKGDATADIR
     parts.files += parts


### PR DESCRIPTION
/usr/share/icons typically contains icon theme directories only

Fixes https://github.com/fritzing/fritzing-app/issues/3011
