### PR TITLE
fix bad part hangs Fritzing bug

### DIFF
--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1900,7 +1900,17 @@ ModelPart* MainWindow::copyToPartsFolder(const QFileInfo& file, bool addToAlien,
 		}
 	}
 	ModelPart *mp = m_referenceModel->loadPart(destFilePath, true);
-	mp->setAlien(true);
+	if (mp != NULL) {
+		mp->setAlien(true);
+	} else {
+		// Part load failed, remove modified files before proceeding.
+                foreach(QString pathToRemove, m_alienFiles) {
+                        QFile::remove(pathToRemove);
+                }
+                m_alienFiles.clear();
+                recoverBackupedFiles();
+                emit alienPartsDismissed();
+	}
 
 	return mp;
 }


### PR DESCRIPTION
This code seems to fix issue #3382 where a corrupted fzp file causes a seg fault in Fritzing and leaves the parts files around after the crash. While I don't know what I'm doing and just copied a section of code that deals with a similar situation and it would be good to have someone familiar with the code review this, since the alternative is a seg fault and a hang, I don't see that this fix could be worse.

Peter