### PR TITLE
Fixes quazip build on Windows with recent versions of Qt

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -1,7 +1,7 @@
 # /*******************************************************************
 #
 # Part of the Fritzing project - http://fritzing.org
-# Copyright (c) 2007-16 Fritzing
+# Copyright (c) 2007-17 Fritzing
 #
 # Fritzing is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,7 +42,6 @@ win32 {
 # release build using msvc 2010 needs to use Multi-threaded (/MT) for the code generation/runtime library option
 # release build using msvc 2010 needs to add msvcrt.lib;%(IgnoreSpecificDefaultLibraries) to the linker/no default libraries option
     CONFIG -= embed_manifest_exe
-    INCLUDEPATH += $$[QT_INSTALL_HEADERS]/QtZlib
     DEFINES += _CRT_SECURE_NO_DEPRECATE
     DEFINES += _WINDOWS
     RELEASE_SCRIPT = $$(RELEASE_SCRIPT)    # environment variable set from release script
@@ -88,8 +87,6 @@ macx {
     CONFIG += x86_64 # x86 ppc
     QMAKE_INFO_PLIST = FritzingInfo.plist
     #DEFINES += QT_NO_DEBUG                # uncomment this for xcode
-    LIBS += -lz
-    LIBS += /usr/lib/libz.dylib
     LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
     LIBS += /System/Library/Frameworks/Carbon.framework/Carbon
     LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
@@ -101,9 +98,6 @@ unix {
             DEFINES += LINUX_64
         } else {
             DEFINES += LINUX_32
-        }
-        !contains(DEFINES, QUAZIP_INSTALLED) {
-            LIBS += -lz
         }
     }
 
@@ -217,6 +211,7 @@ contains(DEFINES, QUAZIP_INSTALLED) {
     INCLUDEPATH += /usr/include/quazip
     LIBS += -lquazip
 } else {
+    include(pri/zlib.pri)
     include(pri/quazip.pri)
 }
 

--- a/pri/zlib.pri
+++ b/pri/zlib.pri
@@ -1,0 +1,47 @@
+# /*******************************************************************
+# Part of the Fritzing project - http://fritzing.org
+# Copyright (c) 2017 Fritzing
+# Fritzing is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# Fritzing is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
+# ********************************************************************
+
+win32 {
+    LIBZINCLUDE = "$$_PRO_FILE_PWD_/src/lib/zlib"
+    exists($$LIBZINCLUDE/zlib.h) {
+        message("found zlib include path at $$LIBZINCLUDE")
+    } else {
+        message("Fritzing requires zlib")
+
+        error("zlib include path not found in $$LIBZINCLUDE")
+    }
+
+    INCLUDEPATH += $$LIBZINCLUDE
+
+    contains(QMAKE_TARGET.arch, x86_64) {
+        LIBZLIB = "$$_PRO_FILE_PWD_/src/lib/zlib/build64"
+    } else {
+        LIBZLIB = "$$_PRO_FILE_PWD_/src/lib/zlib/build32"
+    }
+
+    exists($$LIBZLIB/zlib.lib) {
+        message("found zlib library in $$LIBZLIB")
+    } else {
+        error("zlib library not found in $$LIBZLIB")
+    }
+
+    LIBS += -L$$LIBZLIB -lzlib
+}
+unix {
+    LIBS += -lz
+}
+macx {
+    LIBS += /usr/lib/libz.dylib
+}


### PR DESCRIPTION
I have Qt 5.8.0 installed on Windows 10, and it doesn't include a bundled QtZlib, causing the Fritzing build to fail on quazip. I think it was incorrect (though convenient) to rely on the past existence of QtZlib. Instead, I have modified the build scripts to "detect" zlib on Windows, following the model of `libgit2detect.pri`.  It assumes zlib is extracted and built in `src\lib\zlib`. I moved the *nix zlib configs to the new `zlib.pri` as well.

I have only tested on Windows, as I don't have a build env for Linux or macOS. NOTE: This requires an update to the build instructions, to direct the user to download zlib and build it using e.g. CMake -- very similar to the process for libgit2.