### PR TITLE
Allow headless builds on OS X

### DIFF
--- a/src/fapplication.cpp
+++ b/src/fapplication.cpp
@@ -599,7 +599,9 @@ bool FApplication::init() {
 	PaletteModel::initNames();
 	SvgIconWidget::initNames();
 	PinHeader::initNames();
-	CursorMaster::initCursors();
+	if (m_serviceType == NoService) {
+		CursorMaster::initCursors();
+	}
 
 #ifdef Q_OS_MAC
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)) || defined(QT_MAC_USE_COCOA)

--- a/tools/deploy_fritzing_mac.sh
+++ b/tools/deploy_fritzing_mac.sh
@@ -21,7 +21,7 @@ echo $builddir
 
 echo ">> building fritzing from working directory"
 $QTBIN/qmake -o Makefile phoenix.pro
-make release  # release is the type of build
+make "-j$(sysctl -n machdep.cpu.thread_count)" release  # release is the type of build
 cp -r $builddir/Fritzing.app $deploydir
 
 echo ">> add .app dependencies"


### PR DESCRIPTION
Deployment of Fritzing.app on OS X bombs out while trying to build the parts database. The crash happens inside `Fritzing -db foo`, which can’t set up its mouse pointers because it has no UI.

This patch skips does cursor initialization only if the service is `NoService`. Are there other conditions when we **do** want to bring up a GUI?

Tested very lightly.