### PR TITLE
Add symbol color to styles.xml

### DIFF
--- a/translations/syntax/styles.xml
+++ b/translations/syntax/styles.xml
@@ -14,4 +14,5 @@
       <style name="Comment"  color="#808080" italic="1" /> <!-- e.g. this  -->
       <style name="Region Marker"  color="#dddddd" /> <!-- e.g. ? -->
       <style name="Preprocessor"  color="#b7b1a9" /> <!-- e.g. #ifdef -->
+      <style name="Symbol" color="#dddddd" />
 </styles>


### PR DESCRIPTION
Fixes code symbol invisibility in v0.9.3 on OSX10.12.6