### PR TITLE
Use delete[] where new[] was used for allocation

### DIFF
--- a/src/utils/graphutils.cpp
+++ b/src/utils/graphutils.cpp
@@ -436,8 +436,8 @@ bool GraphUtils::chooseRatsnestGraph(const QList<ConnectorItem *> * partConnecto
     }
 
 
-	delete edges;
-	delete weights;
+	delete [] edges;
+	delete [] weights;
 
 	return retval;
 }


### PR DESCRIPTION
These arrays were allocated with `new[]`, so they have to be deleted with `delete[]`. Otherwise you risk memory leaks.