### PR TITLE
Add pkg-config support for macOS

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -36,6 +36,19 @@ unix:!macx {
     CONFIG += link_pkgconfig
 }
 
+macx {
+    # Support for pkg-config is disabled by default in the Qt package for mac
+    # However, it can be installed with macPorts/Brew etc.
+    # So check if it exists, and re-enable if it does.
+
+    PKG_CONFIG_BIN = $$system(which pkg-config)
+
+    !isEmpty(PKG_CONFIG_BIN) {
+        QT_CONFIG -= no-pkg-config
+        CONFIG += link_pkgconfig
+    }
+}
+
 load(configure)
 
 win32 {


### PR DESCRIPTION
Support for pkg-config is disabled by default in the Qt package for mac. See:

http://stackoverflow.com/questions/16972066/using-pkg-config-with-qt-creator-qmake-on-mac-osx

This patch checks if pkg-config is installed, and if so, enables pkg-config support
