### PR TITLE
Fix SVG font handling for single-quoted font-family inside style attribute

### DIFF
--- a/src/utils/textutils.cpp
+++ b/src/utils/textutils.cpp
@@ -118,7 +118,7 @@ FixedFontsHash fixFontsMapping(const QSet<QString> fontsTofix, const QString & d
 }
 
 bool removeFontFamilySingleQuotes(QString &fileContent) {
-	static QString pattern = "font-family=\"('[^']*')\"";
+	static QString pattern = "font-family(?:=\"|:)('[^']*')\"?";
 	QSet<QString> wrongFontFamilies = TextUtils::getRegexpCaptures(pattern, fileContent);
 
 	foreach(QString ff, wrongFontFamilies) {

--- a/src/utils/textutils.cpp
+++ b/src/utils/textutils.cpp
@@ -54,6 +54,8 @@ const QString TextUtils::SMDFlipSuffix("___");
 const QString TextUtils::RegexFloatDetector = "[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?";
 const QRegExp TextUtils::floatingPointMatcher(RegexFloatDetector);
 
+static const QString fontFamilyQuotesPattern = R"x(font-family(?:="|:)('[^']*')"?)x";
+
 static const QRegExp HexExpr("&#x[0-9a-fA-F];");   // &#x9; &#xa; &#xd;
 static const QRegExp Xmlns("xmlns=([\"|'])[^\"']*\\1");
 
@@ -117,9 +119,8 @@ FixedFontsHash fixFontsMapping(const QSet<QString> fontsTofix, const QString & d
 	return retval;
 }
 
-bool removeFontFamilySingleQuotes(QString &fileContent) {
-	static QString pattern = "font-family(?:=\"|:)('[^']*')\"?";
-	QSet<QString> wrongFontFamilies = TextUtils::getRegexpCaptures(pattern, fileContent);
+bool TextUtils::removeFontFamilySingleQuotes(QString &fileContent) {
+	QSet<QString> wrongFontFamilies = TextUtils::getRegexpCaptures(fontFamilyQuotesPattern, fileContent);
 
 	foreach(QString ff, wrongFontFamilies) {
 		QString wrongFF = ff;

--- a/src/utils/textutils.h
+++ b/src/utils/textutils.h
@@ -147,7 +147,8 @@ protected:
 	static bool fixViewBox(QDomElement & root);
 	static void chopNotDigits(QString &);
 	static void collectTransforms(QDomElement & root, QList<QDomElement> & transforms);
-
+private:
+	static bool removeFontFamilySingleQuotes(QString &fileContent);
 };
 
 #endif

--- a/tests/auto/test_textutils/test_textutils.cpp
+++ b/tests/auto/test_textutils/test_textutils.cpp
@@ -1,0 +1,35 @@
+#define BOOST_TEST_MODULE SVG Tests
+#include <boost/test/included/unit_test.hpp>
+
+//#include <QStringList>
+
+#define private public
+#include "textutils.h"
+
+BOOST_AUTO_TEST_CASE( test_removeFontFamilySingleQuotes )
+{
+    QString input1 = R"(g-text-style=“font-family:Droid Sans;text-anchor:middle;”)";
+    QString input2 = R"(g-text-font-family=“Droid Sans”)";
+    QString input3 = R"(style="font-family:‘Droid Sans’")";
+    QString input4 = R"(style="font-family:'Droid Sans'")";
+    QString input5 = R"x(<text transform="matrix(1 0 0 1 62.9226 29.5)" fill="#8C8C8C" font-family="'DroidSans'" font-size="3.5">echo</text>)x";
+
+    bool changed;
+    changed = TextUtils::removeFontFamilySingleQuotes(input1);
+    BOOST_REQUIRE(!changed);
+
+    changed = TextUtils::removeFontFamilySingleQuotes(input2);
+    BOOST_REQUIRE(!changed);
+
+    // We can probably not process opening and closing single quotes, but
+    // I don't think they are valid svg anyhow.
+    changed = TextUtils::removeFontFamilySingleQuotes(input3);
+    BOOST_REQUIRE(!changed);
+
+    changed = TextUtils::removeFontFamilySingleQuotes(input4);
+    BOOST_REQUIRE(changed);
+
+    changed = TextUtils::removeFontFamilySingleQuotes(input5);
+    BOOST_REQUIRE(changed);
+
+}

--- a/tests/auto/test_textutils/test_textutils.pro
+++ b/tests/auto/test_textutils/test_textutils.pro
@@ -1,0 +1,32 @@
+# /*******************************************************************
+# Part of the Fritzing project - http://fritzing.org
+# Copyright (c) 2019 Fritzing
+# Fritzing is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# Fritzing is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
+# ********************************************************************/
+
+boost_root = ../../boost_1_70_0
+include($$absolute_path(../../../pri/boostdetect.pri))
+
+QT += core xml
+#concurrent core gui network printsupport serialport sql svg widgets xml
+
+HEADERS += $$files(*.h)
+SOURCES += $$files(*.cpp)
+
+INCLUDEPATH += $$absolute_path(../../../src)
+#INCLUDEPATH += $$top_srcdir
+
+HEADERS += $$files(../../../src/utils/textutils.h)
+SOURCES += $$files(../../../src/utils/textutils.cpp)
+INCLUDEPATH += $$absolute_path(../../../src/utils)
+# FLIBS += textutils
+


### PR DESCRIPTION
With latest InkScape and Fritzing releases, one receives an error loading a schematic SVG, as reported here: http://forum.fritzing.org/t/font-error-in-parts-editor-when-reading-schematic-svg-which-is-edited-with-inkscape/3753

The problem is the SVG font fixing handles single quotes in the font-family attribute, but not inside the style attribute. The minimal fix was to update the regex in `removeFontFamilySingleQuotes` accordingly to support both.