### PR TITLE
Fix build with libgit2 > 0.24.0

### DIFF
--- a/src/version/partschecker.cpp
+++ b/src/version/partschecker.cpp
@@ -123,7 +123,9 @@ bool PartsChecker::newPartsAvailable(const QString &repoPath, const QString & sh
      */
 
 
-#if LIBGIT2_VER_MINOR > 23
+#if LIBGIT2_VER_MINOR > 24
+    error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL, NULL);
+#elif LIBGIT2_VER_MINOR == 24
     error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL);
 #else
     error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks);


### PR DESCRIPTION
Hi,

The build with libgit 0.26.0 is broken. A quick check on the history shows that :

Commit 1ffea750c05fda78c88b60b84545f6a3e1371159 fixes build for libgit == 0.24 only
Commit 4cb5185d464bf98e9da5ceca72d5af907ff824ef fixes build with libgit >= 0.24
A merge commit 5193d3614ee30e75ce37bcc67aae9a986b14064f discards the fix for libgit >= 0.24

This PR restores the fix of 4cb5185d464bf98e9da5ceca72d5af907ff824ef (for libgit >= 0.24)