### PR TITLE
Remove Qt 4 serialport support from phoenix.pro

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -24,6 +24,10 @@
 #
 #********************************************************************/
 
+lessThan(QT_MAJOR_VERSION, 5) {
+    error(Fritzing does not build with Qt 4 or earlier)
+}
+
 # Fritzing requires two Qt-provided plugins in order to run correctly,
 # however the QTPLUGIN syntax only seems to work if Qt is built statically,
 # so QTPLUGIN is included here only for information purposes:

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -168,12 +168,7 @@ macx {
     QMAKE_BUNDLE_DATA += FILE_ICONS
 }
 
-QT += core gui svg xml network sql # opengl
-greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += widgets printsupport concurrent serialport
-} else {
-    include($$QTSERIALPORT_PROJECT_ROOT/src/serialport/qt4support/serialport.prf)
-}
+QT += concurrent core gui network printsupport serialport sql svg widgets xml
 
 RC_FILE = fritzing.rc
 RESOURCES += phoenixresources.qrc


### PR DESCRIPTION
```diff
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -165,12 +165,7 @@ macx {
     QMAKE_BUNDLE_DATA += FILE_ICONS
 }
 
-QT += core gui svg xml network sql # opengl
-greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += widgets printsupport concurrent serialport
-} else {
-    include($$QTSERIALPORT_PROJECT_ROOT/src/serialport/qt4support/serialport.prf)
-}
+QT += concurrent core gui network printsupport serialport sql svg widgets xml
 
 RC_FILE = fritzing.rc
 RESOURCES += phoenixresources.qrc
```