### PR TITLE
solved win32 drive letter case sensitivity issue on some systems

### DIFF
--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -152,8 +152,8 @@ QString FolderUtils::getTopLevelDocumentsPath() {
 }
 
 QString FolderUtils::getUserBinsPath() {
-    QDir dir(getTopLevelDocumentsPath());
-    return dir.absoluteFilePath("bins");
+    QDir dir(getTopLevelDocumentsPath() + "/bins");
+    return QFileInfo(dir, "").absoluteFilePath();
 }
 
 QString FolderUtils::getUserPartsPath() {


### PR DESCRIPTION
On some win32 systems the bin search field does not appear in the "Parts view", please see [this Fritzing forum topic](http://forum.fritzing.org/t/search-function-in-the-parts-view-does-not-work/1536/65).
It looks like this happens because QDir::absoluteFilePath on win32 does not return an uppercase drive letter while other File/folder classes/methods do (i.e.: QFileInfo::absoluteFilePath).
Depending on the way the OS is configured or the app is started, some users reports this problem (like me), while most users don't.