### PR TITLE
Changing Linux Installer

### DIFF
--- a/fritzing
+++ b/fritzing
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd ~/.fritzing-0.9.3b
+./Fritzing

--- a/fritzing.desktop
+++ b/fritzing.desktop
@@ -2,8 +2,8 @@
 Name=Fritzing
 GenericName=Fritzing
 Comment=Electronic Design Automation software
-Exec=Fritzing
-Icon=fritzing
+Exec=fritzing
+Icon=/usr/share/icons/fritzing_icon.png
 Terminal=false
 Type=Application
 Categories=Development;IDE;Electronics;X-EDA;X-PCB;

--- a/install_fritzing.sh
+++ b/install_fritzing.sh
@@ -44,3 +44,34 @@ update-mime-database "${MIMEDIR}"
 xdg-icon-resource forceupdate --mode user
 
 echo "installed fritzing system icons"
+
+#Defining new Install Path
+install_path=~/.fritzing-0.9.3b/
+
+#Check if Installation exists
+if [ ! -f $install_path ]
+then
+	echo "Installing"
+	mkdir $install_path
+	cp -r ./* $install_path
+	echo "Copied all files"
+else
+	echo "Already Installed"
+fi
+
+#Put fritzing.desktop to right place and place file for command line startup in /bin/
+sudo cp ./fritzing.desktop /usr/share/applications/fritzing.desktop
+sudo mv  ./fritzing /bin/fritzing
+sudo cp ./icons/fritzing_icon.png /usr/share/icons/fritzing_icon.png
+#Making it all executable
+sudo chmod a+x /bin/fritzing
+sudo chmod a+x /usr/share/applications/fritzing.desktop
+echo "Set up Starter icons"
+
+#Removing unneccesary Directory
+working_dir=${PWD##*/}
+echo "Removing $working_dir"
+cd ..
+sudo rm -r ./$working_dir
+echo "Cleaned"
+echo "Fritzing is now located at $install_path"


### PR DESCRIPTION
Changing the Linux Installer.

The fritzing.desktop file is now copied to /usr/share/applications so it shows up in the app-launcher
Also I added a file in /bin/ so you can start fritzing by simply typing fritzing in the command line.
All the files are also moved to ~/.fritzing so it is more user-friendly (you don't notice it)

Thanks, GQDeltex