### PR TITLE
Support using system QuaZIP on Qt5 and output build messages for system libgit2 and QuaZIP

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -198,7 +198,7 @@ include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
 contains(DEFINES, QUAZIP_INSTALLED) {
-    message("using installed QuaZIP library")
+    !build_pass:message("using installed QuaZIP library")
     LIBS += -lquazip5
 } else {
     include(pri/quazip.pri)
@@ -207,4 +207,4 @@ contains(DEFINES, QUAZIP_INSTALLED) {
 TARGET = Fritzing
 TEMPLATE = app
 
-message("libs $$LIBS")
+!build_pass:message("libs $$LIBS")

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -198,6 +198,7 @@ include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
 contains(DEFINES, QUAZIP_INSTALLED) {
+    message("using installed QuaZIP library")
     LIBS += -lquazip5
 } else {
     include(pri/quazip.pri)

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -198,8 +198,7 @@ include(pri/program.pri)
 include(pri/qtsysteminfo.pri)
 
 contains(DEFINES, QUAZIP_INSTALLED) {
-    INCLUDEPATH += /usr/include/quazip
-    LIBS += -lquazip
+    LIBS += -lquazip5
 } else {
     include(pri/quazip.pri)
 }

--- a/pri/boostdetect.pri
+++ b/pri/boostdetect.pri
@@ -29,7 +29,7 @@ contains(LATESTBOOST, 0) {
     qtCompileTest(boost)
     config_boost {
         LATESTBOOST = installed
-        message("using installed Boost library")
+        !build_pass:message("using installed Boost library")
     } else {
         message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
         error("Easiest to copy the Boost library to ..., so that you have .../boost_1_xx_0")

--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -65,7 +65,7 @@ unix {
             LIBS += $$LIBGIT2LIB/libgit2.a  -lssl -lcrypto
         }
     } else {
-        warning("Using dynamic linking for libgit2.")
+        !build_pass:warning("Using dynamic linking for libgit2.")
         #message("Enabled dynamic linking of libgit2")
         PKGCONFIG += libgit2
     }

--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -35,8 +35,8 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "../debugdialog.h"
 #ifdef QUAZIP_INSTALLED
-#include <quazip/quazip.h>
-#include <quazip/quazipfile.h>
+#include <quazip5/quazip.h>
+#include <quazip5/quazipfile.h>
 #else
 #include "../lib/quazip/quazip.h"
 #include "../lib/quazip/quazipfile.h"


### PR DESCRIPTION
* Currently Qt5 builds can't use system QuaZIP because it is using quazip5 locations.
* Add build-time messages to inform about the use of system libraries
* Don't output three copies of the build-time messages

A bit more info in the commit messages.

This is an updated version of the work in #3254 and a copy of #3468.

Happy to squash commits in this PR or split into separate PRs if preferred.

