### PR TITLE
close gerber regions properly (#3333)

### DIFF
--- a/src/svg/gerbergenerator.cpp
+++ b/src/svg/gerbergenerator.cpp
@@ -541,10 +541,10 @@ void GerberPaintEngine::collectFile(QTextStream &output, bool mirrorX) {
                 output << "G36*\n";
                 for (size_t j = 0; j < r.polygon.size(); j++)
                     xyd(output, r.polygon[j].X, r.polygon[j].Y, j == 0 ? 2 : 1, mirrorX);
+                output << "G37*\n";
                 if (r.lightPolarity)
                     output << "%LPD*%\n";
             }
-            output << "G37*\n";
         }
     }
     for(QList<RoundAperture>::iterator i = roundAperturesDefs.begin(); i != roundAperturesDefs.end(); ++i) {


### PR DESCRIPTION
The original code has only one "end region" (G37) statement for the whole file, but has multiple "start region" (G36) commands. AFAIK this results in an incorrect gerber file. (I think that polarity changes (%LPC or %LPD) inside a region are also illegal, but I'm too lazy to search the specifications for that.) 
This change puts the "end region" (G37) statement at the end of each region.