### PR TITLE
Add view option for "color wires by length"

### DIFF
--- a/src/items/wire.cpp
+++ b/src/items/wire.cpp
@@ -1988,9 +1988,13 @@ QColor Wire::colorForLength() {
         return color();
     }
     qreal length = m_line.length();
-    int wireLength = qCeil(.111 * length); // I have no idea what units this is in
-    if (wireLength > 0 && wireLength <= lengthColorTrans.count()) {
-        return lengthColorTrans[wireLength - 1];
+    qint32 wireLength = qRound(.111 * length); // I have no idea what units this is in
+    if (wireLength < 1) {
+        wireLength = 1;
+    }
+    wireLength -= 1;
+    if (wireLength < lengthColorTrans.count()) {
+        return lengthColorTrans[wireLength];
     }
 
     return color();

--- a/src/items/wire.h
+++ b/src/items/wire.h
@@ -167,6 +167,7 @@ public:
     void setConnector1Rect();
     QRectF connector0Rect(const QLineF & line);
     QRectF connector1Rect(const QLineF & line);
+    void colorByLength(bool);
 
 protected slots:
 	void colorEntry(const QString & text);
@@ -220,6 +221,8 @@ protected:
     void contextMenuEvent(QGraphicsSceneContextMenuEvent *event);
 	void updateCursor(Qt::KeyboardModifiers);
     ViewLayer::ViewID useViewIDForPixmap(ViewLayer::ViewID, bool swappingEnabled);
+    QColor colorForLength();
+    bool coloredByLength();
 
 protected:
 	QLineF	m_line;
@@ -249,12 +252,14 @@ protected:
 	class Bezier * m_bezier;
 	bool m_displayBendpointCursor;
     bool m_banded;
+    bool m_colorByLength;
 
 public:
 	static QStringList colorNames;
 	static QHash<QString, QString> colorTrans;
 	static QHash<int, QString> widthTrans;
 	static QList<int> widths;
+    static QList<QColor> lengthColorTrans;
 
 signals:
 	void wireChangedSignal(Wire* me, const QLineF & oldLine, const QLineF & newLine, QPointF oldPos, QPointF newPos, ConnectorItem * from, ConnectorItem * to);

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -302,6 +302,7 @@ protected slots:
     void showGrid();
     void setGridSize();
     void setBackgroundColor();
+    void colorWiresByLength();
     void showBreadboardView();
     void showSchematicView();
     void showProgramView();
@@ -814,6 +815,7 @@ protected:
     QAction *m_showGridAct;
     QAction *m_setGridSizeAct;
     QAction *m_setBackgroundColorAct;
+    QAction *m_colorWiresByLengthAct;
     QAction *m_showWelcomeAct;
     QAction *m_showBreadboardAct;
     QAction *m_showSchematicAct;

--- a/src/sketch/breadboardsketchwidget.cpp
+++ b/src/sketch/breadboardsketchwidget.cpp
@@ -33,6 +33,7 @@ $Date: 2013-04-21 09:50:09 +0200 (So, 21. Apr 2013) $
 #include "../waitpushundostack.h"
 
 #include <QScrollBar>
+#include <QSettings>
 
 static const double WireHoverStrokeFactor = 4.0;
 
@@ -42,6 +43,13 @@ BreadboardSketchWidget::BreadboardSketchWidget(ViewLayer::ViewID viewID, QWidget
 	m_shortName = QObject::tr("bb");
 	m_viewName = QObject::tr("Breadboard View");
 	initBackgroundColor();
+
+    m_colorWiresByLength = false;
+    QSettings settings;
+    QString colorWiresByLength = settings.value(QString("%1ColorWiresByLength").arg(getShortName())).toString();
+    if (!colorWiresByLength.isEmpty()) {
+        m_colorWiresByLength = (colorWiresByLength.compare("1") == 0);
+    }
 }
 
 void BreadboardSketchWidget::setWireVisible(Wire * wire)
@@ -141,6 +149,7 @@ void BreadboardSketchWidget::initWire(Wire * wire, int penWidth) {
 	}
 	wire->setPenWidth(penWidth - 2, this, (penWidth - 2) * WireHoverStrokeFactor);
 	wire->setColorString("blue", 1.0, false);
+    wire->colorByLength(m_colorWiresByLength);
 }
 
 const QString & BreadboardSketchWidget::traceColor(ViewLayer::ViewLayerPlacement) {
@@ -247,3 +256,22 @@ void BreadboardSketchWidget::getBendpointWidths(Wire * wire, double width, doubl
 	bendpoint2Width = bendpointWidth = -1;
 	negativeOffsetRect = true;
 }
+
+void BreadboardSketchWidget::colorWiresByLength(bool colorByLength) {
+    m_colorWiresByLength = colorByLength;
+    QSettings settings;
+    settings.setValue(QString("%1ColorWiresByLength").arg(viewName()), colorByLength);
+
+    QList<Wire *> wires;
+    QList<Wire *> visited;
+    foreach (QGraphicsItem * item, scene()->items()) {
+        Wire * wire = dynamic_cast<Wire *>(item);
+        if (wire == NULL) continue;
+        wire->colorByLength(colorByLength);
+    }
+}
+
+bool BreadboardSketchWidget::coloringWiresByLength() {
+    return m_colorWiresByLength;
+}
+

--- a/src/sketch/breadboardsketchwidget.h
+++ b/src/sketch/breadboardsketchwidget.h
@@ -46,6 +46,8 @@ public:
 	void showEvent(QShowEvent * event);
 	double getWireStrokeWidth(Wire *, double wireWidth);
 	void getBendpointWidths(class Wire *, double w, double & w1, double & w2, bool & negativeOffsetRect);
+    void colorWiresByLength(bool);
+    bool coloringWiresByLength();
 
 protected:
 	void setWireVisible(Wire * wire);
@@ -61,6 +63,8 @@ protected:
 	ViewLayer::ViewLayerID getLabelViewLayerID(ItemBase *);
 	double getTraceWidth();
 	const QString & traceColor(ViewLayer::ViewLayerPlacement);
+
+    bool m_colorWiresByLength;
 };
 
 #endif


### PR DESCRIPTION
As you probably know, several popular breadboarding kits come with premade jumper wires color-coded by length ([Radio Shack kit](https://www.radioshack.com/products/solderless-jumper-wire-kit), [SparkFun kit](https://www.sparkfun.com/products/124), [Elenco Kit](https://www.amazon.com/Elenco-Piece-Pre-formed-Jumper-Wire/dp/B0002H7AIG%3FSubscriptionId%3DAKIAILSHYYTFIVPWUY6Q%26tag%3Dduckduckgo-osx-20%26linkCode%3Dxm2%26camp%3D2025%26creative%3D165953%26creativeASIN%3DB0002H7AIG)). The color order is consistent between these kits, and it's the same as resistor color order.

When I am breadboarding in Fritzing, I like to logically color-code my wires — black for ground, read for VCC, etc — as I imagine most people do.

However, when the time comes to migrate my design from Fritzing breadboard to actual breadboard, the colors of the jumpers I will use are determined by what's in those kits, not by what I drew in Fritzing.

It would therefore be very helpful if I could toggle my Fritzing between logical coloring and coloring by length, to ease the transition between Fritzing and breadboarding. 

To that end, I added a "Color breadboard wires by length" command to the Fritzing "View" menu, and implemented the standard color-coding for breadboard jumpers of length from 100mil to 1000 mil (which are: silver aka no insulator, red, orange, yellow, green, blue, violet, grey, white, brown).

My change only recolors straight wires, and the recoloring is only for display purposes; the underlying wire color (as seen in the inspector) is unchanged. 

I am also attaching a test file, as well as a screenshot of the code in action:

[Test.fzz.zip](https://github.com/fritzing/fritzing-app/files/678479/Test.fzz.zip)

![test_bb](https://cloud.githubusercontent.com/assets/1645207/21562622/5789468e-ce48-11e6-8997-db939c6ccc33.png)
