### PR TITLE
Remove compile-time checks for Qt 5.0

### DIFF
--- a/src/dialogs/quotedialog.cpp
+++ b/src/dialogs/quotedialog.cpp
@@ -190,13 +190,8 @@ QuoteDialog::QuoteDialog(bool full, QWidget *parent) : QDialog(parent)
     m_tableWidget->verticalHeader()->setVisible(false);
     m_tableWidget->horizontalHeader()->setVisible(false);
     
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    m_tableWidget->verticalHeader()->setResizeMode(QHeaderView::ResizeToContents);
-    m_tableWidget->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
-#else
     m_tableWidget->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
     m_tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-#endif
     
     m_tableWidget->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_tableWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/dialogs/recoverydialog.cpp
+++ b/src/dialogs/recoverydialog.cpp
@@ -67,14 +67,8 @@ RecoveryDialog::RecoveryDialog(QFileInfoList fileInfoList, QWidget *parent, Qt::
     m_recoveryList->header()->setDefaultAlignment(Qt::AlignCenter);
     m_recoveryList->header()->setDragEnabled(false);
     m_recoveryList->header()->setDragDropMode(QAbstractItemView::NoDragDrop);
-    
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    m_recoveryList->header()->setResizeMode(QHeaderView::ResizeToContents);
-    m_recoveryList->header()->setMovable(false);
-#else
     m_recoveryList->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     m_recoveryList->header()->setSectionsMovable(false);
-#endif
 
     connect(m_recoveryList, SIGNAL(itemSelectionChanged()), this, SLOT(updateRecoverButton()));
 

--- a/src/fapplication.cpp
+++ b/src/fapplication.cpp
@@ -105,11 +105,7 @@ $Date: 2013-04-19 12:51:22 +0200 (Fr, 19. Apr 2013) $
 #endif
 #endif
 #ifdef Q_OS_MAC
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)) || defined(QT_MAC_USE_COCOA)
 #define PLATFORM_NAME "mac-os-x-105"
-#else
-#define PLATFORM_NAME "mac-os-x-104"
-#endif
 #endif
 
 #ifdef Q_OS_WIN
@@ -612,11 +608,7 @@ int FApplication::init() {
 	}
 
 #ifdef Q_OS_MAC
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)) || defined(QT_MAC_USE_COCOA)
 	m_buildType = " Cocoa";
-#else
-	m_buildType = " Carbon";
-#endif
 #else
     m_buildType = QString(PLATFORM_NAME).contains("64") ? "64" : "32";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,13 +40,8 @@ $Date: 2013-02-26 16:26:03 +0100 (Di, 26. Feb 2013) $
 #endif
 #endif
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-QtMsgHandler originalMsgHandler;
-#define ORIGINAL_MESSAGE_HANDLER(TYPE, MSG) originalMsgHandler((TYPE), (MSG))
-#else
 QtMessageHandler originalMsgHandler;
 #define ORIGINAL_MESSAGE_HANDLER(TYPE, MSG) originalMsgHandler((TYPE), context, (MSG))
-#endif
 
 void writeCrashMessage(const char * msg) {
     QString path = FolderUtils::getTopLevelUserDataStorePath();
@@ -59,17 +54,11 @@ void writeCrashMessage(const char * msg) {
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 void writeCrashMessage(const QString & msg) {
         writeCrashMessage(msg.toStdString().c_str());
 }
-#endif
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-void fMessageHandler(QtMsgType type, const char *msg)
-#else
 void fMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString & msg)
-#endif
 {
     switch (type) {
       case QtDebugMsg:
@@ -98,11 +87,7 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef Q_OS_WIN
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	originalMsgHandler = qInstallMsgHandler(fMessageHandler);
-#else
     originalMsgHandler = qInstallMessageHandler(fMessageHandler);
-#endif
 #ifndef QT_NO_DEBUG
 #ifdef WIN_CHECK_LEAKS
     HANDLE hLogFile;

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1354,7 +1354,7 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event) {
 		ProcessEventBlocker::processEvents();
 	}
 
-#if defined(Q_OS_MAC) && (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+#if defined(Q_OS_MAC)
 
     // Need to process Backspace on Mac to workaround bug in Qt5
     // See http://qt-project.org/forums/viewthread/36174

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -729,9 +729,6 @@ protected:
 	// Export Menu
 	QMenu *m_exportMenu;
 	QAction *m_exportJpgAct;
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	QAction *m_exportPsAct;
-#endif
 	QAction *m_exportPngAct;
 	QAction *m_exportPdfAct;
 	QAction *m_exportEagleAct;

--- a/src/mainwindow/mainwindow_export.cpp
+++ b/src/mainwindow/mainwindow_export.cpp
@@ -76,9 +76,6 @@ $Date: 2013-04-22 23:44:56 +0200 (Mo, 22. Apr 2013) $
 static QString eagleActionType = ".eagle";
 static QString gerberActionType = ".gerber";
 static QString jpgActionType = ".jpg";
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-static QString psActionType = ".ps";
-#endif
 static QString pdfActionType = ".pdf";
 static QString pngActionType = ".png";
 static QString svgActionType = ".svg";
@@ -139,12 +136,6 @@ void MainWindow::initNames()
 	fileExtFormats[jpgActionType] = tr("JPEG Image (*.jpg)");
 	fileExtFormats[svgActionType] = tr("SVG Image (*.svg)");
 	fileExtFormats[bomActionType] = tr("BoM Text File (*.html)");
-    
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-    OtherKnownExtensions << psActionType;
-	filePrintFormats[psActionType] = QPrinter::PostScriptFormat;
-	fileExtFormats[psActionType] = tr("PostScript (*.ps)");
-#endif
 
 	QSettings settings;
 	AutosaveEnabled = settings.value("autosaveEnabled", QString("%1").arg(AutosaveEnabled)).toBool();
@@ -986,13 +977,6 @@ void MainWindow::createExportActions() {
 	m_exportPngAct->setData(pngActionType);
 	m_exportPngAct->setStatusTip(tr("Export the visible area of the current sketch as a PNG image"));
 	connect(m_exportPngAct, SIGNAL(triggered()), this, SLOT(doExport()));
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	m_exportPsAct = new QAction(tr("PostScript..."), this);
-	m_exportPsAct->setData(psActionType);
-	m_exportPsAct->setStatusTip(tr("Export the visible area of the current sketch as a PostScript image"));
-	connect(m_exportPsAct, SIGNAL(triggered()), this, SLOT(doExport()));
-#endif
 
 	m_exportPdfAct = new QAction(tr("PDF..."), this);
 	m_exportPdfAct->setData(pdfActionType);

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -1403,9 +1403,6 @@ void MainWindow::populateExportMenu() {
 	imageMenu->addSeparator();
 	imageMenu->addAction(m_exportSvgAct);
 	imageMenu->addAction(m_exportPdfAct);
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	imageMenu->addAction(m_exportPsAct);
-#endif
 
 	QMenu * productionMenu = m_exportMenu->addMenu(tr("for Production"));
 	productionMenu->addAction(m_exportEtchablePdfAct);

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -170,10 +170,8 @@ SketchWidget::SketchWidget(ViewLayer::ViewID viewID, QWidget *parent, int size, 
 	m_arrowTimer.setParent(this);
 	m_arrowTimer.setInterval(AutoRepeatDelay);
 	m_arrowTimer.setSingleShot(true);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    m_arrowTimer.setTimerType(Qt::PreciseTimer);
-    m_autoScrollTimer.setTimerType(Qt::PreciseTimer);
-#endif
+	m_arrowTimer.setTimerType(Qt::PreciseTimer);
+	m_autoScrollTimer.setTimerType(Qt::PreciseTimer);
 	connect(&m_arrowTimer, SIGNAL(timeout()), this, SLOT(arrowTimerTimeout()));
 	m_addDefaultParts = false;
 	m_addedDefaultPart = NULL;

--- a/src/utils/autoclosemessagebox.cpp
+++ b/src/utils/autoclosemessagebox.cpp
@@ -56,10 +56,8 @@ void AutoCloseMessageBox::start() {
 	m_animationTimer.setInterval(Interval);
 	m_animationTimer.setSingleShot(false);
 	connect(&m_animationTimer, SIGNAL(timeout()), this, SLOT(moveOut()));
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    m_animationTimer.setTimerType(Qt::PreciseTimer);
-#endif
-    m_movingState = MovingOut;
+	m_animationTimer.setTimerType(Qt::PreciseTimer);
+	m_movingState = MovingOut;
 	m_animationTimer.start();
 	show();
 }

--- a/src/utils/misc.h
+++ b/src/utils/misc.h
@@ -30,25 +30,6 @@ $Date: 2013-02-26 16:26:03 +0100 (Di, 26. Feb 2013) $
 #include <QHash>
 #include <QVector>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-// TODO: this debugging hack seems to break in Qt 5; needs investigation
-#ifdef Q_OS_WIN
-#ifndef QT_NO_DEBUG
-
-#ifdef _MSC_VER // just for the MS compiler
-// windows hack for finding memory leaks
-// the 'new' redefinition breaks QHash and QVector so they are included beforehand.
-#define _CRTDBG_MAP_ALLOC
-#include <iostream>
-#include <crtdbg.h>
-#define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
-#endif
-
-#endif
-#endif
-#endif
-
 #ifdef Q_OS_WIN
 #define getenvUser() getenv("USERNAME")
 #else

--- a/src/utils/textutils.cpp
+++ b/src/utils/textutils.cpp
@@ -696,11 +696,7 @@ double TextUtils::convertToInches(const QString & string) {
 }
 
 QString TextUtils::escapeAnd(const QString & string) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	QString s = Qt::escape(string);
-#else
-    QString s = string.toHtmlEscaped();
-#endif
+	QString s = string.toHtmlEscaped();
 	s.replace('\'', "&apos;");
 	return s;
 }

--- a/src/utils/zoomslider.cpp
+++ b/src/utils/zoomslider.cpp
@@ -60,10 +60,8 @@ ZoomLabel::ZoomLabel(QWidget * parent) : QLabel(parent)
 	m_autoRepeat = m_mouseIsDown = m_mouseIsIn = m_repeated = false;
 	m_timer.setSingleShot(false);
 	m_timer.setInterval(AutoRepeatInterval);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    m_timer.setTimerType(Qt::PreciseTimer);
-#endif
-    connect(&m_timer, SIGNAL(timeout()), this, SLOT(repeat()));
+	m_timer.setTimerType(Qt::PreciseTimer);
+	connect(&m_timer, SIGNAL(timeout()), this, SLOT(repeat()));
 }
 
 ZoomLabel::~ZoomLabel()


### PR DESCRIPTION
Clearly this will have to wait too!

Translations will need updating for PostScript too:
```xml
    <message>
        <location filename="../src/mainwindow/mainwindow_export.cpp" line="146"/>
        <source>PostScript (*.ps)</source>
        <translation>PostScript (*.ps)</translation>
    </message>
```