### PR TITLE
Make pe delete part files on exit

### DIFF
--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -2960,9 +2960,17 @@ QString MainWindow::getStyleSheetSuffix() {
     return "fritzing";
 }
 
-void MainWindow::addToMyParts(ModelPart * modelPart)
+void MainWindow::addToMyParts(ModelPart * modelPart, QStringList & m_peAlienFiles)
 {
-    if (modelPart != NULL) m_binManager->addToMyParts(modelPart);
+    if (modelPart != NULL) {
+        foreach(QString pathToAddFromPe, m_peAlienFiles) {
+            // DebugDialog::debug(QString("addToMyParts adding  %1")
+            //.arg(pathToAddFromPe));
+            m_alienFiles << pathToAddFromPe;
+            m_alienPartsMsg = tr("Do you want to keep the imported parts?");
+        }
+    }
+	m_binManager->addToMyParts(modelPart);
 }
 
 bool MainWindow::anyUsePart(const QString & moduleID) {

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -2960,16 +2960,14 @@ QString MainWindow::getStyleSheetSuffix() {
     return "fritzing";
 }
 
-void MainWindow::addToMyParts(ModelPart * modelPart, QStringList & m_peAlienFiles)
+void MainWindow::addToMyParts(ModelPart * modelPart, QStringList & peAlienFiles)
 {
-    if (modelPart != NULL) {
-        foreach(QString pathToAddFromPe, m_peAlienFiles) {
+        foreach(QString pathToAddFromPe, peAlienFiles) {
             // DebugDialog::debug(QString("addToMyParts adding  %1")
             //.arg(pathToAddFromPe));
             m_alienFiles << pathToAddFromPe;
             m_alienPartsMsg = tr("Do you want to keep the imported parts?");
         }
-    }
 	m_binManager->addToMyParts(modelPart);
 }
 

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -2960,7 +2960,7 @@ QString MainWindow::getStyleSheetSuffix() {
     return "fritzing";
 }
 
-void MainWindow::addToMyParts(ModelPart * modelPart, QStringList & peAlienFiles)
+void MainWindow::addToMyParts(ModelPart * modelPart, const QStringList & peAlienFiles)
 {
         foreach(QString pathToAddFromPe, peAlienFiles) {
             // DebugDialog::debug(QString("addToMyParts adding  %1")

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -52,8 +52,6 @@ $Date: 2013-04-28 14:14:07 +0200 (So, 28. Apr 2013) $
 #include "../svg/svg2gerber.h"
 #include "../routingstatus.h"
 
-extern QStringList peAlienFiles;
-
 QT_BEGIN_NAMESPACE
 class QAction;
 class QListWidget;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -52,6 +52,8 @@ $Date: 2013-04-28 14:14:07 +0200 (So, 28. Apr 2013) $
 #include "../svg/svg2gerber.h"
 #include "../routingstatus.h"
 
+QStringList peAlienFiles;
+
 QT_BEGIN_NAMESPACE
 class QAction;
 class QListWidget;
@@ -456,7 +458,7 @@ protected slots:
 
     void keepMargins();
 	void dockChangeActivation(bool activate, QWidget * originator);
-    void addToMyParts(ModelPart *, QStringList &);
+    void addToMyParts(ModelPart *, const QStringList &);
     void hidePartSilkscreen();
     void fabQuote();
     void findPartInSketch();
@@ -908,7 +910,6 @@ protected:
     bool m_restarting;
 
     QStringList m_alienFiles;
-    QStringList peAlienFiles;
     QString m_alienPartsMsg;
     QStringList m_filesReplacedByAlienOnes;
 

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -52,7 +52,7 @@ $Date: 2013-04-28 14:14:07 +0200 (So, 28. Apr 2013) $
 #include "../svg/svg2gerber.h"
 #include "../routingstatus.h"
 
-QStringList peAlienFiles;
+extern QStringList peAlienFiles;
 
 QT_BEGIN_NAMESPACE
 class QAction;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -908,7 +908,7 @@ protected:
     bool m_restarting;
 
     QStringList m_alienFiles;
-    QStringList m_peAlienFiles;
+    QStringList peAlienFiles;
     QString m_alienPartsMsg;
     QStringList m_filesReplacedByAlienOnes;
 

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -456,7 +456,7 @@ protected slots:
 
     void keepMargins();
 	void dockChangeActivation(bool activate, QWidget * originator);
-    void addToMyParts(ModelPart *);
+    void addToMyParts(ModelPart *, QStringList &);
     void hidePartSilkscreen();
     void fabQuote();
     void findPartInSketch();
@@ -908,6 +908,7 @@ protected:
     bool m_restarting;
 
     QStringList m_alienFiles;
+    QStringList m_peAlienFiles;
     QString m_alienPartsMsg;
     QStringList m_filesReplacedByAlienOnes;
 

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -2357,7 +2357,7 @@ void MainWindow::openNewPartsEditor(PaletteItem * paletteItem)
    if (peMainWindow->setInitialItem(paletteItem)) {   
 	    peMainWindow->show();
 	    peMainWindow->raise();
-        connect(peMainWindow, SIGNAL(addToMyPartsSignal(ModelPart *, QStringList &)), this, SLOT(addToMyParts(ModelPart *, QStringList &)));
+        connect(peMainWindow, SIGNAL(addToMyPartsSignal(ModelPart *, const QStringList &)), this, SLOT(addToMyParts(ModelPart *, const QStringList &)));
    }
    else {
        delete peMainWindow;

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -2357,7 +2357,7 @@ void MainWindow::openNewPartsEditor(PaletteItem * paletteItem)
    if (peMainWindow->setInitialItem(paletteItem)) {   
 	    peMainWindow->show();
 	    peMainWindow->raise();
-        connect(peMainWindow, SIGNAL(addToMyPartsSignal(ModelPart *)), this, SLOT(addToMyParts(ModelPart *)));
+        connect(peMainWindow, SIGNAL(addToMyPartsSignal(ModelPart *, QStringList &)), this, SLOT(addToMyParts(ModelPart *, QStringList &)));
    }
    else {
        delete peMainWindow;

--- a/src/partseditor/pemainwindow.cpp
+++ b/src/partseditor/pemainwindow.cpp
@@ -2296,6 +2296,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 		setImageAttribute(layers, svgPath);
 
         QString actualPath = m_userPartsFolderSvgPath + svgPath; 
+	m_peAlienFiles << actualPath;
         bool result = writeXml(actualPath, removeGorn(svg), false);
         if (!result) {
             // TODO: warn user
@@ -2306,6 +2307,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 	QString suffix = QString("%1_%2_%3").arg(m_prefix).arg(m_guid).arg(m_fileIndex++);
     QString fzpPath = dir.absoluteFilePath(QString("%1.fzp").arg(suffix));  
 
+    m_peAlienFiles << fzpPath;
     if (overWrite) {
         fzpPath = m_originalFzpPath;
     }
@@ -2344,7 +2346,8 @@ bool PEMainWindow::saveAs(bool overWrite)
     ModelPart * modelPart = m_referenceModel->retrieveModelPart(m_originalModuleID);
     if (modelPart == NULL) {
 	    modelPart = m_referenceModel->loadPart(fzpPath, true);
-        emit addToMyPartsSignal(modelPart);
+	modelPart->setAlien(true);
+        emit addToMyPartsSignal(modelPart, m_peAlienFiles);
 	}
     else {
         m_referenceModel->reloadPart(fzpPath, m_originalModuleID);

--- a/src/partseditor/pemainwindow.cpp
+++ b/src/partseditor/pemainwindow.cpp
@@ -2137,6 +2137,8 @@ bool PEMainWindow::saveAs() {
 
 bool PEMainWindow::saveAs(bool overWrite)
 {
+    QStringList peAlienFiles;
+
     bool ok = false;
     QString prefix = QInputDialog::getText(
 		    this,
@@ -2297,6 +2299,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 
         QString actualPath = m_userPartsFolderSvgPath + svgPath; 
 	peAlienFiles << actualPath;
+        // DebugDialog::debug(QString("peAlienFiles %1").arg(peAlienFiles));
         bool result = writeXml(actualPath, removeGorn(svg), false);
         if (!result) {
             // TODO: warn user

--- a/src/partseditor/pemainwindow.cpp
+++ b/src/partseditor/pemainwindow.cpp
@@ -2296,7 +2296,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 		setImageAttribute(layers, svgPath);
 
         QString actualPath = m_userPartsFolderSvgPath + svgPath; 
-	m_peAlienFiles << actualPath;
+	peAlienFiles << actualPath;
         bool result = writeXml(actualPath, removeGorn(svg), false);
         if (!result) {
             // TODO: warn user
@@ -2307,7 +2307,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 	QString suffix = QString("%1_%2_%3").arg(m_prefix).arg(m_guid).arg(m_fileIndex++);
     QString fzpPath = dir.absoluteFilePath(QString("%1.fzp").arg(suffix));  
 
-    m_peAlienFiles << fzpPath;
+    peAlienFiles << fzpPath;
     if (overWrite) {
         fzpPath = m_originalFzpPath;
     }
@@ -2347,7 +2347,7 @@ bool PEMainWindow::saveAs(bool overWrite)
     if (modelPart == NULL) {
 	    modelPart = m_referenceModel->loadPart(fzpPath, true);
 	modelPart->setAlien(true);
-        emit addToMyPartsSignal(modelPart, m_peAlienFiles);
+        emit addToMyPartsSignal(modelPart, peAlienFiles);
 	}
     else {
         m_referenceModel->reloadPart(fzpPath, m_originalModuleID);

--- a/src/partseditor/pemainwindow.h
+++ b/src/partseditor/pemainwindow.h
@@ -83,7 +83,7 @@ public:
     void changeOriginalFile(ViewLayer::ViewID viewID, const QString originalFile, int changeCount);
 
 signals:
-    void addToMyPartsSignal(ModelPart *);
+    void addToMyPartsSignal(ModelPart *, QStringList &);
 
 public slots:
     void metadataChanged(const QString & name, const QString & value);

--- a/src/partseditor/pemainwindow.h
+++ b/src/partseditor/pemainwindow.h
@@ -83,7 +83,7 @@ public:
     void changeOriginalFile(ViewLayer::ViewID viewID, const QString originalFile, int changeCount);
 
 signals:
-    void addToMyPartsSignal(ModelPart *, QStringList &);
+    void addToMyPartsSignal(ModelPart *, const QStringList &);
 
 public slots:
     void metadataChanged(const QString & name, const QString & value);


### PR DESCRIPTION
This fixes issue 3383 where when a new part is created with parts editor, the filenames didn't get copied across to alien_files in the main thread. Since I'm new to both c++ and Qt someone experienced needs to look over the fix and make sure it is appropriate.  