### PR TITLE
folderutils.cpp: Fix getAppPartsSubFolder2 returns current working di…

### DIFF
--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -118,12 +118,12 @@ QDir FolderUtils::getAppPartsSubFolder(QString search) {
 QDir FolderUtils::getAppPartsSubFolder2(QString search) {
 	if (m_partsPath.isEmpty()) {
 		QDir dir = getApplicationSubFolder("fritzing-parts");
-		if (dir.exists()) {
+		if (dir.exists() && dir.dirName().endsWith("fritzing-parts")) {
 			m_partsPath = dir.absolutePath();
 		}
 		else {
 			QDir dir = getApplicationSubFolder("parts");
-			if (dir.exists()) {
+			if (dir.exists() && dir.dirName().endsWith("parts")) {
 				m_partsPath = dir.absolutePath();
 			}
 		}


### PR DESCRIPTION
…rectory if fritzing-parts folder is not found

getApplicationSubFolder returns QDir() if the directory can not be found,
but QDir() returns the current working directory, which nearly always exists and probably is the wrong path.
As getAppPartsSubFolder2 only checks for existence of that directory we end up with the wrong directory if parts folder is used instead for fritzing-parts.
Therefore check if when we ask for fritzing-parts folder we really get a folder with that name.