### PR TITLE
Mazerouter fixes

### DIFF
--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -947,13 +947,13 @@ SketchToolButton *MainWindow::createFlipButton(SketchAreaWidget *parent) {
 	return flipButton;
 }
 
-SketchToolButton *MainWindow::createAutorouteButton(SketchAreaWidget *parent) {
-	SketchToolButton *autorouteButton = new SketchToolButton("Autoroute",parent, m_newAutorouteAct);
-	autorouteButton->setText(tr("Autoroute"));
-	autorouteButton->setEnabledIcon();					// seems to need this to display button icon first time
+// SketchToolButton *MainWindow::createAutorouteButton(SketchAreaWidget *parent) {
+// 	SketchToolButton *autorouteButton = new SketchToolButton("Autoroute",parent, m_newAutorouteAct);
+// 	autorouteButton->setText(tr("Autoroute"));
+// 	autorouteButton->setEnabledIcon();					// seems to need this to display button icon first time
 
-	return autorouteButton;
-}
+// 	return autorouteButton;
+// }
 
 SketchToolButton *MainWindow::createOrderFabButton(SketchAreaWidget *parent) {
     SketchToolButton *orderFabButton = new SketchToolButton("Order",parent, m_orderFabAct);
@@ -1069,12 +1069,14 @@ QList<QWidget*> MainWindow::getButtonsForView(ViewLayer::ViewID viewId) {
 			retval << createFlipButton(parent) << createRoutingStatusLabel(parent); 
 			break;
 		case ViewLayer::SchematicView:
-			retval << createFlipButton(parent) <<  createAutorouteButton(parent) << createRoutingStatusLabel(parent);
+			retval << createFlipButton(parent)
+                // << createAutorouteButton(parent) 
+                << createRoutingStatusLabel(parent);
 			break;
 		case ViewLayer::PCBView:
 			retval << createViewFromButton(parent)
 				<< createActiveLayerButton(parent) 
-				<< createAutorouteButton(parent) 
+				// << createAutorouteButton(parent) 
 				<< createExportEtchableButton(parent)
                 << createRoutingStatusLabel(parent)
                 ;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -546,7 +546,7 @@ protected:
 	class SketchToolButton *createRotateButton(SketchAreaWidget *parent);
 	SketchToolButton *createShareButton(SketchAreaWidget *parent);
 	SketchToolButton *createFlipButton(SketchAreaWidget *parent);
-	SketchToolButton *createAutorouteButton(SketchAreaWidget *parent);
+	// SketchToolButton *createAutorouteButton(SketchAreaWidget *parent);
     SketchToolButton *createOrderFabButton(SketchAreaWidget *parent);
 	QWidget *createActiveLayerButton(SketchAreaWidget *parent);
 	QWidget *createViewFromButton(SketchAreaWidget *parent);
@@ -839,7 +839,7 @@ protected:
 	QMenu *m_pcbTraceMenu;
 	QMenu *m_schematicTraceMenu;
 	QMenu *m_breadboardTraceMenu;
-	QAction *m_newAutorouteAct;
+	// QAction *m_newAutorouteAct;
 	QAction *m_orderFabAct;
 	QAction *m_activeLayerTopAct;
 	QAction *m_activeLayerBottomAct;

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -1522,7 +1522,7 @@ void MainWindow::createWindowMenu() {
 void MainWindow::createTraceMenus()
 {
 	m_pcbTraceMenu = menuBar()->addMenu(tr("&Routing"));
-	m_pcbTraceMenu->addAction(m_newAutorouteAct);
+	// m_pcbTraceMenu->addAction(m_newAutorouteAct);
 	m_pcbTraceMenu->addAction(m_newDesignRulesCheckAct);
 	m_pcbTraceMenu->addAction(m_autorouterSettingsAct);
 	m_pcbTraceMenu->addAction(m_fabQuoteAct);
@@ -1560,7 +1560,7 @@ void MainWindow::createTraceMenus()
 	//m_pcbTraceMenu->addAction(m_checkLoadedTracesAct);
 
     m_schematicTraceMenu = menuBar()->addMenu(tr("&Routing"));
-	m_schematicTraceMenu->addAction(m_newAutorouteAct);
+	// m_schematicTraceMenu->addAction(m_newAutorouteAct);
 	m_schematicTraceMenu->addAction(m_excludeFromAutorouteAct);
 	m_schematicTraceMenu->addAction(m_showUnroutedAct);
 	m_schematicTraceMenu->addAction(m_selectAllTracesAct);
@@ -2699,10 +2699,10 @@ void MainWindow::hideShowTraceMenu() {
 }
 
 void MainWindow::createTraceMenuActions() {
-	m_newAutorouteAct = new QAction(tr("Autoroute"), this);
-	m_newAutorouteAct->setStatusTip(tr("Autoroute connections..."));
-	m_newAutorouteAct->setShortcut(tr("Shift+Ctrl+A"));
-	connect(m_newAutorouteAct, SIGNAL(triggered()), this, SLOT(newAutoroute()));
+	// m_newAutorouteAct = new QAction(tr("Autoroute"), this);
+	// m_newAutorouteAct->setStatusTip(tr("Autoroute connections..."));
+	// m_newAutorouteAct->setShortcut(tr("Shift+Ctrl+A"));
+	// connect(m_newAutorouteAct, SIGNAL(triggered()), this, SLOT(newAutoroute()));
 
 	createOrderFabAct();
 	createActiveLayerActions();


### PR DESCRIPTION
This sounds a bit more optimistic than it should be.
First, some range checking is added, which prevents the mazerouter from totally corrupting memory (which it usually does, even if you don't see immediate crashes). Second, we disable the mazerouter.