### PR TITLE
use SYSTEM_QUAZIP to choose installed QuaZIP

### DIFF
--- a/config.tests/quazip/main.cpp
+++ b/config.tests/quazip/main.cpp
@@ -1,0 +1,4 @@
+#include <quazip/quazipfile.h>
+int main()
+{
+}

--- a/config.tests/quazip/quazip.pro
+++ b/config.tests/quazip/quazip.pro
@@ -1,0 +1,2 @@
+CONFIG += qt
+SOURCES = main.cpp

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -102,7 +102,7 @@ unix {
         } else {
             DEFINES += LINUX_32
         }
-        !contains(DEFINES, QUAZIP_INSTALLED) {
+        isEmpty(SYSTEM_QUAZIP) {
             LIBS += -lz
         }
     }
@@ -199,10 +199,16 @@ include(pri/translations.pri)
 include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
-contains(DEFINES, QUAZIP_INSTALLED) {
-    LIBS += -lquazip
-} else {
+isEmpty(SYSTEM_QUAZIP) {
     include(pri/quazip.pri)
+} else {
+    qtCompileTest(quazip)
+    !config_quazip {
+        error("Requested system QuaZIP but it could not be found")
+    }
+    message("using installed QuaZIP library")
+    DEFINES += QUAZIP_INSTALLED
+    LIBS += -lquazip
 }
 
 TARGET = Fritzing

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -200,7 +200,6 @@ include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
 contains(DEFINES, QUAZIP_INSTALLED) {
-    INCLUDEPATH += /usr/include/quazip
     LIBS += -lquazip
 } else {
     include(pri/quazip.pri)

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -47,7 +47,7 @@ win32 {
     DEFINES += _WINDOWS
     RELEASE_SCRIPT = $$(RELEASE_SCRIPT)    # environment variable set from release script
 
-    message("target arch: $${QMAKE_TARGET.arch}")
+    !build_pass:message("target arch: $${QMAKE_TARGET.arch}")
     contains(QMAKE_TARGET.arch, x86_64) {
         RELDIR = ../release64
         DEBDIR = ../debug64
@@ -171,7 +171,7 @@ RESOURCES += phoenixresources.qrc
 
 # Fritzing is using libgit2 since version 0.9.3
 packagesExist(libgit2) {
-    message("using installed libgit2 library")
+    !build_pass:message("using installed libgit2 library")
     PKGCONFIG += libgit2
 } else {
     include(pri/libgit2detect.pri)
@@ -206,7 +206,7 @@ isEmpty(SYSTEM_QUAZIP) {
     !config_quazip {
         error("Requested system QuaZIP but it could not be found")
     }
-    message("using installed QuaZIP library")
+    !build_pass:message("using installed QuaZIP library")
     DEFINES += QUAZIP_INSTALLED
     LIBS += -lquazip
 }
@@ -214,4 +214,4 @@ isEmpty(SYSTEM_QUAZIP) {
 TARGET = Fritzing
 TEMPLATE = app
 
-message("libs $$LIBS")
+!build_pass:message("libs $$LIBS")

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -171,6 +171,7 @@ RESOURCES += phoenixresources.qrc
 
 # Fritzing is using libgit2 since version 0.9.3
 packagesExist(libgit2) {
+    message("using installed libgit2 library")
     PKGCONFIG += libgit2
 } else {
     include(pri/libgit2detect.pri)

--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -15,7 +15,7 @@
 
 LIBGIT2INCLUDE = $$_PRO_FILE_PWD_/../libgit2/include
 exists($$LIBGIT2INCLUDE/git2.h) {
-    message("found libgit2 include path at $$LIBGIT2INCLUDE")
+    !build_pass:message("found libgit2 include path at $$LIBGIT2INCLUDE")
 } else {
     message("Fritzing requires libgit2")
     message("Build it from the repo at https://github.com/libgit2")
@@ -34,7 +34,7 @@ win32 {
     }
 
     exists($$LIBGIT2LIB/git2.lib) {
-        message("found libgit2 library in $$LIBGIT2LIB")
+        !build_pass:message("found libgit2 library in $$LIBGIT2LIB")
     } else {
         error("libgit2 library not found in $$LIBGIT2LIB")
     }
@@ -44,13 +44,13 @@ unix {
     LIBGIT2LIB = $$_PRO_FILE_PWD_/../libgit2/build
     macx {
         exists($$LIBGIT2LIB/libgit2.dylib) {
-            message("found libgit2 library in $$LIBGIT2LIB")
+            !build_pass:message("found libgit2 library in $$LIBGIT2LIB")
         } else {
             error("libgit2 library not found in $$LIBGIT2LIB")
         }
     } else {
         exists($$LIBGIT2LIB/libgit2.so) {
-            message("found libgit2 library in $$LIBGIT2LIB")
+            !build_pass:message("found libgit2 library in $$LIBGIT2LIB")
         } else {
             error("libgit2 library not found in $$LIBGIT2LIB")
         }

--- a/pri/utils.pri
+++ b/pri/utils.pri
@@ -30,7 +30,7 @@ contains(LATESTBOOST, 0) {
     qtCompileTest(boost)
     config_boost {
         LATESTBOOST = installed
-        message("using installed Boost library")
+        !build_pass:message("using installed Boost library")
     } else {
         message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
         error("Easiest to copy the Boost library to .../src/lib/, so that you have .../src/lib/boost_1_xx_0")
@@ -38,7 +38,7 @@ contains(LATESTBOOST, 0) {
 }
 
 !contains(LATESTBOOST, installed) {
-    message("using Boost from src/lib/boost_1_$${LATESTBOOST}_0")
+    !build_pass:message("using Boost from src/lib/boost_1_$${LATESTBOOST}_0")
     INCLUDEPATH += src/lib/boost_1_$${LATESTBOOST}_0
 }
 

--- a/tools/linux_release_script/release.sh
+++ b/tools/linux_release_script/release.sh
@@ -29,9 +29,9 @@ else
 fi
 
 PKG_OK=$(dpkg-query -W --showformat='${Status}\n' libquazip-dev)
-quazip='QUAZIP_LIB'
+quazip=
 if [ "`expr index "$PKG_OK" installed`" -gt 0 ] ; then
-  quazip='QUAZIP_INSTALLED'
+  quazip=1
   echo "using installed quazip"
 else
   echo "using src/lib/quazip"
@@ -43,7 +43,7 @@ cd $app_folder
 echo "appfolder $app_folder"
 
 echo "compiling... if this is not taking a long time, something is probably wrong"
-$QT_HOME/bin/qmake CONFIG+=release DEFINES+=$quazip
+$QT_HOME/bin/qmake CONFIG+=release SYSTEM_QUAZIP=$quazip
 make
 
 release_name=fritzing-$relname.linux.$arch


### PR DESCRIPTION
Suggest using SYSTEM_QUAZIP=1 with qmake instead of DEFINES+= QUAZIP_INSTALLED, and testing that QuaZIP really is installed (halting if it isn't).

**\* haven't tested: tools/linux_release_script/release.sh

Also a tidy-up for system libgit2 and ensure messages from qmake are only shown once.
