### PR TITLE
Update desktop file

### DIFF
--- a/fritzing.desktop
+++ b/fritzing.desktop
@@ -2,7 +2,7 @@
 Name=Fritzing
 GenericName=Fritzing
 Comment=Electronic Design Automation software
-Exec=Fritzing
+Exec=Fritzing %F
 Icon=fritzing
 Terminal=false
 Type=Application

--- a/fritzing.desktop
+++ b/fritzing.desktop
@@ -9,6 +9,5 @@ Icon=fritzing
 Terminal=false
 Type=Application
 Categories=Development;IDE;Electronics;X-EDA;X-PCB;
-X-SuSE-translate=false
 StartupNotify=true
 MimeType=application/x-fritzing-fz;application/x-fritzing-fzz;application/x-fritzing-fzp;application/x-fritzing-fzpz;application/x-fritzing-fzb;application/x-fritzing-fzbz;application/x-fritzing-fzm;

--- a/fritzing.desktop
+++ b/fritzing.desktop
@@ -2,6 +2,7 @@
 Name=Fritzing
 GenericName=Fritzing
 Comment=Electronic Design Automation software
+Comment[fi]=Suunnittele elektronisia kytkentöjä ja piirilevyjä
 Comment[ru]=Программа проектирования электроники
 Exec=Fritzing %F
 Icon=fritzing

--- a/fritzing.desktop
+++ b/fritzing.desktop
@@ -2,6 +2,7 @@
 Name=Fritzing
 GenericName=Fritzing
 Comment=Electronic Design Automation software
+Comment[ru]=Программа проектирования электроники
 Exec=Fritzing %F
 Icon=fritzing
 Terminal=false


### PR DESCRIPTION
Caught by Debian's Lintian: https://lintian.debian.org/tags/desktop-mime-but-no-exec-code.html
"The desktop entry lists support for at least one mime type, but does not provide codes like %f, %F, %u or %U for the Exec key.
If the application can indeed handle files of the listed mime types, it should specify a way to pass the filenames as parameters."