### PR TITLE
Use Constructor Member Initialization syntax to improve performance

### DIFF
--- a/src/autoroute/mazerouter/mazerouter.cpp
+++ b/src/autoroute/mazerouter/mazerouter.cpp
@@ -400,15 +400,15 @@ void Grid::copy(int fromIndex, int toIndex) {
 }
 
 void Grid::clear() {
-    // memset can be very dangerous, clear out memory this way
-    std::fill_n(data, x * y * z, 0);
+	// memset can be very dangerous, clear out memory this way
+	std::fill_n(data, x * y * z, 0);
 }
 
 Grid::~Grid() {
-    if (data) {
-        delete [] data;
-        data = nullptr;
-    }
+	if (data) {
+		delete [] data;
+		data = nullptr;
+	}
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/autoroute/mazerouter/mazerouter.cpp
+++ b/src/autoroute/mazerouter/mazerouter.cpp
@@ -316,22 +316,11 @@ bool GridPoint::operator<(const GridPoint& other) const {
 	// make sure lower cost is first
 	return qCost > other.qCost;
 }
-
-GridPoint::GridPoint(QPoint p, int zed) :
-    x(p.x()),
-    y(p.y()),
-    z(zed)
-{
-
-}
-
-GridPoint::GridPoint() : x(0), y(0), z(0) { }
-
 ////////////////////////////////////////////////////////////////////
 
 Grid::Grid(int sx, int sy, int sz) : 
-    data(new GridValue[sx * sy * sz]()), // initialize to zero
-    x(sx), y(sy), z(sz) { }
+	data(new GridValue[sx * sy * sz]()), // initialize to zero
+	x(sx), y(sy), z(sz) { }
 
 GridValue Grid::at(int sx, int sy, int sz) const {
     Q_ASSERT (sx < x);

--- a/src/autoroute/mazerouter/mazerouter.cpp
+++ b/src/autoroute/mazerouter/mazerouter.cpp
@@ -317,27 +317,21 @@ bool GridPoint::operator<(const GridPoint& other) const {
 	return qCost > other.qCost;
 }
 
-GridPoint::GridPoint(QPoint p, int zed) {
-	z = zed;
-	x = p.x();
-	y = p.y();
-	flags = 0;
+GridPoint::GridPoint(QPoint p, int zed) :
+    x(p.x()),
+    y(p.y()),
+    z(zed)
+{
+
 }
 
-GridPoint::GridPoint()
-{
-	flags = 0;
-}
+GridPoint::GridPoint() : x(0), y(0), z(0) { }
 
 ////////////////////////////////////////////////////////////////////
 
-Grid::Grid(int sx, int sy, int sz) {
-	x = sx;
-	y = sy;
-	z = sz;
-
-	data = (GridValue *) malloc(x * y * z * sizeof(GridValue));   // calloc initializes grid to 0
-}
+Grid::Grid(int sx, int sy, int sz) : 
+    data(new GridValue[sx * sy * sz]()), // initialize to zero
+    x(sx), y(sy), z(sz) { }
 
 GridValue Grid::at(int sx, int sy, int sz) const {
     Q_ASSERT (sx < x);
@@ -417,23 +411,19 @@ void Grid::copy(int fromIndex, int toIndex) {
 }
 
 void Grid::clear() {
-	memset(data, 0, x * y * z * sizeof(GridValue));
+    // memset can be very dangerous, clear out memory this way
+    std::fill_n(data, x * y * z, 0);
 }
 
-void Grid::free() {
-	if (data) {
-		::free(data);
-		data = NULL;
-	}
+Grid::~Grid() {
+    if (data) {
+        delete [] data;
+        data = nullptr;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////
 
-Score::Score() {
-	totalRoutedCount = totalViaCount = 0;
-	anyUnrouted = false;
-	reorderNet = -1;
-}
 
 void Score::setOrdering(const NetOrdering & _ordering) {
 	reorderNet = -1;
@@ -601,7 +591,6 @@ MazeRouter::~MazeRouter()
 		delete m_board;
 	}
 	if (m_grid) {
-		m_grid->free();
 		delete m_grid;
 	}
 	if (m_boardImage) {
@@ -838,7 +827,6 @@ void MazeRouter::start()
 	ProcessEventBlocker::processEvents();
 
 	if (m_grid) {
-		m_grid->free();
 		delete m_grid;
 		m_grid = NULL;
 	}
@@ -2143,8 +2131,6 @@ void MazeRouter::cleanUpNets(NetList & netList) {
 }
 
 void MazeRouter::createTraces(NetList & netList, Score & bestScore, QUndoCommand * parentCommand) {
-	QPointF topLeft = m_maxRect.topLeft();
-
 	QMultiHash<int, Via *> allVias;
 	QMultiHash<int, JumperItem *> allJumperItems;
 	QMultiHash<int, SymbolPaletteItem *> allNetLabels;

--- a/src/autoroute/mazerouter/mazerouter.h
+++ b/src/autoroute/mazerouter/mazerouter.h
@@ -50,8 +50,8 @@ struct GridPoint {
 	uchar flags = 0;
 
 	bool operator<(const GridPoint&) const;
-	GridPoint(QPoint, int);
-	GridPoint();
+	GridPoint(QPoint p, int zed) : x(p.x()), y(p.y()), z(zed) { }
+	constexpr GridPoint() : x(0), y(0), z(0) { }
 };
 
 struct PointZ {

--- a/src/autoroute/mazerouter/mazerouter.h
+++ b/src/autoroute/mazerouter/mazerouter.h
@@ -45,9 +45,9 @@ typedef quint64 GridValue;
 
 struct GridPoint {
 	int x, y, z;
-	GridValue baseCost;
-	double qCost;
-	uchar flags;
+	GridValue baseCost = 0;
+	double qCost = 0.0;
+	uchar flags = 0;
 
 	bool operator<(const GridPoint&) const;
 	GridPoint(QPoint, int);
@@ -56,19 +56,16 @@ struct GridPoint {
 
 struct PointZ {
 	QPointF p;
-	int z;
+	int z = 0;
 
-	PointZ(QPointF _p, int _z) {
-		p = _p;
-		z = _z;
-	}
+	PointZ(QPointF _p, int _z) : p(_p), z(_z) { }
 };
 
 struct Net {
-	QList<class ConnectorItem *>* net;
+	QList<class ConnectorItem *>* net = nullptr;
 	QList< QList<ConnectorItem *> > subnets;
-	int pinsWithin;
-	int id;
+	int pinsWithin = 0;
+	int id = 0;
 };
 
 struct NetList {
@@ -76,14 +73,12 @@ struct NetList {
 };
 
 struct Trace {
-	int netIndex;
-	int order;
-	uchar flags;
+	int netIndex = 0;
+	int order = 0;
+	uchar flags = 0;
 	QList<GridPoint> gridPoints;
 
-	Trace() {
-		flags = 0;
-	}
+	Trace() = default;
 };
 
 struct NetOrdering {
@@ -95,36 +90,36 @@ struct Score {
 	QMultiHash<int, Trace> traces;
 	QHash<int, int> routedCount;
 	QHash<int, int> viaCount;
-	int totalRoutedCount;
-	int totalViaCount;
-	int reorderNet;
-	bool anyUnrouted;
+	int totalRoutedCount = 0;
+	int totalViaCount = 0;
+	int reorderNet = -1;
+	bool anyUnrouted = false;
 
-	Score();
+	Score() = default;
 	void setOrdering(const NetOrdering &);
 };
 
 struct Nearest {
-	int i, j;
-	double distance;
-	ConnectorItem * ic;
-	ConnectorItem * jc;
+	int i = 0, j = 0;
+	double distance = 0.0;
+	ConnectorItem * ic = nullptr;
+	ConnectorItem * jc = nullptr;
 };
 
 struct Grid {
-	GridValue * data;
-	int x;
-	int y;
-	int z;
+	GridValue * data = nullptr;
+	int x = 0;
+	int y = 0;
+	int z = 0;
 
 	Grid(int x, int y, int layers);
+    ~Grid();
 
 	GridValue at(int x, int y, int z) const;
 	void setAt(int x, int y, int z, GridValue value);
 	QList<QPoint> init(int x, int y, int z, int width, int height, const QImage &, GridValue value, bool collectPoints);
 	QList<QPoint> init4(int x, int y, int z, int width, int height, const QImage *, GridValue value, bool collectPoints);
 	void clear();
-	void free();
 	void copy(int fromIndex, int toIndex);
 };
 

--- a/src/autoroute/mazerouter/mazerouter.h
+++ b/src/autoroute/mazerouter/mazerouter.h
@@ -107,6 +107,7 @@ struct Nearest {
 };
 
 struct Grid {
+	/// @todo replace this with std::unique_ptr<GridValue[]>
 	GridValue * data = nullptr;
 	int x = 0;
 	int y = 0;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1365,10 +1365,10 @@ QString WireWidthChangeCommand::getParamString() const {
 ///////////////////////////////////////////
 
 RoutingStatusCommand::RoutingStatusCommand(SketchWidget * sketchWidget, const RoutingStatus & oldRoutingStatus, const RoutingStatus & newRoutingStatus, QUndoCommand * parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_oldRoutingStatus(oldRoutingStatus),
+	m_newRoutingStatus(newRoutingStatus)
 {
-	m_oldRoutingStatus = oldRoutingStatus;
-	m_newRoutingStatus = newRoutingStatus;
 }
 
 void RoutingStatusCommand::undo() {
@@ -1393,11 +1393,11 @@ QString RoutingStatusCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 ShowLabelFirstTimeCommand::ShowLabelFirstTimeCommand(SketchWidget *sketchWidget, CrossViewType crossView, long id, bool oldVis, bool newVis, QUndoCommand *parent)
-	: BaseCommand(crossView, sketchWidget, parent)
+	: BaseCommand(crossView, sketchWidget, parent),
+	m_itemID(id),
+	m_oldVis(oldVis),
+	m_newVis(newVis)
 {
-	m_itemID = id;
-	m_oldVis = oldVis;
-	m_newVis = newVis;
 }
 
 void ShowLabelFirstTimeCommand::undo()

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -53,10 +53,10 @@ CommandProgress BaseCommand::m_commandProgress;
 
 BaseCommand::BaseCommand(BaseCommand::CrossViewType crossViewType, SketchWidget* sketchWidget, QUndoCommand *parent)
 	: QUndoCommand(parent),
-    m_crossViewType(crossViewType),
-    m_sketchWidget(sketchWidget),
-    m_parentCommand(parent),
-    m_index(BaseCommand::nextIndex++)
+	m_crossViewType(crossViewType),
+	m_sketchWidget(sketchWidget),
+	m_parentCommand(parent),
+	m_index(BaseCommand::nextIndex++)
 {
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1770,11 +1770,11 @@ QString TransformItemCommand::getParamString() const {
 
 SetResistanceCommand::SetResistanceCommand(SketchWidget * sketchWidget, long itemID, QString oldResistance, QString newResistance, QString oldPinSpacing, QString newPinSpacing, QUndoCommand * parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_oldResistance(oldResistance),
-    m_newResistance(newResistance),
-    m_oldPinSpacing(oldPinSpacing),
-    m_newPinSpacing(newPinSpacing),
-    m_itemID(itemID)
+	m_oldResistance(oldResistance),
+	m_newResistance(newResistance),
+	m_oldPinSpacing(oldPinSpacing),
+	m_newPinSpacing(newPinSpacing),
+	m_itemID(itemID)
 {
 }
 
@@ -1802,11 +1802,11 @@ QString SetResistanceCommand::getParamString() const {
 
 SetPropCommand::SetPropCommand(SketchWidget * sketchWidget, long itemID, QString prop, QString oldValue, QString newValue, bool redraw, QUndoCommand * parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_redraw(redraw),
-    m_prop(prop),
-    m_oldValue(oldValue),
-    m_newValue(newValue),
-    m_itemID(itemID)
+	m_redraw(redraw),
+	m_prop(prop),
+	m_oldValue(oldValue),
+	m_newValue(newValue),
+	m_itemID(itemID)
 {
 }
 
@@ -1835,13 +1835,13 @@ QString SetPropCommand::getParamString() const {
 
 ResizeJumperItemCommand::ResizeJumperItemCommand(SketchWidget * sketchWidget, long itemID, QPointF oldPos, QPointF oldC0, QPointF oldC1, QPointF newPos, QPointF newC0, QPointF newC1, QUndoCommand * parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_oldPos(oldPos),
-    m_oldC0(oldC0),
-    m_oldC1(oldC1),
-    m_newPos(newPos),
-    m_newC0(newC0),
-    m_newC1(newC1),
-    m_itemID(itemID)
+	m_oldPos(oldPos),
+	m_oldC0(oldC0),
+	m_oldC1(oldC1),
+	m_newPos(newPos),
+	m_newC0(newC0),
+	m_newC1(newC1),
+	m_itemID(itemID)
 {
 }
 
@@ -1914,12 +1914,12 @@ LoadLogoImageCommand::LoadLogoImageCommand(SketchWidget *sketchWidget, long id,
         const QString & oldSvg, const QSizeF oldAspectRatio, const QString & oldFilename,
         const QString & newFilename, bool addName, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_itemID(id),
-    m_oldSvg(oldSvg),
-    m_oldAspectRatio(oldAspectRatio),
-    m_oldFilename(oldFilename),
-    m_newFilename(newFilename),
-    m_addName(addName)
+	m_itemID(id),
+	m_oldSvg(oldSvg),
+	m_oldAspectRatio(oldAspectRatio),
+	m_oldFilename(oldFilename),
+	m_newFilename(newFilename),
+	m_addName(addName)
 {
 }
 
@@ -1951,8 +1951,8 @@ QString LoadLogoImageCommand::getParamString() const {
 
 ChangeBoardLayersCommand::ChangeBoardLayersCommand(SketchWidget *sketchWidget, int oldLayers, int newLayers, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_oldLayers(oldLayers),
-    m_newLayers(newLayers)
+	m_oldLayers(oldLayers),
+	m_newLayers(newLayers)
 {
 }
 
@@ -1985,8 +1985,8 @@ QString ChangeBoardLayersCommand::getParamString() const {
 
 SetDropOffsetCommand::SetDropOffsetCommand(SketchWidget *sketchWidget, long id,  QPointF dropOffset, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_itemID(id),
-    m_dropOffset(dropOffset)
+	m_itemID(id),
+	m_dropOffset(dropOffset)
 {
 }
 
@@ -2013,10 +2013,10 @@ QString SetDropOffsetCommand::getParamString() const {
 
 RenamePinsCommand::RenamePinsCommand(SketchWidget *sketchWidget, long id, const QStringList & oldOnes, const QStringList & newOnes, bool singleRow, QUndoCommand *parent) :
 	BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_itemID(id),
-    m_oldLabels(oldOnes),
-    m_newLabels(newOnes),
-    m_singleRow(singleRow)
+	m_itemID(id),
+	m_oldLabels(oldOnes),
+	m_newLabels(newOnes),
+	m_singleRow(singleRow)
 {
 }
 
@@ -2085,9 +2085,9 @@ WireExtrasCommand::WireExtrasCommand(SketchWidget* sketchWidget, long fromID,
                                      const QDomElement & oldExtras, const QDomElement & newExtras,
                                      QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_fromID(fromID),
-    m_oldExtras(oldExtras),
-    m_newExtras(newExtras)
+	m_fromID(fromID),
+	m_oldExtras(oldExtras),
+	m_newExtras(newExtras)
 {
 
 }
@@ -2122,11 +2122,11 @@ HidePartLayerCommand::HidePartLayerCommand(SketchWidget *sketchWidget, long from
         ViewLayer::ViewLayerID layerID, bool wasHidden, bool isHidden,
         QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_fromID(fromID),
-    m_wasHidden(wasHidden),
-    m_isHidden(isHidden),
-    m_layerID(layerID),
-    m_oldLayer(ViewLayer::ViewLayerID::UnknownLayer)
+	m_fromID(fromID),
+	m_wasHidden(wasHidden),
+	m_isHidden(isHidden),
+	m_layerID(layerID),
+	m_oldLayer(ViewLayer::ViewLayerID::UnknownLayer)
 {
 }
 
@@ -2192,9 +2192,9 @@ QString AddSubpartCommand::getParamString() const {
 
 PackItemsCommand::PackItemsCommand(SketchWidget *sketchWidget, int columns, const QList<long> & ids, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_columns(columns),
-    m_ids(ids),
-    m_firstTime(true)
+	m_columns(columns),
+	m_ids(ids),
+	m_firstTime(true)
 {
 }
 
@@ -2226,8 +2226,7 @@ QString PackItemsCommand::getParamString() const {
 
 TemporaryCommand::TemporaryCommand(const QString & text) : QUndoCommand(text), m_enabled(true) { }
 
-TemporaryCommand::~TemporaryCommand() {
-}
+TemporaryCommand::~TemporaryCommand() { }
 
 void TemporaryCommand::setEnabled(bool enabled) {
 	m_enabled = enabled;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1166,9 +1166,9 @@ void CheckStickyCommand::stick(SketchWidget * sketchWidget, long fromID, long to
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 CleanUpWiresCommand::CleanUpWiresCommand(SketchWidget* sketchWidget, CleanUpWiresCommand::Direction direction, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+    m_direction(direction)
 {
-	m_direction = direction;
 }
 
 void CleanUpWiresCommand::undo()
@@ -1770,11 +1770,11 @@ QString TransformItemCommand::getParamString() const {
 
 SetResistanceCommand::SetResistanceCommand(SketchWidget * sketchWidget, long itemID, QString oldResistance, QString newResistance, QString oldPinSpacing, QString newPinSpacing, QUndoCommand * parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_itemID(itemID),
     m_oldResistance(oldResistance),
     m_newResistance(newResistance),
     m_oldPinSpacing(oldPinSpacing),
-    m_newPinSpacing(newPinSpacing)
+    m_newPinSpacing(newPinSpacing),
+    m_itemID(itemID)
 {
 }
 
@@ -1803,10 +1803,10 @@ QString SetResistanceCommand::getParamString() const {
 SetPropCommand::SetPropCommand(SketchWidget * sketchWidget, long itemID, QString prop, QString oldValue, QString newValue, bool redraw, QUndoCommand * parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
     m_redraw(redraw),
-    m_itemID(itemID),
     m_prop(prop),
     m_oldValue(oldValue),
-    m_newValue(newValue)
+    m_newValue(newValue),
+    m_itemID(itemID)
 {
 }
 
@@ -1835,13 +1835,13 @@ QString SetPropCommand::getParamString() const {
 
 ResizeJumperItemCommand::ResizeJumperItemCommand(SketchWidget * sketchWidget, long itemID, QPointF oldPos, QPointF oldC0, QPointF oldC1, QPointF newPos, QPointF newC0, QPointF newC1, QUndoCommand * parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_itemID(itemID),
     m_oldPos(oldPos),
-    m_newPos(newPos),
     m_oldC0(oldC0),
-    m_newC0(newC0),
     m_oldC1(oldC1),
-    m_newC1(newC1)
+    m_newPos(newPos),
+    m_newC0(newC0),
+    m_newC1(newC1),
+    m_itemID(itemID)
 {
 }
 
@@ -1872,7 +1872,7 @@ QString ResizeJumperItemCommand::getParamString() const {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-ShowLabelCommand::ShowLabelCommand(class SketchWidget *sketchWidget, QUndoCommand *parent)
+ShowLabelCommand::ShowLabelCommand(SketchWidget *sketchWidget, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
 {
 }
@@ -1913,14 +1913,14 @@ QString ShowLabelCommand::getParamString() const {
 LoadLogoImageCommand::LoadLogoImageCommand(SketchWidget *sketchWidget, long id,
         const QString & oldSvg, const QSizeF oldAspectRatio, const QString & oldFilename,
         const QString & newFilename, bool addName, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+    m_itemID(id),
+    m_oldSvg(oldSvg),
+    m_oldAspectRatio(oldAspectRatio),
+    m_oldFilename(oldFilename),
+    m_newFilename(newFilename),
+    m_addName(addName)
 {
-	m_itemID = id;
-	m_oldFilename = oldFilename;
-	m_newFilename = newFilename;
-	m_oldAspectRatio = oldAspectRatio;
-	m_oldSvg = oldSvg;
-	m_addName = addName;
 }
 
 void LoadLogoImageCommand::undo() {
@@ -1950,10 +1950,10 @@ QString LoadLogoImageCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 ChangeBoardLayersCommand::ChangeBoardLayersCommand(SketchWidget *sketchWidget, int oldLayers, int newLayers, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+    m_oldLayers(oldLayers),
+    m_newLayers(newLayers)
 {
-	m_oldLayers = oldLayers;
-	m_newLayers = newLayers;
 }
 
 void ChangeBoardLayersCommand::undo() {
@@ -1984,10 +1984,10 @@ QString ChangeBoardLayersCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 SetDropOffsetCommand::SetDropOffsetCommand(SketchWidget *sketchWidget, long id,  QPointF dropOffset, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+    m_itemID(id),
+    m_dropOffset(dropOffset)
 {
-	m_itemID = id;
-	m_dropOffset = dropOffset;
 }
 
 void SetDropOffsetCommand::undo() {
@@ -2012,12 +2012,12 @@ QString SetDropOffsetCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 RenamePinsCommand::RenamePinsCommand(SketchWidget *sketchWidget, long id, const QStringList & oldOnes, const QStringList & newOnes, bool singleRow, QUndoCommand *parent) :
-	BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+    m_itemID(id),
+    m_oldLabels(oldOnes),
+    m_newLabels(newOnes),
+    m_singleRow(singleRow)
 {
-	m_oldLabels = oldOnes;
-	m_newLabels = newOnes;
-	m_itemID = id;
-	m_singleRow = singleRow;
 }
 
 void RenamePinsCommand::undo() {
@@ -2084,12 +2084,12 @@ QString GroundFillSeedCommand::getParamString() const {
 WireExtrasCommand::WireExtrasCommand(SketchWidget* sketchWidget, long fromID,
                                      const QDomElement & oldExtras, const QDomElement & newExtras,
                                      QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+    m_fromID(fromID),
+    m_oldExtras(oldExtras),
+    m_newExtras(newExtras)
 {
 
-	m_fromID = fromID;
-	m_newExtras = newExtras;
-	m_oldExtras = oldExtras;
 }
 
 void WireExtrasCommand::undo()
@@ -2121,12 +2121,12 @@ QString WireExtrasCommand::getParamString() const {
 HidePartLayerCommand::HidePartLayerCommand(SketchWidget *sketchWidget, long fromID,
         ViewLayer::ViewLayerID layerID, bool wasHidden, bool isHidden,
         QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+    m_fromID(fromID),
+    m_wasHidden(wasHidden),
+    m_isHidden(isHidden),
+    m_layerID(layerID)
 {
-	m_fromID = fromID;
-	m_wasHidden = wasHidden;
-	m_isHidden = isHidden;
-	m_layerID = layerID;
 }
 
 void HidePartLayerCommand::undo()
@@ -2155,10 +2155,10 @@ QString HidePartLayerCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 AddSubpartCommand::AddSubpartCommand(SketchWidget *sketchWidget,  CrossViewType crossView, long id, long subpartID, QUndoCommand *parent)
-	: BaseCommand(crossView, sketchWidget, parent)
+	: BaseCommand(crossView, sketchWidget, parent),
+    m_itemID(id),
+    m_subpartItemID(subpartID)
 {
-	m_itemID = id;
-	m_subpartItemID = subpartID;
 
 }
 
@@ -2190,11 +2190,11 @@ QString AddSubpartCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 PackItemsCommand::PackItemsCommand(SketchWidget *sketchWidget, int columns, const QList<long> & ids, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+    m_columns(columns),
+    m_ids(ids),
+    m_firstTime(true)
 {
-	m_ids = ids;
-	m_columns = columns;
-	m_firstTime = true;
 }
 
 void PackItemsCommand::undo()
@@ -2223,9 +2223,7 @@ QString PackItemsCommand::getParamString() const {
 
 ////////////////////////////////////
 
-TemporaryCommand::TemporaryCommand(const QString & text) : QUndoCommand(text) {
-	m_enabled = true;
-}
+TemporaryCommand::TemporaryCommand(const QString & text) : QUndoCommand(text), m_enabled(true) { }
 
 TemporaryCommand::~TemporaryCommand() {
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1101,11 +1101,11 @@ QString ChangeZCommand::getParamString() const {
 
 CheckStickyCommand::CheckStickyCommand(SketchWidget* sketchWidget, BaseCommand::CrossViewType crossViewType, long itemID, bool checkCurrent, CheckType checkType, QUndoCommand *parent)
 	: BaseCommand(crossViewType, sketchWidget, parent),
-	m_itemId(itemID),
-	m_skipFirstRedo(true),
-	m_checkType(checkType),
-	m_checkCurrent(checkCurrent)
+	m_itemID(itemID),
+	m_checkCurrent(checkCurrent),
+	m_checkType(checkType)
 {
+	m_skipFirstRedo = true;
 }
 
 CheckStickyCommand::~CheckStickyCommand() {
@@ -1306,13 +1306,13 @@ QString CleanUpRatsnestsCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 WireColorChangeCommand::WireColorChangeCommand(SketchWidget* sketchWidget, long wireId, const QString &oldColor, const QString &newColor, double oldOpacity, double newOpacity, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_wireId(wireId),
+	m_oldColor(oldColor),
+	m_newColor(newColor),
+	m_oldOpacity(oldOpacity),
+	m_newOpacity(newOpacity)
 {
-	m_wireId = wireId;
-	m_oldColor = oldColor;
-	m_newColor = newColor;
-	m_oldOpacity = oldOpacity;
-	m_newOpacity = newOpacity;
 }
 
 void WireColorChangeCommand::undo() {
@@ -1336,11 +1336,11 @@ QString WireColorChangeCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 WireWidthChangeCommand::WireWidthChangeCommand(SketchWidget* sketchWidget, long wireId, double oldWidth, double newWidth, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_wireId(wireId),
+	m_oldWidth(oldWidth),
+	m_newWidth(newWidth)
 {
-	m_wireId = wireId;
-	m_oldWidth = oldWidth;
-	m_newWidth = newWidth;
 }
 
 void WireWidthChangeCommand::undo() {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1422,10 +1422,10 @@ QString ShowLabelFirstTimeCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 RestoreLabelCommand::RestoreLabelCommand(SketchWidget *sketchWidget,long id, QDomElement & element, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_itemID(id),
+	m_element(element)
 {
-	m_itemID = id;
-	m_element = element;
 	// seems to be safe to keep a copy of the element even though the document may no longer exist
 }
 
@@ -1451,13 +1451,13 @@ QString RestoreLabelCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 MoveLabelCommand::MoveLabelCommand(SketchWidget *sketchWidget, long id, QPointF oldPos, QPointF oldOffset, QPointF newPos, QPointF newOffset, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_itemID(id),
+	m_oldPos(oldPos),
+	m_newPos(newPos),
+	m_oldOffset(oldOffset),
+	m_newOffset(newOffset)
 {
-	m_itemID = id;
-	m_oldPos = oldPos;
-	m_newPos = newPos;
-	m_oldOffset = oldOffset;
-	m_newOffset = newOffset;
 }
 
 void MoveLabelCommand::undo()
@@ -1484,11 +1484,11 @@ QString MoveLabelCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 MoveLockCommand::MoveLockCommand(SketchWidget *sketchWidget, long id, bool oldLock, bool newLock, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_itemID(id),
+	m_oldLock(oldLock),
+	m_newLock(newLock)
 {
-	m_itemID = id;
-	m_oldLock = oldLock;
-	m_newLock = newLock;
 }
 
 void MoveLockCommand::undo()
@@ -1519,11 +1519,11 @@ QString MoveLockCommand::getParamString() const {
 ChangeLabelTextCommand::ChangeLabelTextCommand(SketchWidget *sketchWidget, long id,
         const QString & oldText, const QString & newText,
         QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+	m_itemID(id),
+	m_oldText(oldText),
+	m_newText(newText)
 {
-	m_itemID = id;
-	m_oldText = oldText;
-	m_newText = newText;
 }
 
 void ChangeLabelTextCommand::undo() {
@@ -1547,9 +1547,9 @@ QString ChangeLabelTextCommand::getParamString() const {
 ///////////////////////////////////////////////
 
 IncLabelTextCommand::IncLabelTextCommand(SketchWidget *sketchWidget, long id,  QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+	m_itemID(id)
 {
-	m_itemID = id;
 }
 
 void IncLabelTextCommand::undo() {
@@ -1575,13 +1575,13 @@ QString IncLabelTextCommand::getParamString() const {
 ChangeNoteTextCommand::ChangeNoteTextCommand(SketchWidget *sketchWidget, long id,
         const QString & oldText, const QString & newText,
         QSizeF oldSize, QSizeF newSize, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+	m_itemID(id),
+	m_oldText(oldText),
+	m_newText(newText),
+	m_oldSize(oldSize),
+	m_newSize(newSize)
 {
-	m_itemID = id;
-	m_oldText = oldText;
-	m_newText = newText;
-	m_oldSize = oldSize;
-	m_newSize = newSize;
 }
 
 void ChangeNoteTextCommand::undo() {
@@ -1641,11 +1641,11 @@ QString ChangeNoteTextCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 RotateFlipLabelCommand::RotateFlipLabelCommand(SketchWidget* sketchWidget, long itemID, double degrees, Qt::Orientations orientation, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_itemID(itemID),
+	m_degrees(degrees),
+	m_orientation(orientation)
 {
-	m_itemID = itemID;
-	m_degrees = degrees;
-	m_orientation = orientation;
 }
 
 void RotateFlipLabelCommand::undo()
@@ -1671,11 +1671,11 @@ QString RotateFlipLabelCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ResizeNoteCommand::ResizeNoteCommand(SketchWidget* sketchWidget, long itemID, const QSizeF & oldSize, const QSizeF & newSize, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_itemID(itemID),
+	m_oldSize(oldSize),
+	m_newSize(newSize)
 {
-	m_itemID = itemID;
-	m_oldSize = oldSize;
-	m_newSize = newSize;
 }
 
 void ResizeNoteCommand::undo()
@@ -1702,13 +1702,13 @@ QString ResizeNoteCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ResizeBoardCommand::ResizeBoardCommand(SketchWidget * sketchWidget, long itemID, double oldWidth, double oldHeight, double newWidth, double newHeight, QUndoCommand * parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_oldWidth(oldWidth),
+	m_oldHeight(oldHeight),
+	m_newWidth(newWidth),
+	m_newHeight(newHeight),
+	m_itemID(itemID)
 {
-	m_itemID = itemID;
-	m_oldWidth = oldWidth;
-	m_newWidth = newWidth;
-	m_oldHeight = oldHeight;
-	m_newHeight = newHeight;
 }
 
 void ResizeBoardCommand::undo() {
@@ -1741,9 +1741,9 @@ QString ResizeBoardCommand::getParamString() const {
 
 TransformItemCommand::TransformItemCommand(SketchWidget *sketchWidget, long id, const QMatrix & oldMatrix, const QMatrix & newMatrix, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_itemID(id),
-    m_oldMatrix(oldMatrix),
-    m_newMatrix(newMatrix)
+	m_itemID(id),
+	m_oldMatrix(oldMatrix),
+	m_newMatrix(newMatrix)
 {
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -1100,12 +1100,12 @@ QString ChangeZCommand::getParamString() const {
 //////////////////////////////////////////singlev///////////////////////////////////////////////////////////////////////
 
 CheckStickyCommand::CheckStickyCommand(SketchWidget* sketchWidget, BaseCommand::CrossViewType crossViewType, long itemID, bool checkCurrent, CheckType checkType, QUndoCommand *parent)
-	: BaseCommand(crossViewType, sketchWidget, parent)
+	: BaseCommand(crossViewType, sketchWidget, parent),
+	m_itemId(itemID),
+	m_skipFirstRedo(true),
+	m_checkType(checkType),
+	m_checkCurrent(checkCurrent)
 {
-	m_itemID = itemID;
-	m_skipFirstRedo = true;
-	m_checkType = checkType;
-	m_checkCurrent = checkCurrent;
 }
 
 CheckStickyCommand::~CheckStickyCommand() {
@@ -1167,7 +1167,7 @@ void CheckStickyCommand::stick(SketchWidget * sketchWidget, long fromID, long to
 
 CleanUpWiresCommand::CleanUpWiresCommand(SketchWidget* sketchWidget, CleanUpWiresCommand::Direction direction, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
-    m_direction(direction)
+	m_direction(direction)
 {
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -2125,7 +2125,8 @@ HidePartLayerCommand::HidePartLayerCommand(SketchWidget *sketchWidget, long from
     m_fromID(fromID),
     m_wasHidden(wasHidden),
     m_isHidden(isHidden),
-    m_layerID(layerID)
+    m_layerID(layerID),
+    m_oldLayer(ViewLayer::ViewLayerID::UnknownLayer)
 {
 }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -939,10 +939,10 @@ QString ChangeLayerCommand::getParamString() const {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 SelectItemCommand::SelectItemCommand(SketchWidget* sketchWidget, SelectItemType type, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::CrossView, sketchWidget, parent),
+	m_type(type),
+	m_updated(false)
 {
-	m_type = type;
-	m_updated = false;
 }
 
 int SelectItemCommand::id() const {

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -185,12 +185,12 @@ int BaseCommand::totalChildCount(const QUndoCommand * command) {
 
 AddDeleteItemCommand::AddDeleteItemCommand(SketchWidget* sketchWidget, BaseCommand::CrossViewType crossViewType, QString moduleID, ViewLayer::ViewLayerPlacement viewLayerPlacement, ViewGeometry & viewGeometry, qint64 id, long modelIndex, QUndoCommand *parent)
 	: BaseCommand(crossViewType, sketchWidget, parent),
-    m_moduleID(moduleID),
-    m_itemID(id),
-    m_viewGeometry(viewGeometry),
-    m_modelIndex(modelIndex),
-    m_dropOrigin(nullptr),
-    m_viewLayerPlacement(viewLayerPlacement)
+	m_moduleID(moduleID),
+	m_itemID(id),
+	m_viewGeometry(viewGeometry),
+	m_modelIndex(modelIndex),
+	m_dropOrigin(nullptr),
+	m_viewLayerPlacement(viewLayerPlacement)
 {
 }
 
@@ -219,9 +219,9 @@ SketchWidget * AddDeleteItemCommand::dropOrigin() {
 
 AddItemCommand::AddItemCommand(SketchWidget* sketchWidget, BaseCommand::CrossViewType crossViewType, QString moduleID, ViewLayer::ViewLayerPlacement viewLayerPlacement, ViewGeometry & viewGeometry, qint64 id, bool updateInfoView, long modelIndex, QUndoCommand *parent)
 	: AddDeleteItemCommand(sketchWidget, crossViewType, moduleID, viewLayerPlacement, viewGeometry, id, modelIndex, parent),
-    m_updateInfoView(updateInfoView),
-    m_module(false),
-    m_restoreIndexesCommand(nullptr)
+	m_updateInfoView(updateInfoView),
+	m_module(false),
+	m_restoreIndexesCommand(nullptr)
 {
 }
 
@@ -276,10 +276,10 @@ QString DeleteItemCommand::getParamString() const {
 
 MoveItemCommand::MoveItemCommand(SketchWidget* sketchWidget, long itemID, ViewGeometry & oldG, ViewGeometry & newG, bool updateRatsnest, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_updateRatsnest(updateRatsnest),
-    m_itemID(itemID),
-    m_old(oldG),
-    m_new(newG)
+	m_updateRatsnest(updateRatsnest),
+	m_itemID(itemID),
+	m_old(oldG),
+	m_new(newG)
 {
 }
 
@@ -315,9 +315,9 @@ QString MoveItemCommand::getParamString() const {
 
 SimpleMoveItemCommand::SimpleMoveItemCommand(SketchWidget* sketchWidget, long itemID, QPointF & oldP, QPointF & newP, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_itemID(itemID),
-    m_old(oldP),
-    m_new(newP)
+	m_itemID(itemID),
+	m_old(oldP),
+	m_new(newP)
 {
 }
 
@@ -402,8 +402,8 @@ QString MoveItemsCommand::getParamString() const {
 
 RotateItemCommand::RotateItemCommand(SketchWidget* sketchWidget, long itemID, double degrees, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_itemID(itemID),
-    m_degrees(degrees)
+	m_itemID(itemID),
+	m_degrees(degrees)
 {
 }
 
@@ -431,8 +431,8 @@ QString RotateItemCommand::getParamString() const {
 
 FlipItemCommand::FlipItemCommand(SketchWidget* sketchWidget, long itemID, Qt::Orientations orientation, QUndoCommand *parent)
 	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
-    m_itemID(itemID),
-    m_orientation(orientation)
+	m_itemID(itemID),
+	m_orientation(orientation)
 {
 }
 
@@ -626,16 +626,16 @@ QString ChangeWireCurveCommand::getParamString() const {
 ChangeLegCommand::ChangeLegCommand(SketchWidget* sketchWidget, long fromID, const QString & fromConnectorID,
                                    const QPolygonF & oldLeg, const QPolygonF & newLeg, bool relative, bool active,
                                    const QString & why, QUndoCommand *parent)
-	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent)
+	: BaseCommand(BaseCommand::SingleView, sketchWidget, parent),
+	m_fromConnectorID(fromConnectorID),
+	m_fromID(fromID),
+	m_newLeg(newLeg),
+	m_oldLeg(oldLeg),
+	m_relative(relative),
+	m_active(active),
+	m_simple(false),
+	m_why(why)
 {
-	m_why = why;
-	m_simple = false;
-	m_fromID = fromID;
-	m_oldLeg = oldLeg;
-	m_newLeg = newLeg;
-	m_relative = relative;
-	m_fromConnectorID = fromConnectorID;
-	m_active = active;
 }
 
 void ChangeLegCommand::undo()

--- a/src/commands.h
+++ b/src/commands.h
@@ -37,10 +37,10 @@ class CommandProgress : public QObject {
 	Q_OBJECT
 
 public:
-	CommandProgress();
+	CommandProgress() = default;
 
 	void setActive(bool);
-	bool active();
+	constexpr bool active() const noexcept { return m_active; }
 	void emitUndo();
 	void emitRedo();
 
@@ -49,11 +49,11 @@ signals:
 	void incRedo();
 
 protected:
-	bool m_active;
+	bool m_active = false;
 };
 
 /////////////////////////////////////////////
-
+class SketchWidget;
 class BaseCommand : public QUndoCommand
 {
 public:
@@ -63,12 +63,12 @@ public:
 	};
 
 public:
-	BaseCommand(BaseCommand::CrossViewType, class SketchWidget*, QUndoCommand* parent);
+	BaseCommand(BaseCommand::CrossViewType, SketchWidget*, QUndoCommand* parent);
 	~BaseCommand();
 
-	BaseCommand::CrossViewType crossViewType() const;
+	BaseCommand::CrossViewType crossViewType() const noexcept;
 	void setCrossViewType(BaseCommand::CrossViewType);
-	class SketchWidget* sketchWidget() const;
+	SketchWidget* sketchWidget() const;
 	int subCommandCount() const;
 	const BaseCommand * subCommand(int index) const;
 	virtual QString getDebugString() const;
@@ -96,13 +96,13 @@ protected:
 
 protected:
 	BaseCommand::CrossViewType m_crossViewType;
-	class SketchWidget *m_sketchWidget;
+	SketchWidget *m_sketchWidget = nullptr;
 	QList<BaseCommand *> m_commands;
-	QUndoCommand * m_parentCommand;
-	int m_index;
-	bool m_undoOnly;
-	bool m_redoOnly;
-	bool m_skipFirstRedo;
+	QUndoCommand * m_parentCommand = nullptr;
+	int m_index = 0;
+	bool m_undoOnly = false;
+	bool m_redoOnly = false;
+	bool m_skipFirstRedo = false;
 
 	static CommandProgress m_commandProgress;
 };
@@ -112,11 +112,11 @@ protected:
 class AddDeleteItemCommand : public BaseCommand
 {
 public:
-	AddDeleteItemCommand(class SketchWidget * sketchWidget, BaseCommand::CrossViewType, QString moduleID, ViewLayer::ViewLayerPlacement, ViewGeometry &, qint64 id, long modelIndex, QUndoCommand *parent);
+	AddDeleteItemCommand(SketchWidget * sketchWidget, BaseCommand::CrossViewType, QString moduleID, ViewLayer::ViewLayerPlacement, ViewGeometry &, qint64 id, long modelIndex, QUndoCommand *parent);
 
 	long itemID() const;
-	void setDropOrigin(class SketchWidget *);
-	class SketchWidget * dropOrigin();
+	void setDropOrigin(SketchWidget *);
+	SketchWidget * dropOrigin();
 
 protected:
 	QString getParamString() const;
@@ -126,7 +126,7 @@ protected:
 	long m_itemID;
 	ViewGeometry m_viewGeometry;
 	long m_modelIndex;
-	class SketchWidget * m_dropOrigin;
+	SketchWidget * m_dropOrigin;
 	ViewLayer::ViewLayerPlacement m_viewLayerPlacement;
 };
 
@@ -144,9 +144,9 @@ protected:
 	QString getParamString() const;
 
 protected:
-	bool m_updateInfoView;
-	bool m_module;
-	RestoreIndexesCommand * m_restoreIndexesCommand;
+	bool m_updateInfoView = false;
+	bool m_module = false;
+	RestoreIndexesCommand * m_restoreIndexesCommand = nullptr;
 };
 
 /////////////////////////////////////////////
@@ -154,7 +154,7 @@ protected:
 class DeleteItemCommand : public AddDeleteItemCommand
 {
 public:
-	DeleteItemCommand(class SketchWidget *sketchWidget, BaseCommand::CrossViewType, QString moduleID, ViewLayer::ViewLayerPlacement, ViewGeometry &, qint64 id, long modelIndex, QUndoCommand *parent);
+	DeleteItemCommand(SketchWidget *sketchWidget, BaseCommand::CrossViewType, QString moduleID, ViewLayer::ViewLayerPlacement, ViewGeometry &, qint64 id, long modelIndex, QUndoCommand *parent);
 	void undo();
 	void redo();
 
@@ -168,7 +168,7 @@ protected:
 class MoveItemCommand : public BaseCommand
 {
 public:
-	MoveItemCommand(class SketchWidget *sketchWidget, long id, ViewGeometry & oldG, ViewGeometry & newG, bool updateRatsnest, QUndoCommand *parent);
+	MoveItemCommand(SketchWidget *sketchWidget, long id, ViewGeometry & oldG, ViewGeometry & newG, bool updateRatsnest, QUndoCommand *parent);
 	void undo();
 	void redo();
 
@@ -176,8 +176,8 @@ protected:
 	QString getParamString() const;
 
 protected:
-	bool m_updateRatsnest;
-	long m_itemID;
+	bool m_updateRatsnest = false;
+	long m_itemID = 0;
 	ViewGeometry m_old;
 	ViewGeometry m_new;
 };
@@ -187,7 +187,7 @@ protected:
 class SimpleMoveItemCommand : public BaseCommand
 {
 public:
-	SimpleMoveItemCommand(class SketchWidget *sketchWidget, long id, QPointF & oldP, QPointF & newP, QUndoCommand *parent);
+	SimpleMoveItemCommand(SketchWidget *sketchWidget, long id, QPointF & oldP, QPointF & newP, QUndoCommand *parent);
 	void undo();
 	void redo();
 
@@ -195,7 +195,7 @@ protected:
 	QString getParamString() const;
 
 protected:
-	long m_itemID;
+	long m_itemID = 0;
 	QPointF m_old;
 	QPointF m_new;
 };
@@ -203,7 +203,7 @@ protected:
 /////////////////////////////////////////////
 
 struct MoveItemThing {
-	long id;
+	long id = 0;
 	QPointF oldPos;
 	QPointF newPos;
 };
@@ -211,7 +211,7 @@ struct MoveItemThing {
 class MoveItemsCommand : public BaseCommand
 {
 public:
-	MoveItemsCommand(class SketchWidget *sketchWidget, bool updateRatsnest, QUndoCommand *parent);
+	MoveItemsCommand(SketchWidget *sketchWidget, bool updateRatsnest, QUndoCommand *parent);
 	void undo();
 	void redo();
 	void addItem(long id, const QPointF & oldPos, const QPointF & newPos);
@@ -231,7 +231,7 @@ protected:
 class RotateItemCommand : public BaseCommand
 {
 public:
-	RotateItemCommand(class SketchWidget *sketchWidget, long id, double degrees, QUndoCommand *parent);
+	RotateItemCommand(SketchWidget *sketchWidget, long id, double degrees, QUndoCommand *parent);
 	void undo();
 	void redo();
 
@@ -249,7 +249,7 @@ class FlipItemCommand : public BaseCommand
 {
 
 public:
-	FlipItemCommand(class SketchWidget *sketchWidget, long id, Qt::Orientations orientation, QUndoCommand *parent);
+	FlipItemCommand(SketchWidget *sketchWidget, long id, Qt::Orientations orientation, QUndoCommand *parent);
 	void undo();
 	void redo();
 
@@ -262,12 +262,12 @@ protected:
 };
 
 /////////////////////////////////////////////
-
+class QMatrix;
 class TransformItemCommand : public BaseCommand
 {
 
 public:
-	TransformItemCommand(class SketchWidget *sketchWidget, long id, const class QMatrix & oldMatrix, const class QMatrix & newMatrix, QUndoCommand *parent);
+	TransformItemCommand(SketchWidget *sketchWidget, long id, const QMatrix & oldMatrix, const class QMatrix & newMatrix, QUndoCommand *parent);
 	void undo();
 	void redo();
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -566,7 +566,7 @@ struct StickyThing {
 };
 
 /////////////////////////////////////////////
-
+class SketchWidget;
 class CheckStickyCommand : public BaseCommand
 {
 public:
@@ -577,7 +577,7 @@ public:
 	};
 
 public:
-	CheckStickyCommand(class SketchWidget *sketchWidget, BaseCommand::CrossViewType, long itemID, bool checkCurrent, CheckType, QUndoCommand *parent);
+	CheckStickyCommand(SketchWidget *sketchWidget, BaseCommand::CrossViewType, long itemID, bool checkCurrent, CheckType, QUndoCommand *parent);
 	~CheckStickyCommand();
 
 	void undo();
@@ -589,9 +589,9 @@ protected:
 	QString getParamString() const;
 
 protected:
-	long m_itemID;
+	long m_itemID = 0;
 	QList<StickyThing *> m_stickyList;
-	bool m_checkCurrent;
+	bool m_checkCurrent = false;
 	CheckType m_checkType;
 };
 

--- a/src/connectors/bus.cpp
+++ b/src/connectors/bus.cpp
@@ -24,19 +24,23 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "connectoritem.h"
 #include "../model/modelpart.h"
 
-Bus::Bus(BusShared * busShared, ModelPart * modelPart) : QObject()
+Bus::Bus(BusShared * busShared, ModelPart * modelPart) : QObject(),
+    m_connectors(),
+    m_subConnector(nullptr),
+    m_busShared(busShared),
+    m_modelPart(modelPart)
 {
-	m_busShared = busShared;
-	m_modelPart = modelPart;
 }
 
-const QString & Bus::id() const {
-	if (m_busShared == NULL) return ___emptyString___;
-
-	return m_busShared->id();
+const QString & Bus::id() const noexcept {
+	if (!m_busShared) { 
+        return ___emptyString___;
+    } else {
+	    return m_busShared->id();
+    }
 }
 
-const QList<Connector *> & Bus::connectors() const {
+const QList<Connector *> & Bus::connectors() const noexcept {
 	return m_connectors;
 }
 
@@ -45,7 +49,7 @@ void Bus::addConnector(Connector * connector) {
 	m_connectors.append(connector);
 }
 
-ModelPart * Bus::modelPart() {
+ModelPart * Bus::modelPart() const noexcept {
 	return m_modelPart;
 }
 
@@ -53,6 +57,6 @@ void Bus::addSubConnector(Connector * subConnector) {
 	m_subConnector = subConnector;
 }
 
-Connector * Bus::subConnector() const {
+Connector * Bus::subConnector() const noexcept {
 	return m_subConnector;
 }

--- a/src/connectors/bus.cpp
+++ b/src/connectors/bus.cpp
@@ -24,20 +24,18 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "connectoritem.h"
 #include "../model/modelpart.h"
 
-Bus::Bus(BusShared * busShared, ModelPart * modelPart) : QObject(),
-    m_connectors(),
-    m_subConnector(nullptr),
-    m_busShared(busShared),
-    m_modelPart(modelPart)
+Bus::Bus(BusShared * busShared, ModelPart * modelPart) 
+	: QObject(),
+	m_connectors(),
+	m_subConnector(nullptr),
+	m_busShared(busShared),
+	m_modelPart(modelPart)
 {
 }
 
 const QString & Bus::id() const noexcept {
-	if (!m_busShared) { 
-        return ___emptyString___;
-    } else {
-	    return m_busShared->id();
-    }
+	if (!m_busShared) return ___emptyString___;
+	return m_busShared->id();
 }
 
 const QList<Connector *> & Bus::connectors() const noexcept {

--- a/src/connectors/bus.h
+++ b/src/connectors/bus.h
@@ -29,25 +29,28 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QGraphicsScene>
 #include <QPointer>
 
+class BusShared;
+class ModelPart;
+class Connector;
 class Bus : public QObject
 {
 	Q_OBJECT
 
 public:
-	Bus(class BusShared *, class ModelPart *);
+	Bus(BusShared *, ModelPart *);
 
-	const QString & id() const;
-	void addConnector(class Connector *);
-	class ModelPart * modelPart();
-	const QList<Connector *> & connectors() const;
-	Connector * subConnector() const;
+	const QString & id() const noexcept;
+	void addConnector(Connector *);
+	ModelPart * modelPart() const noexcept;
+	const QList<Connector *> & connectors() const noexcept;
+	Connector * subConnector() const noexcept;
 	void addSubConnector(Connector *);
 
 protected:
-	QList<class Connector *> m_connectors;
-	class Connector * m_subConnector;
+	QList<Connector *> m_connectors;
+	Connector * m_subConnector;
 	BusShared * m_busShared;
-	QPointer<class ModelPart> m_modelPart;
+	QPointer<ModelPart> m_modelPart;
 };
 
 

--- a/src/connectors/ercdata.cpp
+++ b/src/connectors/ercdata.cpp
@@ -34,8 +34,8 @@ bool ValidReal::setValue(const QString & v) {
 
 ErcData::ErcData(const QDomElement & ercElement) : 
     m_eType(UnknownEType),
-    m_currentFlow(UnknownFlow),
-    m_ignore(Never)
+    m_ignore(Never),
+    m_currentFlow(UnknownFlow)
 {
 	QString eType = ercElement.attribute("etype");
 	if (eType.compare("VCC", Qt::CaseInsensitive) == 0) {

--- a/src/connectors/ercdata.cpp
+++ b/src/connectors/ercdata.cpp
@@ -20,18 +20,6 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ercdata.h"
 
-ValidReal::ValidReal() {
-	m_ok = false;
-}
-
-bool ValidReal::isValid() {
-	return m_ok;
-}
-
-double ValidReal::value() {
-	return m_value;
-}
-
 void ValidReal::setValue(double v) {
 	m_value = v;
 	m_ok = true;
@@ -44,12 +32,11 @@ bool ValidReal::setValue(const QString & v) {
 
 //////////////////////////////////////////////////////////
 
-ErcData::ErcData(const QDomElement & ercElement)
+ErcData::ErcData(const QDomElement & ercElement) : 
+    m_eType(UnknownEType),
+    m_currentFlow(UnknownFlow),
+    m_ignore(Never)
 {
-	m_eType = UnknownEType;
-	m_currentFlow = UnknownFlow;
-	m_ignore = Never;
-
 	QString eType = ercElement.attribute("etype");
 	if (eType.compare("VCC", Qt::CaseInsensitive) == 0) {
 		m_eType = VCC;
@@ -102,6 +89,7 @@ void ErcData::readVoltage(QDomElement & voltageElement) {
 }
 
 bool ErcData::writeToElement(QDomElement & ercElement, QDomDocument & doc) {
+    bool success = true;
 	switch (m_eType) {
 	case Ground:
 		ercElement.setAttribute("etype", "ground");
@@ -113,23 +101,24 @@ bool ErcData::writeToElement(QDomElement & ercElement, QDomDocument & doc) {
 		writeVoltage(ercElement, doc);
 		break;
 	default:
-		return false;
+        success = false;
+        break;
 	}
 
-	return true;
+    return success;
 }
 
 void ErcData::writeCurrent(QDomElement & parent, QDomDocument & doc) {
-	if (m_current.isValid() || m_currentMin.isValid() || m_currentMax.isValid() || m_currentFlow != UnknownFlow) {
+    if (m_current || m_currentMin || m_currentMax || m_currentFlow != UnknownFlow) {
 		QDomElement currentElement = doc.createElement("current");
 		parent.appendChild(currentElement);
-		if (m_current.isValid()) {
+        if (m_current) {
 			currentElement.setAttribute("value", QString::number(m_current.value()));
 		}
-		if (m_currentMin.isValid()) {
+		if (m_currentMin) {
 			currentElement.setAttribute("valueMin", QString::number(m_currentMin.value()));
 		}
-		if (m_currentMax.isValid()) {
+		if (m_currentMax) {
 			currentElement.setAttribute("valueMax", QString::number(m_currentMax.value()));
 		}
 		switch (m_currentFlow) {
@@ -146,25 +135,18 @@ void ErcData::writeCurrent(QDomElement & parent, QDomDocument & doc) {
 }
 
 void ErcData::writeVoltage(QDomElement & parent, QDomDocument & doc) {
-	if (m_voltage.isValid() || m_voltageMin.isValid() || m_voltageMax.isValid()) {
+    if (m_voltage || m_voltageMin || m_voltageMax) {
 		QDomElement voltageElement = doc.createElement("voltage");
 		parent.appendChild(voltageElement);
-		if (m_voltage.isValid()) {
+        if (m_voltage) {
 			voltageElement.setAttribute("value", QString::number(m_voltage.value()));
 		}
-		if (m_voltageMin.isValid()) {
+        if (m_voltageMin) {
 			voltageElement.setAttribute("valueMin", QString::number(m_voltageMin.value()));
 		}
-		if (m_voltageMax.isValid()) {
+        if (m_voltageMax) {
 			voltageElement.setAttribute("valueMax", QString::number(m_voltageMax.value()));
 		}
 	}
 }
 
-ErcData::EType ErcData::eType() {
-	return m_eType;
-}
-
-ErcData::Ignore ErcData::ignore() {
-	return m_ignore;
-}

--- a/src/connectors/ercdata.cpp
+++ b/src/connectors/ercdata.cpp
@@ -20,7 +20,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "ercdata.h"
 
-void ValidReal::setValue(double v) {
+void ValidReal::setValue(double v) noexcept {
 	m_value = v;
 	m_ok = true;
 }

--- a/src/connectors/ercdata.cpp
+++ b/src/connectors/ercdata.cpp
@@ -33,9 +33,9 @@ bool ValidReal::setValue(const QString & v) {
 //////////////////////////////////////////////////////////
 
 ErcData::ErcData(const QDomElement & ercElement) : 
-    m_eType(UnknownEType),
-    m_ignore(Never),
-    m_currentFlow(UnknownFlow)
+	m_eType(UnknownEType),
+	m_ignore(Never),
+	m_currentFlow(UnknownFlow)
 {
 	QString eType = ercElement.attribute("etype");
 	if (eType.compare("VCC", Qt::CaseInsensitive) == 0) {
@@ -109,10 +109,10 @@ bool ErcData::writeToElement(QDomElement & ercElement, QDomDocument & doc) {
 }
 
 void ErcData::writeCurrent(QDomElement & parent, QDomDocument & doc) {
-    if (m_current || m_currentMin || m_currentMax || m_currentFlow != UnknownFlow) {
+	if (m_current || m_currentMin || m_currentMax || m_currentFlow != UnknownFlow) {
 		QDomElement currentElement = doc.createElement("current");
 		parent.appendChild(currentElement);
-        if (m_current) {
+		if (m_current) {
 			currentElement.setAttribute("value", QString::number(m_current.value()));
 		}
 		if (m_currentMin) {
@@ -135,16 +135,16 @@ void ErcData::writeCurrent(QDomElement & parent, QDomDocument & doc) {
 }
 
 void ErcData::writeVoltage(QDomElement & parent, QDomDocument & doc) {
-    if (m_voltage || m_voltageMin || m_voltageMax) {
+	if (m_voltage || m_voltageMin || m_voltageMax) {
 		QDomElement voltageElement = doc.createElement("voltage");
 		parent.appendChild(voltageElement);
-        if (m_voltage) {
+		if (m_voltage) {
 			voltageElement.setAttribute("value", QString::number(m_voltage.value()));
 		}
-        if (m_voltageMin) {
+		if (m_voltageMin) {
 			voltageElement.setAttribute("valueMin", QString::number(m_voltageMin.value()));
 		}
-        if (m_voltageMax) {
+		if (m_voltageMax) {
 			voltageElement.setAttribute("valueMax", QString::number(m_voltageMax.value()));
 		}
 	}

--- a/src/connectors/ercdata.h
+++ b/src/connectors/ercdata.h
@@ -29,12 +29,12 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 class ValidReal {
 public:
 	constexpr ValidReal() noexcept : m_ok(false), m_value(0.0) { }
-    constexpr ValidReal(double value) noexcept : m_ok(true), m_value(value) { }
+	constexpr ValidReal(double value) noexcept : m_ok(true), m_value(value) { }
 	constexpr bool isValid() const noexcept { return m_ok; }
 	constexpr double value() const noexcept { return m_value; }
 	void setValue(double value) noexcept;
 	bool setValue(const QString &);
-    explicit constexpr operator bool() const { return m_ok; }
+	explicit constexpr operator bool() const { return m_ok; }
 private:
 	bool m_ok;
 	double m_value;

--- a/src/connectors/ercdata.h
+++ b/src/connectors/ercdata.h
@@ -28,14 +28,14 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 class ValidReal {
 public:
-	ValidReal();
-
-	bool isValid();
-	double value();
-	void setValue(double);
+	constexpr ValidReal() noexcept : m_ok(false), m_value(0.0) { }
+    constexpr ValidReal(double value) noexcept : m_ok(true), m_value(value) { }
+	constexpr bool isValid() const noexcept { return m_ok; }
+	constexpr double value() const noexcept { return m_value; }
+	void setValue(double value) noexcept;
 	bool setValue(const QString &);
-
-protected:
+    explicit constexpr operator bool() const { return m_ok; }
+private:
 	bool m_ok;
 	double m_value;
 
@@ -66,8 +66,8 @@ public:
 	ErcData(const QDomElement & ercElement);
 
 	bool writeToElement(QDomElement & ercElement, QDomDocument & doc);
-	EType eType();
-	Ignore ignore();
+	constexpr EType eType() const noexcept { return m_eType; }
+	constexpr Ignore ignore() const noexcept { return m_ignore; }
 
 protected:
 	void readVoltage(QDomElement &);
@@ -78,13 +78,13 @@ protected:
 protected:
 	EType m_eType;
 	Ignore m_ignore;
+	CurrentFlow m_currentFlow;
 	ValidReal m_voltage;
 	ValidReal m_voltageMin;
 	ValidReal m_voltageMax;
 	ValidReal m_current;
 	ValidReal m_currentMin;
 	ValidReal m_currentMax;
-	CurrentFlow m_currentFlow;
 };
 
 #endif

--- a/src/connectors/nonconnectoritem.cpp
+++ b/src/connectors/nonconnectoritem.cpp
@@ -35,18 +35,19 @@ constexpr double EffectiveAdjustmentFactor = 5.0 / 15.0;
 
 /////////////////////////////////////////////////////////
 
-NonConnectorItem::NonConnectorItem(ItemBase * attachedTo) : QGraphicsRectItem(attachedTo),
-    m_attachedTo(attachedTo),
-    m_hidden(false),
-    m_inactive(false),
-    m_paint(false),
-    m_opacity(0.0),
-    m_effectively(Effectively::EffectivelyUnknown),
-    m_radius(0),
-    m_strokeWidth(0),
-    m_negativeOffsetRect(false),
-    m_shape(),
-    m_isPath(false)
+NonConnectorItem::NonConnectorItem(ItemBase * attachedTo) 
+	: QGraphicsRectItem(attachedTo),
+	m_attachedTo(attachedTo),
+	m_hidden(false),
+	m_inactive(false),
+	m_paint(false),
+	m_opacity(0.0),
+	m_effectively(Effectively::EffectivelyUnknown),
+	m_radius(0),
+	m_strokeWidth(0),
+	m_negativeOffsetRect(false),
+	m_shape(),
+	m_isPath(false)
 {
 	setAcceptHoverEvents(false);
 	setAcceptedMouseButtons(Qt::NoButton);
@@ -166,27 +167,18 @@ bool NonConnectorItem::inactive() const {
 }
 
 long NonConnectorItem::attachedToID() {
-    if (!attachedTo()) {
-        return -1;
-    } else {
-        return attachedTo()->id();
-    }
+	if (!attachedTo()) return -1;
+	return attachedTo()->id();
 }
 
 const QString & NonConnectorItem::attachedToTitle() {
-    if (!attachedTo()) {
-        return ___emptyString___;
-    } else {
-	    return attachedTo()->title();
-    }
+	if (!attachedTo()) return ___emptyString___;
+	return attachedTo()->title();
 }
 
 const QString & NonConnectorItem::attachedToInstanceTitle() {
-	if (!attachedTo()) { 
-        return ___emptyString___;
-    } else {
-	    return attachedTo()->instanceTitle();
-    }
+	if (!attachedTo()) return ___emptyString___; 
+	return attachedTo()->instanceTitle();
 }
 
 void NonConnectorItem::setCircular(bool circular) {
@@ -235,9 +227,6 @@ void NonConnectorItem::setShape(QPainterPath & pp) {
 }
 
 int NonConnectorItem::attachedToItemType() {
-    if (!m_attachedTo) {
-        return ModelPart::Unknown;
-    } else {
-	    return m_attachedTo->itemType();
-    }
+	if (!m_attachedTo) return ModelPart::Unknown;
+	return m_attachedTo->itemType();
 }

--- a/src/connectors/nonconnectoritem.cpp
+++ b/src/connectors/nonconnectoritem.cpp
@@ -31,16 +31,23 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../model/modelpart.h"
 
 //static const double EffectiveAdjustment = 1.25;
-static const double EffectiveAdjustmentFactor = 5.0 / 15.0;
+constexpr double EffectiveAdjustmentFactor = 5.0 / 15.0;
 
 /////////////////////////////////////////////////////////
 
-NonConnectorItem::NonConnectorItem(ItemBase * attachedTo) : QGraphicsRectItem(attachedTo)
+NonConnectorItem::NonConnectorItem(ItemBase * attachedTo) : QGraphicsRectItem(attachedTo),
+    m_attachedTo(attachedTo),
+    m_hidden(false),
+    m_inactive(false),
+    m_paint(false),
+    m_opacity(0.0),
+    m_effectively(Effectively::EffectivelyUnknown),
+    m_radius(0),
+    m_strokeWidth(0),
+    m_negativeOffsetRect(false),
+    m_shape(),
+    m_isPath(false)
 {
-	m_effectively = EffectivelyUnknown;
-	m_radius = m_strokeWidth = 0;
-	m_layerHidden = m_isPath = m_inactive = m_hidden = false;
-	m_attachedTo = attachedTo;
 	setAcceptHoverEvents(false);
 	setAcceptedMouseButtons(Qt::NoButton);
 	setFlag(QGraphicsItem::ItemIsMovable, false);
@@ -48,8 +55,6 @@ NonConnectorItem::NonConnectorItem(ItemBase * attachedTo) : QGraphicsRectItem(at
 	setFlag(QGraphicsItem::ItemIsFocusable, false);
 }
 
-NonConnectorItem::~NonConnectorItem() {
-}
 
 ItemBase * NonConnectorItem::attachedTo() {
 	return m_attachedTo;
@@ -138,7 +143,7 @@ void NonConnectorItem::setHidden(bool hide) {
 	this->update();
 }
 
-bool NonConnectorItem::hidden() {
+bool NonConnectorItem::hidden() const {
 	return m_hidden;
 }
 
@@ -147,7 +152,7 @@ void NonConnectorItem::setLayerHidden(bool hide) {
 	this->update();
 }
 
-bool NonConnectorItem::layerHidden() {
+bool NonConnectorItem::layerHidden() const {
 	return m_layerHidden;
 }
 
@@ -156,23 +161,32 @@ void NonConnectorItem::setInactive(bool inactivate) {
 	this->update();
 }
 
-bool NonConnectorItem::inactive() {
+bool NonConnectorItem::inactive() const {
 	return m_inactive;
 }
 
 long NonConnectorItem::attachedToID() {
-	if (attachedTo() == NULL) return -1;
-	return attachedTo()->id();
+    if (!attachedTo()) {
+        return -1;
+    } else {
+        return attachedTo()->id();
+    }
 }
 
 const QString & NonConnectorItem::attachedToTitle() {
-	if (attachedTo() == NULL) return ___emptyString___;
-	return attachedTo()->title();
+    if (!attachedTo()) {
+        return ___emptyString___;
+    } else {
+	    return attachedTo()->title();
+    }
 }
 
 const QString & NonConnectorItem::attachedToInstanceTitle() {
-	if (attachedTo() == NULL) return ___emptyString___;
-	return attachedTo()->instanceTitle();
+	if (!attachedTo()) { 
+        return ___emptyString___;
+    } else {
+	    return attachedTo()->instanceTitle();
+    }
 }
 
 void NonConnectorItem::setCircular(bool circular) {
@@ -189,15 +203,15 @@ void NonConnectorItem::setIsPath(bool path) {
 	m_isPath = path;
 }
 
-bool NonConnectorItem::isPath() {
+bool NonConnectorItem::isPath() const {
 	return m_isPath;
 }
 
-double NonConnectorItem::radius() {
+double NonConnectorItem::radius() const {
 	return m_radius;
 }
 
-double NonConnectorItem::strokeWidth() {
+double NonConnectorItem::strokeWidth() const {
 	return m_strokeWidth;
 }
 
@@ -221,7 +235,9 @@ void NonConnectorItem::setShape(QPainterPath & pp) {
 }
 
 int NonConnectorItem::attachedToItemType() {
-	if (m_attachedTo == NULL) return ModelPart::Unknown;
-
-	return m_attachedTo->itemType();
+    if (!m_attachedTo) {
+        return ModelPart::Unknown;
+    } else {
+	    return m_attachedTo->itemType();
+    }
 }

--- a/src/connectors/nonconnectoritem.h
+++ b/src/connectors/nonconnectoritem.h
@@ -36,27 +36,27 @@ class NonConnectorItem : public QObject, public QGraphicsRectItem
 
 public:
 	NonConnectorItem(ItemBase* attachedTo);
-	~NonConnectorItem();
+	~NonConnectorItem() = default;
 
 	ItemBase * attachedTo();
 	virtual void setHidden(bool hidden);
-	bool hidden();
+	bool hidden() const;
 	virtual void setInactive(bool inactivate);
-	bool inactive();
+	bool inactive() const;
 	virtual void setLayerHidden(bool hidden);
-	bool layerHidden();
+	bool layerHidden() const;
 	long attachedToID();
 	const QString & attachedToTitle();
 	const QString & attachedToInstanceTitle();
 	void setCircular(bool);
 	void setRadius(double radius, double strokeWidth);
-	double radius();
-	double strokeWidth();
+	double radius() const;
+	double strokeWidth() const;
 	void setShape(QPainterPath &);
 	void paint( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
 	QPainterPath shape() const;
 	void setIsPath(bool);
-	bool isPath();
+	bool isPath() const;
 	int attachedToItemType();
 
 protected:
@@ -71,19 +71,19 @@ protected:
 
 protected:
 	QPointer<ItemBase> m_attachedTo;
-	bool m_hidden;
-	bool m_layerHidden;
-	bool m_inactive;
-	bool m_paint;
-	double m_opacity;
-	bool m_circular;
-	Effectively m_effectively;
-	double m_radius;
-	double m_strokeWidth;
-	double m_negativePenWidth;
-	bool m_negativeOffsetRect;
+	bool m_hidden = false;
+	bool m_layerHidden = false;
+	bool m_inactive = false;
+	bool m_paint = false;
+	double m_opacity = 0.0;
+	bool m_circular = false;
+	Effectively m_effectively = Effectively::EffectivelyUnknown;
+	double m_radius = 0.0;
+	double m_strokeWidth = 0.0;
+	double m_negativePenWidth = 0.0;
+	bool m_negativeOffsetRect = false;
 	QPainterPath m_shape;
-	bool m_isPath;
+	bool m_isPath = false;
 
 };
 

--- a/src/connectors/svgidlayer.cpp
+++ b/src/connectors/svgidlayer.cpp
@@ -20,11 +20,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "svgidlayer.h"
 
-SvgIdLayer::SvgIdLayer(ViewLayer::ViewID viewID) {
-	m_viewID = viewID;
-	m_pointRectBottom.processed = m_pointRectTop.processed = m_path = m_hybrid = false;
-	m_radius = m_strokeWidth = 0;
-}
+SvgIdLayer::SvgIdLayer(ViewLayer::ViewID viewID) : m_viewID(viewID) { }
 
 SvgIdLayer * SvgIdLayer::copyLayer() {
 	SvgIdLayer * toSvgIdLayer = new SvgIdLayer(m_viewID);
@@ -33,55 +29,74 @@ SvgIdLayer * SvgIdLayer::copyLayer() {
 }
 
 QPointF SvgIdLayer::point(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.point;
-
-	return m_pointRectTop.point;
+    if (viewLayerPlacement == ViewLayer::NewBottom) {
+        return m_pointRectBottom.point;
+    } else {
+        return m_pointRectTop.point;
+    }
 }
 
 QRectF SvgIdLayer::rect(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.rect;
-
-	return m_pointRectTop.rect;
+	if (viewLayerPlacement == ViewLayer::NewBottom) {
+        return m_pointRectBottom.rect;
+    } else {
+        return m_pointRectTop.rect;
+    }
 }
 
 bool SvgIdLayer::processed(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.processed;
-
-	return m_pointRectTop.processed;
+	if (viewLayerPlacement == ViewLayer::NewBottom) {
+        return m_pointRectBottom.processed;
+    } else {
+	    return m_pointRectTop.processed;
+    }
 }
 
 bool SvgIdLayer::svgVisible(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.svgVisible;
-
-	return m_pointRectTop.svgVisible;
+	if (viewLayerPlacement == ViewLayer::NewBottom) {
+        return m_pointRectBottom.svgVisible;
+    } else {
+	    return m_pointRectTop.svgVisible;
+    }
 }
 
+void PointRect::unprocess() {
+    processed = false;
+}
+
+void PointRect::setInvisible() {
+    svgVisible = false;
+    processed = true;
+}
+PointRect::PointRect() { }
+PointRect::PointRect(bool _svgVisible, bool _processed, QRectF _rect, QPointF _point) : 
+    rect(_rect), 
+    point(_point),
+    processed(_processed),
+    svgVisible(_svgVisible) { }
+
+PointRect::PointRect(const PointRect& other) : rect(other.rect), point(other.point), processed(other.processed), svgVisible(other.svgVisible) { }
+
 void SvgIdLayer::unprocess() {
-	m_pointRectTop.processed = m_pointRectBottom.processed = false;
+    m_pointRectTop.unprocess();
+    m_pointRectBottom.unprocess();
 }
 
 void SvgIdLayer::setInvisible(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
 	if (viewLayerPlacement == ViewLayer::NewBottom) {
-		m_pointRectBottom.svgVisible = false;
-		m_pointRectBottom.processed = true;
-		return;
-	}
-
-	m_pointRectTop.svgVisible = false;
-	m_pointRectTop.processed = true;
+        m_pointRectBottom.setInvisible();
+	} else {
+        m_pointRectTop.setInvisible();
+    }
 }
 
+void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, const PointRect& other) {
+    if (viewLayerPlacement == ViewLayer::NewBottom) {
+        m_pointRectBottom = other;
+    } else {
+        m_pointRectTop = other;
+    }
+}
 void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, QPointF point, QRectF rect, bool svgVisible) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) {
-		m_pointRectBottom.svgVisible = svgVisible;
-		m_pointRectBottom.processed = true;
-		m_pointRectBottom.point = point;
-		m_pointRectBottom.rect = rect;
-		return;
-	}
-
-	m_pointRectTop.svgVisible = svgVisible;
-	m_pointRectTop.processed = true;
-	m_pointRectTop.point = point;
-	m_pointRectTop.rect = rect;
+    setPointRect(viewLayerPlacement, PointRect(svgVisible, true, point, rect));
 }

--- a/src/connectors/svgidlayer.cpp
+++ b/src/connectors/svgidlayer.cpp
@@ -98,5 +98,5 @@ void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, 
     }
 }
 void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, QPointF point, QRectF rect, bool svgVisible) {
-    setPointRect(viewLayerPlacement, PointRect(svgVisible, true, point, rect));
+    setPointRect(viewLayerPlacement, PointRect(svgVisible, true, rect, point));
 }

--- a/src/connectors/svgidlayer.cpp
+++ b/src/connectors/svgidlayer.cpp
@@ -20,75 +20,71 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "svgidlayer.h"
 
-SvgIdLayer::SvgIdLayer(ViewLayer::ViewID viewID) : m_viewID(viewID) { }
+SvgIdLayer::SvgIdLayer(ViewLayer::ViewID viewID) : 
+    m_viewID(viewID),
+	m_svgViewLayerID(),
+	m_svgId(),
+	m_terminalId(),
+	m_legId(),
+	m_legColor(),
+	m_legLine(),
+	m_radius(0.0),
+	m_strokeWidth(0.0),
+	m_legStrokeWidth(0.0),
+	m_hybrid(false),
+	m_path(false)
+{ }
+
+SvgIdLayer::SvgIdLayer(const SvgIdLayer& other) : 
+    m_viewID(other.m_viewID),
+	m_svgViewLayerID(other.m_svgViewLayerID),
+	m_svgId(other.m_svgId),
+	m_terminalId(other.m_terminalId),
+	m_legId(other.m_legId),
+	m_legColor(other.m_legColor),
+	m_legLine(other.m_legLine),
+	m_radius(other.m_radius),
+	m_strokeWidth(other.m_strokeWidth),
+	m_legStrokeWidth(other.m_legStrokeWidth),
+	m_hybrid(other.m_hybrid),
+	m_path(other.m_path) { }
 
 SvgIdLayer * SvgIdLayer::copyLayer() {
-	SvgIdLayer * toSvgIdLayer = new SvgIdLayer(m_viewID);
-	*toSvgIdLayer = *this;
-	return toSvgIdLayer;
+    return new SvgIdLayer(*this);
 }
 
 QPointF SvgIdLayer::point(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
     if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.point;
+        return m_pointRectBottom.getPoint();
     } else {
-        return m_pointRectTop.point;
+        return m_pointRectTop.getPoint();
     }
 }
 
 QRectF SvgIdLayer::rect(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
 	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.rect;
+        return m_pointRectBottom.getRect();
     } else {
-        return m_pointRectTop.rect;
+        return m_pointRectTop.getRect();
     }
 }
 
 bool SvgIdLayer::processed(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
 	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.processed;
+        return m_pointRectBottom.isProcessed();
     } else {
-	    return m_pointRectTop.processed;
+        return m_pointRectTop.isProcessed();
     }
 }
 
 bool SvgIdLayer::svgVisible(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
 	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.svgVisible;
+        return m_pointRectBottom.isSvgVisible();
     } else {
-	    return m_pointRectTop.svgVisible;
+	    return m_pointRectTop.isSvgVisible();
     }
 }
 
-void PointRect::unprocess() {
-    processed = false;
-}
-
-void PointRect::setInvisible() {
-    svgVisible = false;
-    processed = true;
-}
-PointRect::PointRect() { }
-PointRect::PointRect(bool _svgVisible, bool _processed, QRectF _rect, QPointF _point) : 
-    rect(_rect), 
-    point(_point),
-    processed(_processed),
-    svgVisible(_svgVisible) { }
-
-PointRect::PointRect(const PointRect& other) : rect(other.rect), point(other.point), processed(other.processed), svgVisible(other.svgVisible) { }
-
-void SvgIdLayer::unprocess() {
-    m_pointRectTop.unprocess();
-    m_pointRectBottom.unprocess();
-}
-
-void SvgIdLayer::setInvisible(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        m_pointRectBottom.setInvisible();
-	} else {
-        m_pointRectTop.setInvisible();
-    }
-}
 
 void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, const PointRect& other) {
     if (viewLayerPlacement == ViewLayer::NewBottom) {
@@ -99,4 +95,18 @@ void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, 
 }
 void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, QPointF point, QRectF rect, bool svgVisible) {
     setPointRect(viewLayerPlacement, PointRect(svgVisible, true, rect, point));
+}
+
+void PointRect::unprocess() noexcept {
+    processed = false;
+}
+
+void PointRect::setInvisible() noexcept {
+    svgVisible = false;
+    processed = true;
+}
+
+void SvgIdLayer::unprocess() noexcept {
+    m_pointRectTop.unprocess();
+    m_pointRectBottom.unprocess();
 }

--- a/src/connectors/svgidlayer.cpp
+++ b/src/connectors/svgidlayer.cpp
@@ -21,7 +21,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "svgidlayer.h"
 
 SvgIdLayer::SvgIdLayer(ViewLayer::ViewID viewID) : 
-    m_viewID(viewID),
+	m_viewID(viewID),
 	m_svgViewLayerID(),
 	m_svgId(),
 	m_terminalId(),
@@ -36,7 +36,7 @@ SvgIdLayer::SvgIdLayer(ViewLayer::ViewID viewID) :
 { }
 
 SvgIdLayer::SvgIdLayer(const SvgIdLayer& other) : 
-    m_viewID(other.m_viewID),
+	m_viewID(other.m_viewID),
 	m_svgViewLayerID(other.m_svgViewLayerID),
 	m_svgId(other.m_svgId),
 	m_terminalId(other.m_terminalId),
@@ -50,63 +50,51 @@ SvgIdLayer::SvgIdLayer(const SvgIdLayer& other) :
 	m_path(other.m_path) { }
 
 SvgIdLayer * SvgIdLayer::copyLayer() {
-    return new SvgIdLayer(*this);
+	return new SvgIdLayer(*this);
 }
 
 QPointF SvgIdLayer::point(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-    if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.getPoint();
-    } else {
-        return m_pointRectTop.getPoint();
-    }
+	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.getPoint();
+	return m_pointRectTop.getPoint();
 }
 
 QRectF SvgIdLayer::rect(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.getRect();
-    } else {
-        return m_pointRectTop.getRect();
-    }
+	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.getRect();
+	return m_pointRectTop.getRect();
 }
 
 bool SvgIdLayer::processed(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.isProcessed();
-    } else {
-        return m_pointRectTop.isProcessed();
-    }
+	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.isProcessed();
+	return m_pointRectTop.isProcessed();
 }
 
 bool SvgIdLayer::svgVisible(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
-	if (viewLayerPlacement == ViewLayer::NewBottom) {
-        return m_pointRectBottom.isSvgVisible();
-    } else {
+	if (viewLayerPlacement == ViewLayer::NewBottom) return m_pointRectBottom.isSvgVisible();
 	    return m_pointRectTop.isSvgVisible();
-    }
 }
 
 
 void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, const PointRect& other) {
-    if (viewLayerPlacement == ViewLayer::NewBottom) {
-        m_pointRectBottom = other;
-    } else {
-        m_pointRectTop = other;
-    }
+	if (viewLayerPlacement == ViewLayer::NewBottom) {
+		m_pointRectBottom = other;
+	} else {
+		m_pointRectTop = other;
+	}
 }
 void SvgIdLayer::setPointRect(ViewLayer::ViewLayerPlacement viewLayerPlacement, QPointF point, QRectF rect, bool svgVisible) {
-    setPointRect(viewLayerPlacement, PointRect(svgVisible, true, rect, point));
+	setPointRect(viewLayerPlacement, PointRect(svgVisible, true, rect, point));
 }
 
 void PointRect::unprocess() noexcept {
-    processed = false;
+	processed = false;
 }
 
 void PointRect::setInvisible() noexcept {
-    svgVisible = false;
-    processed = true;
+	svgVisible = false;
+	processed = true;
 }
 
 void SvgIdLayer::unprocess() noexcept {
-    m_pointRectTop.unprocess();
-    m_pointRectBottom.unprocess();
+	m_pointRectTop.unprocess();
+	m_pointRectBottom.unprocess();
 }

--- a/src/connectors/svgidlayer.h
+++ b/src/connectors/svgidlayer.h
@@ -26,47 +26,69 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../viewlayer.h"
 
 
-struct PointRect {
-	QRectF rect;
-	QPointF point;
-	bool processed = false;
-	bool svgVisible = false;
-
-    void unprocess();
-    void setInvisible();
-    PointRect();
-    PointRect(bool svgVisible, bool processed, QRectF, QPointF);
-    PointRect(const PointRect& other);
+class PointRect {
+    public:
+        PointRect() = default;
+        PointRect(bool _svgVisible, bool _processed, QRectF _rect, QPointF _point) noexcept : 
+            rect(_rect),
+            point(_point),
+            processed(_processed),
+            svgVisible(_svgVisible) { }
+        PointRect(const PointRect& other);
+        void unprocess() noexcept;
+        void setInvisible() noexcept;
+        constexpr QPointF getPoint() const noexcept { return point; }
+        constexpr QRectF getRect() const noexcept { return rect; }
+        constexpr bool isProcessed() const noexcept { return processed; }
+        constexpr bool isSvgVisible() const noexcept { return svgVisible; }
+        void setPoint(QPointF other) noexcept {
+            this->point = other;
+        }
+        void setRect(QRectF other) noexcept {
+            this->rect = other;
+        }
+    private:
+        QRectF rect;
+        QPointF point;
+        bool processed = false;
+        bool svgVisible = false;
 };
 
 class SvgIdLayer
 {
 public:
 	SvgIdLayer(ViewLayer::ViewID);
+    SvgIdLayer(const SvgIdLayer&);
 	SvgIdLayer * copyLayer();
 
 	QPointF point(ViewLayer::ViewLayerPlacement);
 	QRectF rect(ViewLayer::ViewLayerPlacement);
 	bool processed(ViewLayer::ViewLayerPlacement);
 	bool svgVisible(ViewLayer::ViewLayerPlacement);
-	void unprocess();
-	void setInvisible(ViewLayer::ViewLayerPlacement);
+	void unprocess() noexcept;
+	inline void setInvisible(ViewLayer::ViewLayerPlacement placement) noexcept {
+        if (placement == ViewLayer::ViewLayerPlacement::NewBottom) {
+            m_pointRectBottom.setInvisible();
+        } else {
+            m_pointRectTop.setInvisible();
+        }
+    }
 	void setPointRect(ViewLayer::ViewLayerPlacement, QPointF, QRectF, bool svgVisible);
     void setPointRect(ViewLayer::ViewLayerPlacement, const PointRect& newPointRect);
 
 public:
 	ViewLayer::ViewID m_viewID;
+	ViewLayer::ViewLayerID m_svgViewLayerID;
 	QString m_svgId;
 	QString m_terminalId;
-	ViewLayer::ViewLayerID m_svgViewLayerID;
 	QString m_legId;
 	QString m_legColor;
 	QLineF m_legLine;
-	double m_radius = 0.0;
-	double m_strokeWidth = 0.0;
-	double m_legStrokeWidth = 0.0;
-	bool m_hybrid = false;
-	bool m_path = false;
+	double m_radius;
+	double m_strokeWidth;
+	double m_legStrokeWidth;
+	bool m_hybrid;
+	bool m_path;
 
 protected:
 	PointRect m_pointRectBottom;

--- a/src/connectors/svgidlayer.h
+++ b/src/connectors/svgidlayer.h
@@ -29,8 +29,14 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 struct PointRect {
 	QRectF rect;
 	QPointF point;
-	bool processed;
-	bool svgVisible;
+	bool processed = false;
+	bool svgVisible = false;
+
+    void unprocess();
+    void setInvisible();
+    PointRect();
+    PointRect(bool svgVisible, bool processed, QRectF, QPointF);
+    PointRect(const PointRect& other);
 };
 
 class SvgIdLayer
@@ -46,26 +52,25 @@ public:
 	void unprocess();
 	void setInvisible(ViewLayer::ViewLayerPlacement);
 	void setPointRect(ViewLayer::ViewLayerPlacement, QPointF, QRectF, bool svgVisible);
+    void setPointRect(ViewLayer::ViewLayerPlacement, const PointRect& newPointRect);
 
 public:
+	ViewLayer::ViewID m_viewID;
 	QString m_svgId;
 	QString m_terminalId;
-	ViewLayer::ViewID m_viewID;
 	ViewLayer::ViewLayerID m_svgViewLayerID;
-	bool m_hybrid;
-	double m_radius;
-	double m_strokeWidth;
 	QString m_legId;
 	QString m_legColor;
-	double m_legStrokeWidth;
 	QLineF m_legLine;
-	bool m_path;
+	double m_radius = 0.0;
+	double m_strokeWidth = 0.0;
+	double m_legStrokeWidth = 0.0;
+	bool m_hybrid = false;
+	bool m_path = false;
 
 protected:
 	PointRect m_pointRectBottom;
 	PointRect m_pointRectTop;
-
-protected:
 };
 
 

--- a/src/connectors/svgidlayer.h
+++ b/src/connectors/svgidlayer.h
@@ -27,38 +27,38 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 
 class PointRect {
-    public:
-        PointRect() = default;
-        PointRect(bool _svgVisible, bool _processed, QRectF _rect, QPointF _point) noexcept : 
-            rect(_rect),
-            point(_point),
-            processed(_processed),
-            svgVisible(_svgVisible) { }
-        PointRect(const PointRect& other);
-        void unprocess() noexcept;
-        void setInvisible() noexcept;
-        constexpr QPointF getPoint() const noexcept { return point; }
-        constexpr QRectF getRect() const noexcept { return rect; }
-        constexpr bool isProcessed() const noexcept { return processed; }
-        constexpr bool isSvgVisible() const noexcept { return svgVisible; }
-        void setPoint(QPointF other) noexcept {
-            this->point = other;
-        }
-        void setRect(QRectF other) noexcept {
-            this->rect = other;
-        }
-    private:
-        QRectF rect;
-        QPointF point;
-        bool processed = false;
-        bool svgVisible = false;
+	public:
+		PointRect() = default;
+		PointRect(bool _svgVisible, bool _processed, QRectF _rect, QPointF _point) noexcept : 
+			rect(_rect),
+			point(_point),
+			processed(_processed),
+			svgVisible(_svgVisible) { }
+		PointRect(const PointRect& other);
+		void unprocess() noexcept;
+		void setInvisible() noexcept;
+		constexpr QPointF getPoint() const noexcept { return point; }
+		constexpr QRectF getRect() const noexcept { return rect; }
+		constexpr bool isProcessed() const noexcept { return processed; }
+		constexpr bool isSvgVisible() const noexcept { return svgVisible; }
+		void setPoint(QPointF other) noexcept {
+			this->point = other;
+		}
+		void setRect(QRectF other) noexcept {
+			this->rect = other;
+		}
+	private:
+		QRectF rect;
+		QPointF point;
+		bool processed = false;
+		bool svgVisible = false;
 };
 
 class SvgIdLayer
 {
 public:
 	SvgIdLayer(ViewLayer::ViewID);
-    SvgIdLayer(const SvgIdLayer&);
+	SvgIdLayer(const SvgIdLayer&);
 	SvgIdLayer * copyLayer();
 
 	QPointF point(ViewLayer::ViewLayerPlacement);
@@ -67,14 +67,14 @@ public:
 	bool svgVisible(ViewLayer::ViewLayerPlacement);
 	void unprocess() noexcept;
 	inline void setInvisible(ViewLayer::ViewLayerPlacement placement) noexcept {
-        if (placement == ViewLayer::ViewLayerPlacement::NewBottom) {
-            m_pointRectBottom.setInvisible();
-        } else {
-            m_pointRectTop.setInvisible();
-        }
-    }
+		if (placement == ViewLayer::ViewLayerPlacement::NewBottom) {
+			m_pointRectBottom.setInvisible();
+		} else {
+			m_pointRectTop.setInvisible();
+		}
+	}
 	void setPointRect(ViewLayer::ViewLayerPlacement, QPointF, QRectF, bool svgVisible);
-    void setPointRect(ViewLayer::ViewLayerPlacement, const PointRect& newPointRect);
+	void setPointRect(ViewLayer::ViewLayerPlacement, const PointRect& newPointRect);
 
 public:
 	ViewLayer::ViewID m_viewID;

--- a/src/dock/layerpalette.cpp
+++ b/src/dock/layerpalette.cpp
@@ -23,48 +23,33 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QAction>
 
 
-ViewLayerCheckBox::ViewLayerCheckBox(QWidget * parent) : QCheckBox(parent) {
-}
-
-
-ViewLayerCheckBox::~ViewLayerCheckBox()
-{
-}
-
-void ViewLayerCheckBox::setViewLayer(ViewLayer * viewLayer)
-{
-	m_viewLayer = viewLayer;
-}
-
-ViewLayer * ViewLayerCheckBox::viewLayer() {
-	return m_viewLayer;
-}
-
+ViewLayerCheckBox::ViewLayerCheckBox(QWidget * parent) : QCheckBox(parent), m_viewLayer(nullptr) { } 
 //////////////////////////////////////
 
-LayerPalette::LayerPalette(QWidget * parent) : QScrollArea(parent)
+LayerPalette::LayerPalette(QWidget * parent) : QScrollArea(parent),
+    m_showAllWidget(new QCheckBox(tr("show all layers"))),
+    m_checkBoxes(),
+    m_mainLayout(new QVBoxLayout()),
+    m_groupBox(new QGroupBox("")),
+    m_showAllLayersAct(nullptr),
+    m_hideAllLayersAct(nullptr)
 {
 
-	m_hideAllLayersAct = m_showAllLayersAct = NULL;
-
-	QFrame * frame = new QFrame(this);
-
-	m_mainLayout = new QVBoxLayout();
+	auto frame = new QFrame(this);
+    
 	m_mainLayout->setSizeConstraint( QLayout::SetMinAndMaxSize );
-	m_mainLayout -> setObjectName("LayerWindowFrame");
+	m_mainLayout->setObjectName("LayerWindowFrame");
 	for (int i = 0; i < ViewLayer::ViewLayerCount; i++) {
-		ViewLayerCheckBox * cb = new ViewLayerCheckBox(this);
+		auto cb = new ViewLayerCheckBox(this);
 		connect(cb, SIGNAL(clicked(bool)), this, SLOT(setLayerVisibility(bool)));
 		m_checkBoxes.append(cb);
 		cb -> setObjectName("LayerCheckBox");
 		cb->setVisible(false);
 	}
 
-	m_groupBox = new QGroupBox("");
 	m_groupBox -> setObjectName("LayerWindowList");
-	QVBoxLayout * groupLayout = new QVBoxLayout();
+	auto groupLayout = new QVBoxLayout();
 	groupLayout -> setObjectName("LayerWindowBoxes");
-	m_showAllWidget = new QCheckBox(tr("show all layers"));
 	connect(m_showAllWidget, SIGNAL(clicked(bool)), this, SLOT(setAllLayersVisible(bool)));
 
 	groupLayout->addWidget(m_showAllWidget);
@@ -78,10 +63,6 @@ LayerPalette::LayerPalette(QWidget * parent) : QScrollArea(parent)
 	this->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	this->setWidget(frame);
 
-}
-
-LayerPalette::~LayerPalette()
-{
 }
 
 void LayerPalette::resetLayout(LayerHash & viewLayers, LayerList & keys) {
@@ -126,7 +107,7 @@ void LayerPalette::updateLayerPalette(LayerHash & viewLayers, LayerList & keys)
 
 void LayerPalette::setLayerVisibility(bool) {
 	ViewLayerCheckBox * cb = qobject_cast<ViewLayerCheckBox *>(sender());
-	if (cb == NULL) return;
+	if (!cb) return;
 
 	// want to toggle layer individually in this case
 	cb->viewLayer()->setIncludeChildLayers(false);

--- a/src/dock/layerpalette.cpp
+++ b/src/dock/layerpalette.cpp
@@ -26,13 +26,14 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 ViewLayerCheckBox::ViewLayerCheckBox(QWidget * parent) : QCheckBox(parent), m_viewLayer(nullptr) { } 
 //////////////////////////////////////
 
-LayerPalette::LayerPalette(QWidget * parent) : QScrollArea(parent),
-    m_showAllWidget(new QCheckBox(tr("show all layers"))),
-    m_checkBoxes(),
-    m_mainLayout(new QVBoxLayout()),
-    m_groupBox(new QGroupBox("")),
-    m_showAllLayersAct(nullptr),
-    m_hideAllLayersAct(nullptr)
+LayerPalette::LayerPalette(QWidget * parent) 
+	: QScrollArea(parent),
+	m_showAllWidget(new QCheckBox(tr("show all layers"))),
+	m_checkBoxes(),
+	m_mainLayout(new QVBoxLayout()),
+	m_groupBox(new QGroupBox("")),
+	m_showAllLayersAct(nullptr),
+	m_hideAllLayersAct(nullptr)
 {
 
 	auto frame = new QFrame(this);

--- a/src/dock/layerpalette.h
+++ b/src/dock/layerpalette.h
@@ -35,11 +35,11 @@ class ViewLayerCheckBox : public QCheckBox
 {
 	Q_OBJECT
 public:
-	ViewLayerCheckBox(QWidget * parent = NULL);
-	~ViewLayerCheckBox();
+	ViewLayerCheckBox(QWidget * parent = nullptr);
+	~ViewLayerCheckBox() = default;
 
-	void setViewLayer(ViewLayer *);
-	ViewLayer * viewLayer();
+	void setViewLayer(ViewLayer * vl) noexcept { m_viewLayer = vl; }
+	ViewLayer * viewLayer() const noexcept { return m_viewLayer; }
 
 protected:
 	ViewLayer * m_viewLayer;
@@ -49,8 +49,8 @@ class LayerPalette : public QScrollArea
 {
 	Q_OBJECT
 public:
-	LayerPalette(QWidget * parent = NULL);
-	~LayerPalette();
+	LayerPalette(QWidget * parent = nullptr);
+	~LayerPalette() = default;
 
 	void updateLayerPalette(LayerHash & viewLayers, LayerList & keys);
 	void resetLayout(LayerHash & viewLayers, LayerList & keys);

--- a/src/items/wire.cpp
+++ b/src/items/wire.cpp
@@ -88,11 +88,11 @@ QStringList Wire::colorNames;
 QHash<int, QString> Wire::widthTrans;
 QList<int> Wire::widths;
 QList<QColor> Wire::lengthColorTrans;
-double Wire::STANDARD_TRACE_WIDTH;
-double Wire::HALF_STANDARD_TRACE_WIDTH;
-double Wire::THIN_TRACE_WIDTH;
+double Wire::STANDARD_TRACE_WIDTH = 0.0;
+double Wire::HALF_STANDARD_TRACE_WIDTH = 0.0;
+double Wire::THIN_TRACE_WIDTH = 0.0;
 
-const double DefaultHoverStrokeWidth = 4;
+constexpr double DefaultHoverStrokeWidth = 4;
 
 static Bezier UndoBezier;
 static BezierDisplay * TheBezierDisplay = NULL;

--- a/src/layerattributes.cpp
+++ b/src/layerattributes.cpp
@@ -21,22 +21,8 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "layerattributes.h"
 #include "debugdialog.h"
 
-LayerAttributes::LayerAttributes()
-{
-	orientation = Qt::Vertical;
-	createShape = true;
-}
-
-const QString & LayerAttributes::filename() {
-	return m_filename;
-}
-
 void LayerAttributes::setFilename(const QString & filename) {
 	m_filename = filename;
-}
-
-const QByteArray & LayerAttributes::loaded() const {
-	return m_loaded;
 }
 
 void LayerAttributes::clearLoaded() {

--- a/src/layerattributes.h
+++ b/src/layerattributes.h
@@ -31,7 +31,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 class LayerAttributes {
 
 public:
-	LayerAttributes() noexcept : orientation(Qt::Vertical), createShape(true), doConnectors(false) { }
+	LayerAttributes() noexcept = default;
 	const QString & filename() const noexcept { return m_filename; }
 	void setFilename(const QString &);
 	const QByteArray & loaded() const noexcept { return m_loaded; }
@@ -40,13 +40,13 @@ public:
 
 
 public:
-	Qt::Orientations orientation;
-	bool createShape;
-	bool doConnectors;
+	Qt::Orientations orientation = Qt::Vertical;
+	bool createShape = true;
+	bool doConnectors = false;
 	QString error;
-	ViewLayer::ViewID viewID;
-	ViewLayer::ViewLayerID viewLayerID;
-	ViewLayer::ViewLayerPlacement viewLayerPlacement;
+	ViewLayer::ViewID viewID = ViewLayer::ViewID::UnknownView;
+	ViewLayer::ViewLayerID viewLayerID = ViewLayer::ViewLayerID::UnknownLayer;
+	ViewLayer::ViewLayerPlacement viewLayerPlacement = ViewLayer::ViewLayerPlacement::UnknownPlacement;
 protected:
 	QString m_filename;
 	QByteArray m_loaded;

--- a/src/layerattributes.h
+++ b/src/layerattributes.h
@@ -31,26 +31,25 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 class LayerAttributes {
 
 public:
-	LayerAttributes();
-
-	const QString & filename();
+	LayerAttributes() noexcept : orientation(Qt::Vertical), createShape(true), doConnectors(false) { }
+	const QString & filename() const noexcept { return m_filename; }
 	void setFilename(const QString &);
-	const QByteArray & loaded() const;
+	const QByteArray & loaded() const noexcept { return m_loaded; }
 	void clearLoaded();
 	void setLoaded(const QByteArray &);
 
-protected:
-	QString m_filename;
-	QByteArray m_loaded;
 
 public:
+	Qt::Orientations orientation;
+	bool createShape;
+	bool doConnectors;
 	QString error;
 	ViewLayer::ViewID viewID;
 	ViewLayer::ViewLayerID viewLayerID;
 	ViewLayer::ViewLayerPlacement viewLayerPlacement;
-	bool doConnectors;
-	Qt::Orientations orientation;
-	bool createShape;
+protected:
+	QString m_filename;
+	QByteArray m_loaded;
 };
 
 #endif

--- a/src/lib/quazip/quazipfile.h
+++ b/src/lib/quazip/quazipfile.h
@@ -71,16 +71,16 @@ QuaZIP as long as you respect either GPL or LGPL for QuaZIP code.
 class QuaZipFile: public QIODevice {
 	Q_OBJECT
 private:
-	QuaZip *zip;
+	QuaZip *zip = nullptr;
 	QString fileName;
-	QuaZip::CaseSensitivity caseSensitivity;
-	bool raw;
-	qint64 writePos;
+	QuaZip::CaseSensitivity caseSensitivity = QuaZip::CaseSensitivity::csDefault;
+	bool raw = false;
+	qint64 writePos = 0;
 	// these two are for writing raw files
-	ulong uncompressedSize;
-	quint32 crc;
-	bool internal;
-	int zipError;
+	ulong uncompressedSize = 0l;
+	quint32 crc = 0;
+	bool internal = false;
+	int zipError = 0;
 	// these are not supported nor implemented
 	QuaZipFile(const QuaZipFile& that);
 	QuaZipFile& operator=(const QuaZipFile& that);

--- a/src/lib/quazip/quazipnewinfo.h
+++ b/src/lib/quazip/quazipnewinfo.h
@@ -56,9 +56,9 @@ struct QuaZipNewInfo {
 	 **/
 	QDateTime dateTime;
 	/// File internal attributes.
-	quint16 internalAttr;
+	quint16 internalAttr = 0;
 	/// File external attributes.
-	quint32 externalAttr;
+	quint32 externalAttr = 0;
 	/// File comment.
 	/** Will be encoded using QuaZip::getCommentCodec().
 	 **/
@@ -71,7 +71,7 @@ struct QuaZipNewInfo {
 	/** This is only needed if you are using raw file zipping mode, i. e.
 	 * adding precompressed file in the zip archive.
 	 **/
-	ulong uncompressedSize;
+	ulong uncompressedSize = 0;
 	/// Constructs QuaZipNewInfo instance.
 	/** Initializes name with \a name, dateTime with current date and
 	 * time. Attributes are initialized with zeros, comment and extra

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,26 +51,12 @@ void writeCrashMessage(const QString & msg) {
 	writeCrashMessage(msg.toStdString().c_str());
 }
 
-void fMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString & msg)
+void fMessageHandler(QtMsgType type, const QMessageLogContext & context, const QString & msg)
 {
-	switch (type) {
-		case QtDebugMsg:
-            originalMsgHandler(type, context, msg);
-			break;
-		case QtWarningMsg:
-		originalMsgHandler(type, context, msg);
-			break;
-		case QtCriticalMsg:
-		originalMsgHandler(type, context, msg);
-			break;
-		case QtFatalMsg:
-			{
-				writeCrashMessage(msg);
-			}
-
-			// don't abort
-			originalMsgHandler(QtWarningMsg, context, msg);
+	if (type == QtFatalMsg) {
+		writeCrashMessage(msg);
 	}
+	originalMsgHandler(type, context, msg);
 }
 
 

--- a/src/mainwindow/sketchareawidget.h
+++ b/src/mainwindow/sketchareawidget.h
@@ -28,6 +28,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QStatusBar>
 #include <QMainWindow>
 
+class ExpandingLabel;
 class SketchAreaWidget : public QFrame {
 	Q_OBJECT
 public:
@@ -52,14 +53,14 @@ public:
 	static const QString RoutingStateLabelName;
 
 protected:
-	QWidget *m_contentView;
+	QWidget *m_contentView = nullptr;
 
-	QFrame *m_toolbar;
-	QHBoxLayout *m_leftButtonsContainer;
-	QVBoxLayout *m_middleButtonsContainer;
-	QHBoxLayout *m_rightButtonsContainer;
-	QFrame *m_statusBarArea;
-	class ExpandingLabel * m_routingStatusLabel;
+	QFrame *m_toolbar = nullptr;
+	QHBoxLayout *m_leftButtonsContainer = nullptr;
+	QVBoxLayout *m_middleButtonsContainer = nullptr;
+	QHBoxLayout *m_rightButtonsContainer = nullptr;
+	QFrame *m_statusBarArea = nullptr;
+	ExpandingLabel * m_routingStatusLabel = nullptr;
 
 };
 

--- a/src/partsbinpalette/graphicsflowlayout.cpp
+++ b/src/partsbinpalette/graphicsflowlayout.cpp
@@ -25,7 +25,8 @@ constexpr auto SpaceBefore = 5;
 constexpr auto SpaceAfter = 3;
 
 GraphicsFlowLayout::GraphicsFlowLayout(QGraphicsLayoutItem *parent, int spacing)
-	: QGraphicsLinearLayout(parent), m_lastWidth(0.0)
+	: QGraphicsLinearLayout(parent), 
+	m_lastWidth(0.0)
 {
 	setSpacing(spacing);
 }
@@ -45,9 +46,9 @@ int GraphicsFlowLayout::heightForWidth(int width) {
 
 
 int GraphicsFlowLayout::doLayout(const QRectF &rect) {
-    auto x = rect.x();
-    auto y = rect.y();
-    auto lineHeight = 0.0;
+	auto x = rect.x();
+	auto y = rect.y();
+	auto lineHeight = 0.0;
 
 	for(int i=0; i < count(); ++i) {
 		QGraphicsLayoutItem* item = itemAt(i);

--- a/src/partsbinpalette/graphicsflowlayout.cpp
+++ b/src/partsbinpalette/graphicsflowlayout.cpp
@@ -21,11 +21,11 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "graphicsflowlayout.h"
 #include "../utils/misc.h"
 
-static const int SpaceBefore = 5;
-static const int SpaceAfter = 3;
+constexpr auto SpaceBefore = 5;
+constexpr auto SpaceAfter = 3;
 
 GraphicsFlowLayout::GraphicsFlowLayout(QGraphicsLayoutItem *parent, int spacing)
-	: QGraphicsLinearLayout(parent)
+	: QGraphicsLinearLayout(parent), m_lastWidth(0.0)
 {
 	setSpacing(spacing);
 }
@@ -40,19 +40,18 @@ void GraphicsFlowLayout::setGeometry(const QRectF &rect) {
 }
 
 int GraphicsFlowLayout::heightForWidth(int width) {
-	int height = doLayout(QRectF(0, 0, width, 0));
-	return height;
+	return doLayout(QRectF(0, 0, width, 0));
 }
 
 
 int GraphicsFlowLayout::doLayout(const QRectF &rect) {
-	double x = rect.x();
-	double y = rect.y();
-	double lineHeight = 0;
+    auto x = rect.x();
+    auto y = rect.y();
+    auto lineHeight = 0.0;
 
-	for(int i=0; i < count(); i++) {
+	for(int i=0; i < count(); ++i) {
 		QGraphicsLayoutItem* item = itemAt(i);
-		int nextX = x + item->preferredSize().width() + spacing();
+		auto nextX = x + item->preferredSize().width() + spacing();
 
 		if (item->sizePolicy().horizontalPolicy() == QSizePolicy::Expanding) {
 			int myY = y + lineHeight + spacing() + SpaceBefore;
@@ -83,7 +82,7 @@ int GraphicsFlowLayout::doLayout(const QRectF &rect) {
 
 void GraphicsFlowLayout::clear() {
 	QList<QGraphicsLayoutItem*> itemsToRemove;
-	for(int i=0; i < count(); i++) {
+	for(int i=0; i < count(); ++i) {
 		itemsToRemove << itemAt(i);
 	}
 
@@ -93,7 +92,7 @@ void GraphicsFlowLayout::clear() {
 }
 
 int GraphicsFlowLayout::indexOf(const QGraphicsLayoutItem *item) {
-	for(int i=0; i < count(); i++) {
+	for(int i=0; i < count(); ++i) {
 		if(itemAt(i) == item) return i;
 	}
 	return -1;

--- a/src/partsbinpalette/graphicsflowlayout.cpp
+++ b/src/partsbinpalette/graphicsflowlayout.cpp
@@ -55,7 +55,7 @@ int GraphicsFlowLayout::doLayout(const QRectF &rect) {
 		auto nextX = x + item->preferredSize().width() + spacing();
 
 		if (item->sizePolicy().horizontalPolicy() == QSizePolicy::Expanding) {
-			int myY = y + lineHeight + spacing() + SpaceBefore;
+			auto myY = y + lineHeight + spacing() + SpaceBefore;
 			QRectF r(QPoint(rect.x(), myY), item->preferredSize());
 			item->setGeometry(r);
 			x = rect.x();

--- a/src/partsbinpalette/partsbiniconview.cpp
+++ b/src/partsbinpalette/partsbiniconview.cpp
@@ -42,17 +42,13 @@ PartsBinIconView::PartsBinIconView(ReferenceModel* referenceModel, PartsBinPalet
 	setAlignment(Qt::AlignLeft | Qt::AlignTop);
 	setAcceptDrops(true);
 
-	QGraphicsScene* scene = new QGraphicsScene(this);
-	this->setScene(scene);
+	this->setScene(new QGraphicsScene(this));
 
-	m_layouter = NULL;
-	m_layout = NULL;
 	setupLayout();
 
 	//connect(scene, SIGNAL(selectionChanged()), this, SLOT(informNewSelection()));
 	//connect(scene, SIGNAL(changed(const QList<QRectF>&)), this, SLOT(informNewSelection()));
 
-	m_noSelectionChangeEmition = false;
 	setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
 	setContextMenuPolicy(Qt::CustomContextMenu);
@@ -95,13 +91,13 @@ void PartsBinIconView::resizeEvent(QResizeEvent * event) {
 
 void PartsBinIconView::mousePressEvent(QMouseEvent *event) {
 	SvgIconWidget* icon = svgIconWidgetAt(event->pos());
-	if (icon == NULL || event->button() != Qt::LeftButton) {
+	if (!icon || event->button() != Qt::LeftButton) {
 		QGraphicsView::mousePressEvent(event);
-		if (icon == NULL) {
-			viewItemInfo(NULL);
+		if (!icon ) {
+			viewItemInfo(nullptr);
 		}
 	} else {
-		if (icon != NULL) {
+		if (icon) {
 			QList<QGraphicsItem *> items = scene()->selectedItems();
 			for (int i = 0; i < items.count(); i++) {
 				// not sure why clearSelection doesn't do the update, but whatever...
@@ -120,7 +116,7 @@ void PartsBinIconView::mousePressEvent(QMouseEvent *event) {
 			mousePressOnItem(event->pos(), moduleID, icon->rect().size().toSize(), (mts - icon->pos()), hotspot );
 		}
 		else {
-			viewItemInfo(NULL);
+			viewItemInfo(nullptr);
 		}
 	}
 	informNewSelection();
@@ -141,7 +137,7 @@ void PartsBinIconView::addPart(ModelPart * model, int position) {
 }
 
 void PartsBinIconView::removePart(const QString &moduleID) {
-	SvgIconWidget *itemToRemove = NULL;
+	SvgIconWidget *itemToRemove = nullptr;
 	int position = 0;
 	foreach(QGraphicsItem *gIt, m_layouter->childItems()) {
 		SvgIconWidget *it = dynamic_cast<SvgIconWidget*>(gIt);
@@ -154,7 +150,7 @@ void PartsBinIconView::removePart(const QString &moduleID) {
 	}
 	if(itemToRemove) {
 		m_itemBaseHash.remove(moduleID);
-		itemToRemove->setParentItem(NULL);
+		itemToRemove->setParentItem(nullptr);
 		m_noSelectionChangeEmition = true;
 		m_layout->removeItem(itemToRemove);
 		delete itemToRemove;
@@ -176,7 +172,7 @@ void PartsBinIconView::removeParts() {
 
 	foreach (SvgIconWidget * itemToRemove, itemsToRemove) {
 		m_noSelectionChangeEmition = true;
-		itemToRemove->setParentItem(NULL);
+		itemToRemove->setParentItem(nullptr);
 		m_layout->removeItem(itemToRemove);
 		delete itemToRemove;
 	}
@@ -196,14 +192,14 @@ int PartsBinIconView::setItemAux(ModelPart * modelPart, int position) {
 		return position;
 	}
 
-	SvgIconWidget* svgicon = NULL;
+	SvgIconWidget* svgicon = nullptr;
 	if (modelPart->itemType() != ModelPart::Space) {
 		ItemBase::PluralType plural;
 		ItemBase * itemBase = loadItemBase(moduleID, plural);
 		svgicon = new SvgIconWidget(modelPart, ViewLayer::IconView, itemBase, plural == ItemBase::Plural);
 	}
 	else {
-		svgicon = new SvgIconWidget(modelPart, ViewLayer::IconView, NULL, false);
+		svgicon = new SvgIconWidget(modelPart, ViewLayer::IconView, nullptr, false);
 	}
 
 
@@ -228,7 +224,7 @@ void PartsBinIconView::loadFromModel(PaletteModel * model) {
 	QList<QObject *>::const_iterator i;
 	for (i = root->children().constBegin(); i != root->children().constEnd(); ++i) {
 		ModelPart* mp = qobject_cast<ModelPart *>(*i);
-		if (mp == NULL) continue;
+        if (!mp) continue;
 
 		QDomElement instance = mp->instanceDomElement();
 		if (instance.isNull()) continue;
@@ -252,7 +248,7 @@ ModelPart *PartsBinIconView::selectedModelPart() {
 	if(icon) {
 		return icon->modelPart();
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -261,7 +257,7 @@ ItemBase *PartsBinIconView::selectedItemBase() {
 	if(icon) {
 		return icon->itemBase();
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -367,7 +363,7 @@ bool PartsBinIconView::inEmptyArea(const QPoint& pos) {
 
 QGraphicsWidget* PartsBinIconView::closestItemTo(const QPoint& pos) {
 	QPointF realPos = mapToScene(pos);
-	SvgIconWidget *item = NULL;
+	SvgIconWidget *item = nullptr;
 	this -> setObjectName("partsIcon");
 	if((item = svgIconWidgetAt(realPos.x()+ICON_SPACING,realPos.y()+ICON_SPACING))) {
 		return item;
@@ -381,7 +377,7 @@ QGraphicsWidget* PartsBinIconView::closestItemTo(const QPoint& pos) {
 	if((item = svgIconWidgetAt(realPos.x()-ICON_SPACING,realPos.y()-ICON_SPACING))) {
 		return item;
 	}
-	return NULL;
+	return nullptr;
 }
 
 QList<QObject*> PartsBinIconView::orderedChildren() {
@@ -416,16 +412,16 @@ SvgIconWidget * PartsBinIconView::svgIconWidgetAt(int x, int y) {
 
 SvgIconWidget * PartsBinIconView::svgIconWidgetAt(const QPoint & pos) {
 	QGraphicsItem * item = itemAt(pos);
-	while (item != NULL) {
+    while (item) {
 		SvgIconWidget * svgIconWidget = dynamic_cast<SvgIconWidget *>(item);
-		if (svgIconWidget != NULL) {
+        if (svgIconWidget) {
 			return svgIconWidget;
 		}
 
 		item = item->parentItem();
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void PartsBinIconView::reloadPart(const QString & moduleID) {
@@ -433,7 +429,8 @@ void PartsBinIconView::reloadPart(const QString & moduleID) {
 
 	for (int i = 0; i < m_layout->count(); i++) {
 		SvgIconWidget *it = dynamic_cast<SvgIconWidget*>(m_layout->itemAt(i));
-		if (it == NULL) continue;
+        if (!it) 
+            continue;
 
 		if (it->itemBase()->moduleID().compare(moduleID) != 0) continue;
 
@@ -448,8 +445,8 @@ void PartsBinIconView::reloadPart(const QString & moduleID) {
 ItemBase * PartsBinIconView::loadItemBase(const QString & moduleID, ItemBase::PluralType & plural) {
 	ItemBase * itemBase = ItemBaseHash.value(moduleID);
 	ModelPart * modelPart = m_referenceModel->retrieveModelPart(moduleID);
-	if (itemBase == NULL) {
-		itemBase = PartFactory::createPart(modelPart, ViewLayer::NewTop, ViewLayer::IconView, ViewGeometry(), ItemBase::getNextID(), NULL, NULL, false);
+    if (!itemBase) {
+		itemBase = PartFactory::createPart(modelPart, ViewLayer::NewTop, ViewLayer::IconView, ViewGeometry(), ItemBase::getNextID(), nullptr, nullptr, false);
 		ItemBaseHash.insert(moduleID, itemBase);
 	}
 	m_itemBaseHash.insert(moduleID, itemBase);

--- a/src/partsbinpalette/partsbiniconview.h
+++ b/src/partsbinpalette/partsbiniconview.h
@@ -32,14 +32,16 @@ QT_BEGIN_NAMESPACE
 class QDragEnterEvent;
 class QDropEvent;
 QT_END_NAMESPACE
-
+class PaletteModel;
+class SvgIconWidget;
+class GraphicsFlowLayout;
 class PartsBinIconView : public InfoGraphicsView, public PartsBinView
 {
 	Q_OBJECT
 public:
 	PartsBinIconView(ReferenceModel* referenceModel, PartsBinPaletteWidget *parent);
-	void loadFromModel(class PaletteModel *);
-	void setPaletteModel(class PaletteModel *model, bool clear=false);
+	void loadFromModel(PaletteModel *);
+	void setPaletteModel(PaletteModel *model, bool clear=false);
 	void addPart(ModelPart * model, int position = -1);
 	void removePart(const QString &moduleID);
 	void removeParts();
@@ -72,8 +74,8 @@ protected:
 
 	bool inEmptyArea(const QPoint& pos);
 	QGraphicsWidget* closestItemTo(const QPoint& pos);
-	class SvgIconWidget * svgIconWidgetAt(const QPoint & pos);
-	class SvgIconWidget * svgIconWidgetAt(int x, int y);
+	SvgIconWidget * svgIconWidgetAt(const QPoint & pos);
+	SvgIconWidget * svgIconWidgetAt(int x, int y);
 	ItemBase * loadItemBase(const QString & moduleID, ItemBase::PluralType &);
 
 public slots:
@@ -92,11 +94,11 @@ signals:
 protected:
 	LayerHash m_viewLayers;
 
-	QGraphicsWidget *m_layouter;
-	class GraphicsFlowLayout *m_layout;
+	QGraphicsWidget *m_layouter = nullptr;
+	GraphicsFlowLayout *m_layout = nullptr;
 
-	QMenu *m_itemMenu;
-	bool m_noSelectionChangeEmition;
+	QMenu *m_itemMenu = nullptr;
+	bool m_noSelectionChangeEmition = false;
 };
 
 #endif /* ICONVIEW_H_ */

--- a/src/partsbinpalette/partsbinview.cpp
+++ b/src/partsbinpalette/partsbinview.cpp
@@ -32,7 +32,10 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 QHash<QString, QString> PartsBinView::TranslatedCategoryNames;
 QHash<QString, ItemBase *> PartsBinView::ItemBaseHash;
 
-PartsBinView::PartsBinView(ReferenceModel *referenceModel, PartsBinPaletteWidget *parent) {
+PartsBinView::PartsBinView(ReferenceModel *referenceModel, PartsBinPaletteWidget *parent) 
+	: m_referenceModel(referenceModel),
+	m_parent(parent)
+{
 	if (TranslatedCategoryNames.count() == 0) {
 		TranslatedCategoryNames.insert("Basic", QObject::tr("Basic"));
 		TranslatedCategoryNames.insert("Input", QObject::tr("Input"));
@@ -50,12 +53,6 @@ PartsBinView::PartsBinView(ReferenceModel *referenceModel, PartsBinPaletteWidget
 		TranslatedCategoryNames.insert("Other",  QObject::tr("Other"));
 		TranslatedCategoryNames.insert("Sensors",  QObject::tr("Sensors"));
 	}
-
-	m_referenceModel = referenceModel;
-	m_parent = parent;
-}
-
-PartsBinView::~PartsBinView() {
 }
 
 void PartsBinView::cleanup() {

--- a/src/partsbinpalette/partsbinview.h
+++ b/src/partsbinpalette/partsbinview.h
@@ -33,7 +33,7 @@ class PartsBinView {
 
 public:
 	PartsBinView(ReferenceModel *referenceModel, PartsBinPaletteWidget *parent);
-	virtual ~PartsBinView();				// removes compiler warnings
+	virtual ~PartsBinView() = default;				// removes compiler warnings
 
 	virtual void setPaletteModel(PaletteModel * model, bool clear = false);
 	void reloadParts(PaletteModel * model);

--- a/src/partsbinpalette/partsbinview.h
+++ b/src/partsbinpalette/partsbinview.h
@@ -75,10 +75,10 @@ public:
 	static QHash<QString, QString> TranslatedCategoryNames;
 
 protected:
-	ReferenceModel *m_referenceModel;
-	PartsBinPaletteWidget *m_parent;
+	ReferenceModel *m_referenceModel = nullptr;
+	PartsBinPaletteWidget *m_parent = nullptr;
 
-	bool m_infoViewOnHover;
+	bool m_infoViewOnHover = false;
 
 	QPoint m_dragStartPos;
 

--- a/src/program/platform.cpp
+++ b/src/program/platform.cpp
@@ -26,18 +26,19 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDir>
 #include <QSettings>
 
-Platform::Platform(const QString &name) : QObject(),
-    m_name(name),
-    m_commandLocation(QSettings().value(QString("programwindow/programmer.%1").  arg(getName())).toString()),
-    m_canProgram(false),
-    m_extensions(),
-    m_boards(),
-    m_defaultBoardName(),
-    m_referenceUrl(),
-    m_ideName(),
-    m_downloadUrl(),
-    m_minVersion(),
-    m_syntaxer(new Syntaxer())
+Platform::Platform(const QString &name) 
+	: QObject(),
+	m_name(name),
+	m_commandLocation(QSettings().value(QString("programwindow/programmer.%1").  arg(getName())).toString()),
+	m_canProgram(false),
+	m_extensions(),
+	m_boards(),
+	m_defaultBoardName(),
+	m_referenceUrl(),
+	m_ideName(),
+	m_downloadUrl(),
+	m_minVersion(),
+	m_syntaxer(new Syntaxer())
 {
 	initSyntaxer();
 }

--- a/src/program/platform.cpp
+++ b/src/program/platform.cpp
@@ -26,21 +26,20 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDir>
 #include <QSettings>
 
-Platform::Platform(const QString &name) : QObject()
+Platform::Platform(const QString &name) : QObject(),
+    m_name(name),
+    m_commandLocation(QSettings().value(QString("programwindow/programmer.%1").  arg(getName())).toString()),
+    m_canProgram(false),
+    m_extensions(),
+    m_boards(),
+    m_defaultBoardName(),
+    m_referenceUrl(),
+    m_ideName(),
+    m_downloadUrl(),
+    m_minVersion(),
+    m_syntaxer(new Syntaxer())
 {
-	m_name = name;
 	initSyntaxer();
-	initCommandLocation();
-}
-
-Platform::~Platform()
-{
-	// nothing to do
-}
-
-QString Platform::getName() const
-{
-	return m_name;
 }
 
 void Platform::upload(QWidget * source, const QString &port, const QString &board, const QString &fileLocation)
@@ -48,13 +47,8 @@ void Platform::upload(QWidget * source, const QString &port, const QString &boar
 	// stub
 }
 
-Syntaxer * Platform::getSyntaxer() {
-	return m_syntaxer;
-}
-
 void Platform::initSyntaxer()
 {
-	Syntaxer * syntaxer = new Syntaxer();
 	QDir dir(FolderUtils::getApplicationSubFolderPath("translations"));
 	dir.cd("syntax");
 	QStringList nameFilters;
@@ -62,22 +56,12 @@ void Platform::initSyntaxer()
 	QFileInfoList list = dir.entryInfoList(nameFilters, QDir::Files | QDir::NoSymLinks);
 	foreach (QFileInfo fileInfo, list) {
 		if (fileInfo.completeBaseName().compare(getName(), Qt::CaseInsensitive) == 0) {
-			syntaxer->loadSyntax(fileInfo.absoluteFilePath());
+			m_syntaxer->loadSyntax(fileInfo.absoluteFilePath());
 			break;
 		}
 	}
-	m_syntaxer = syntaxer;
 }
 
-void Platform::initCommandLocation() {
-	QSettings settings;
-	m_commandLocation = settings.value(QString("programwindow/programmer.%1").arg(getName())).toString();
-}
-
-QString Platform::getCommandLocation() const
-{
-	return m_commandLocation;
-}
 
 void Platform::setCommandLocation(const QString &commandLocation)
 {
@@ -86,11 +70,6 @@ void Platform::setCommandLocation(const QString &commandLocation)
 	settings.setValue(QString("programwindow/programmer.%1").arg(getName()), commandLocation);
 
 	emit commandLocationChanged();
-}
-
-QStringList Platform::getExtensions() const
-{
-	return m_extensions;
 }
 
 void Platform::setExtensions(const QStringList &suffixes)

--- a/src/program/platform.h
+++ b/src/program/platform.h
@@ -39,15 +39,15 @@ class Platform : public QObject
 
 public:
 	Platform(const QString &name);
-	~Platform();
+	~Platform() = default;
 
 	virtual void upload(QWidget *source, const QString &port, const QString &board, const QString &fileLocation);
-	Syntaxer *getSyntaxer();
+	Syntaxer *getSyntaxer() const noexcept { return m_syntaxer; }
 
-	QString getName() const;
-	QString getCommandLocation() const;
+	QString getName() const noexcept { return m_name; }
+	QString getCommandLocation() const noexcept { return m_commandLocation; }
 	void setCommandLocation(const QString &commandLocation);
-	QStringList getExtensions() const;
+	QStringList getExtensions() const noexcept { return m_extensions; }
 	void setExtensions(const QStringList &suffixes);
 	QMap<QString, QString> getBoards() const;
 	void setBoards(const QMap<QString, QString> &boards);
@@ -81,7 +81,6 @@ protected:
 
 private:
 	void initSyntaxer();
-	void initCommandLocation();
 
 private:
 	QPointer<Syntaxer> m_syntaxer;

--- a/src/program/syntaxer.h
+++ b/src/program/syntaxer.h
@@ -35,10 +35,10 @@ public:
 	CommentInfo(const QString & start, const QString & end, Qt::CaseSensitivity);
 
 public:
-	bool m_multiLine;
+	bool m_multiLine = false;
 	QString m_start;
 	QString m_end;
-	int m_index;
+	int m_index = 0;
 	Qt::CaseSensitivity m_caseSensitive;
 };
 
@@ -75,14 +75,14 @@ protected:
 	static QHash<QString, QString> m_listsToFormats;
 
 protected:
-	TrieNode * m_trieRoot;
+	TrieNode * m_trieRoot = nullptr;
 	QString m_name;
 	QString m_extensionString;
 	QStringList m_extensions;
 	QList<CommentInfo *> m_commentInfo;
-	QChar m_stringDelimiter;
-	bool m_hlCStringChar;
-	bool m_canProgram;
+	QChar m_stringDelimiter = 0;
+	bool m_hlCStringChar = false;
+	bool m_canProgram = false;
 };
 
 class SyntaxerTrieLeaf : public TrieLeaf

--- a/src/svg/gedaelementlexer.cpp
+++ b/src/svg/gedaelementlexer.cpp
@@ -31,19 +31,18 @@ GedaElementLexer::GedaElementLexer(const QString &source) :
 	m_elementMatcher("Element\\s*([\\(\\[])"),
 	m_stringMatcher("\"([^\"\\\\]*(\\\\.[^\"\\\\]*)*)\""),
 	m_integerMatcher("[-+]?\\d+"),
-    m_hexMatcher("0[xX][0-9a-fA-F]+"),
-    m_source(),
-    m_chars(nullptr),
-    m_size(0),
-    m_pos(0),
-    m_current(0),
-    m_currentCommand(),
-    m_currentNumber(0l),
-    m_currentHexString(0l),
-    m_currentString(),
-    m_comments()
+	m_hexMatcher("0[xX][0-9a-fA-F]+"),
+	m_source(),
+	m_chars(nullptr),
+	m_size(0),
+	m_pos(0),
+	m_current(0),
+	m_currentCommand(),
+	m_currentNumber(0l),
+	m_currentHexString(0l),
+	m_currentString(),
+	m_comments()
 {
-    /// @todo figure out how to do inplace initialization of a cleaned source string.
 	m_source = clean(source);
 	m_chars = m_source.unicode();
 	m_size = m_source.size();

--- a/src/svg/gedaelementlexer.cpp
+++ b/src/svg/gedaelementlexer.cpp
@@ -25,25 +25,30 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 static QRegExp findWhitespace("[\\s]+");
 
-GedaElementLexer::GedaElementLexer(const QString &source)
+GedaElementLexer::GedaElementLexer(const QString &source) :
+    m_nonWhitespaceMatcher("[^\\s]"),
+	m_commentMatcher("(^\\s*\\#)"),
+	m_elementMatcher("Element\\s*([\\(\\[])"),
+	m_stringMatcher("\"([^\"\\\\]*(\\\\.[^\"\\\\]*)*)\""),
+	m_integerMatcher("[-+]?\\d+"),
+    m_hexMatcher("0[xX][0-9a-fA-F]+"),
+    m_source(),
+    m_chars(nullptr),
+    m_size(0),
+    m_pos(0),
+    m_current(0),
+    m_currentCommand(),
+    m_currentNumber(0l),
+    m_currentHexString(0l),
+    m_currentString(),
+    m_comments()
 {
-	m_nonWhitespaceMatcher.setPattern("[^\\s]");
-	m_commentMatcher.setPattern("(^\\s*\\#)");
-	m_elementMatcher.setPattern("Element\\s*([\\(\\[])");
-	//m_stringMatcher.setPattern("\"([^\"]*)\"");
-	m_stringMatcher.setPattern("\"([^\"\\\\]*(\\\\.[^\"\\\\]*)*)\"");
-	m_integerMatcher.setPattern("[-+]?\\d+");
-	m_hexMatcher.setPattern("0[xX][0-9a-fA-F]+");
+    /// @todo figure out how to do inplace initialization of a cleaned source string.
 	m_source = clean(source);
 	m_chars = m_source.unicode();
 	m_size = m_source.size();
 	//qDebug() << m_source;
-	m_pos = 0;
 	m_current = next();
-}
-
-GedaElementLexer::~GedaElementLexer()
-{
 }
 
 QString GedaElementLexer::clean(const QString & source) {

--- a/src/svg/gedaelementlexer.h
+++ b/src/svg/gedaelementlexer.h
@@ -30,7 +30,7 @@ class GedaElementLexer
 {
 public:
 	GedaElementLexer(const QString &source);
-	~GedaElementLexer();
+	~GedaElementLexer() = default;
 	int lex();
 	QString currentCommand();
 	double currentNumber();
@@ -42,21 +42,21 @@ protected:
 	QString clean(const QString & source);
 
 protected:
-	QString m_source;
-	const QChar *m_chars;
-	int m_size;
-	int m_pos;
-	QChar m_current;
-	QString m_currentCommand;
-	long m_currentNumber;
-	long m_currentHexString;
-	QString m_currentString;
+	QRegExp m_nonWhitespaceMatcher;
+	QRegExp m_commentMatcher;
+	QRegExp m_elementMatcher;
+	QRegExp m_stringMatcher;
 	QRegExp m_integerMatcher;
 	QRegExp m_hexMatcher;
-	QRegExp m_stringMatcher;
-	QRegExp m_elementMatcher;
-	QRegExp m_commentMatcher;
-	QRegExp m_nonWhitespaceMatcher;
+	QString m_source;
+	const QChar *m_chars = nullptr;
+	int m_size = 0;
+	int m_pos = 0;
+	QChar m_current;
+	QString m_currentCommand;
+	long m_currentNumber = 0l;
+	long m_currentHexString = 0l;
+	QString m_currentString;
 	QStringList m_comments;
 };
 

--- a/src/svg/gedaelementparser.cpp
+++ b/src/svg/gedaelementparser.cpp
@@ -24,10 +24,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "gedaelementparser.h"
 #include "gedaelementlexer.h"
 
-GedaElementParser::GedaElementParser() :
-    m_tos(0)
-{
-}
+GedaElementParser::GedaElementParser() : m_tos(0) { }
 
 QVector<QVariant> & GedaElementParser::symStack() {
 	return m_symStack;

--- a/src/svg/gedaelementparser.cpp
+++ b/src/svg/gedaelementparser.cpp
@@ -24,11 +24,8 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "gedaelementparser.h"
 #include "gedaelementlexer.h"
 
-GedaElementParser::GedaElementParser()
-{
-}
-
-GedaElementParser::~GedaElementParser()
+GedaElementParser::GedaElementParser() :
+    m_tos(0)
 {
 }
 
@@ -47,19 +44,19 @@ void GedaElementParser::reallocateStack()
 	m_stateStack.resize(size);
 }
 
-QString GedaElementParser::errorMessage() const
+QString GedaElementParser::errorMessage() const noexcept
 {
 	return m_errorMessage;
 }
 
-QVariant GedaElementParser::result() const
+QVariant GedaElementParser::result() const noexcept
 {
 	return m_result;
 }
 
 bool GedaElementParser::parse(GedaElementLexer *lexer)
 {
-	const int INITIAL_STATE = 0;
+	constexpr int INITIAL_STATE = 0;
 
 	int yytoken = -1;
 

--- a/src/svg/gedaelementparser.h
+++ b/src/svg/gedaelementparser.h
@@ -33,12 +33,12 @@ class GedaElementParser: public GedaElementGrammar
 {
 public:
 	GedaElementParser();
-	~GedaElementParser();
+	~GedaElementParser() = default;
 
 	bool parse(GedaElementLexer *lexer);
 	QVector<QVariant> & symStack();
-	QString errorMessage() const;
-	QVariant result() const;
+	QString errorMessage() const noexcept;
+	QVariant result() const noexcept;
 
 private:
 	void reallocateStack();

--- a/src/svg/svgpathlexer.h
+++ b/src/svg/svgpathlexer.h
@@ -37,7 +37,7 @@ public:
 	double currentNumber();
 
 public:
-	static const char FakeClosePathChar = 'x';
+	static constexpr char FakeClosePathChar = 'x';
 
 protected:
 	QChar next();
@@ -45,12 +45,12 @@ protected:
 
 protected:
 	QString m_source;
-	const QChar *m_chars;
-	int m_size;
-	int m_pos;
-	QChar m_current;
-	QChar m_currentCommand;
-	double m_currentNumber;
+	const QChar *m_chars = nullptr;
+	int m_size = 0;
+	int m_pos = 0;
+	QChar m_current = 0;
+	QChar m_currentCommand = 0;
+	double m_currentNumber = 0.0;
 };
 
 #endif

--- a/src/svg/svgpathparser.cpp
+++ b/src/svg/svgpathparser.cpp
@@ -24,13 +24,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "svgpathparser.h"
 #include "svgpathlexer.h"
 
-SVGPathParser::SVGPathParser()
-{
-}
-
-SVGPathParser::~SVGPathParser()
-{
-}
+SVGPathParser::SVGPathParser() : m_tos(0) { }
 
 QVector<QVariant> & SVGPathParser::symStack() {
 	return m_symStack;
@@ -47,12 +41,12 @@ void SVGPathParser::reallocateStack()
 	m_stateStack.resize(size);
 }
 
-QString SVGPathParser::errorMessage() const
+QString SVGPathParser::errorMessage() const noexcept
 {
 	return m_errorMessage;
 }
 
-QVariant SVGPathParser::result() const
+QVariant SVGPathParser::result() const noexcept
 {
 	return m_result;
 }

--- a/src/svg/svgpathparser.h
+++ b/src/svg/svgpathparser.h
@@ -33,12 +33,12 @@ class SVGPathParser: public SVGPathGrammar
 {
 public:
 	SVGPathParser();
-	~SVGPathParser();
+	~SVGPathParser() = default;
 
 	bool parse(SVGPathLexer *lexer);
 	QVector<QVariant> & symStack();
-	QString errorMessage() const;
-	QVariant result() const;
+	QString errorMessage() const noexcept;
+	QVariant result() const noexcept;
 
 private:
 	void reallocateStack();

--- a/src/utils/autoclosemessagebox.cpp
+++ b/src/utils/autoclosemessagebox.cpp
@@ -28,13 +28,13 @@ constexpr auto Wait = 100;
 
 AutoCloseMessageBox::AutoCloseMessageBox( QWidget * parent )
 	: QLabel(parent),
-    m_movingState(MovingState::MovingOut),
-    m_endX(0),
-    m_endY(0),
-    m_startX(0),
-    m_startY(0),
-    m_animationTimer(),
-    m_counter(0) 
+	m_movingState(MovingState::MovingOut),
+	m_endX(0),
+	m_endY(0),
+	m_startX(0),
+	m_startY(0),
+	m_animationTimer(),
+	m_counter(0) 
 {
 	setWordWrap(true);
 }

--- a/src/utils/autoclosemessagebox.cpp
+++ b/src/utils/autoclosemessagebox.cpp
@@ -22,12 +22,19 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../debugdialog.h"
 #include "../mainwindow/mainwindow.h"
 
-static const int Interval = 30;
-static const int Steps = 7;
-static const int Wait = 100;
+constexpr auto Interval = 30;
+constexpr auto Steps = 7;
+constexpr auto Wait = 100;
 
 AutoCloseMessageBox::AutoCloseMessageBox( QWidget * parent )
-	: QLabel(parent)
+	: QLabel(parent),
+    m_movingState(MovingState::MovingOut),
+    m_endX(0),
+    m_endY(0),
+    m_startX(0),
+    m_startY(0),
+    m_animationTimer(),
+    m_counter(0) 
 {
 	setWordWrap(true);
 }

--- a/src/utils/zoomslider.cpp
+++ b/src/utils/zoomslider.cpp
@@ -31,13 +31,14 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "zoomslider.h"
 #include "../debugdialog.h"
 
-double ZoomSlider::ZoomStep;
+double ZoomSlider::ZoomStep = 0.0;
 QList<double> ZoomSlider::ZoomFactors;
 
-static const int MIN_VALUE = 10;
-static const int STARTING_VALUE = 100;
-static const int HEIGHT = 16;
-static const int STEP = 100;
+
+constexpr auto MIN_VALUE = 10;
+constexpr auto STARTING_VALUE = 100;
+constexpr auto HEIGHT = 16;
+constexpr auto STEP = 100;
 
 static int AutoRepeatDelay = 0;
 static int AutoRepeatInterval = 0;

--- a/src/viewgeometry.cpp
+++ b/src/viewgeometry.cpp
@@ -21,30 +21,30 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "viewgeometry.h"
 #include "utils/graphicsutils.h"
 
-ViewGeometry::ViewGeometry(  ) :
-    m_z(-1),
-    m_loc(-1, -1),
-    m_line(-1, -1, -1, -1),
-    m_rect(),
-    m_selected(false),
-    m_wireFlags(WireFlag::NoFlag)
+ViewGeometry::ViewGeometry(  ) 
+	: m_z(-1),
+	m_loc(-1, -1),
+	m_line(-1, -1, -1, -1),
+	m_rect(),
+	m_selected(false),
+	m_wireFlags(WireFlag::NoFlag)
 {
 }
 
-ViewGeometry::ViewGeometry(const ViewGeometry& that) :
-    m_z(that.m_z),
-    m_loc(that.m_loc),
-    m_line(that.m_line),
-    m_rect(that.m_rect),
-    m_selected(false),
-    m_wireFlags(that.m_wireFlags),
-    m_transform(that.m_transform) { }
+ViewGeometry::ViewGeometry(const ViewGeometry& that) 
+	: m_z(that.m_z),
+	m_loc(that.m_loc),
+	m_line(that.m_line),
+	m_rect(that.m_rect),
+	m_selected(false),
+	m_wireFlags(that.m_wireFlags),
+	m_transform(that.m_transform) { }
 
-ViewGeometry::ViewGeometry(QDomElement & geometry) :
-    m_z(geometry.attribute("z").toDouble()),
-    m_loc(geometry.attribute("x").toDouble(),
-          geometry.attribute("y").toDouble()),
-    m_wireFlags(static_cast<WireFlags>(geometry.attribute("wireFlags").toInt()))
+ViewGeometry::ViewGeometry(QDomElement & geometry) 
+	: m_z(geometry.attribute("z").toDouble()),
+	m_loc(geometry.attribute("x").toDouble(),
+	      geometry.attribute("y").toDouble()),
+	m_wireFlags(static_cast<WireFlags>(geometry.attribute("wireFlags").toInt()))
 {
 
 	QString x1 = geometry.attribute("x1");

--- a/src/viewgeometry.cpp
+++ b/src/viewgeometry.cpp
@@ -21,25 +21,32 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "viewgeometry.h"
 #include "utils/graphicsutils.h"
 
-ViewGeometry::ViewGeometry(  )
+ViewGeometry::ViewGeometry(  ) :
+    m_z(-1),
+    m_loc(-1, -1),
+    m_line(-1, -1, -1, -1),
+    m_rect(),
+    m_selected(false),
+    m_wireFlags(WireFlag::NoFlag)
 {
-	m_z = -1;
-	m_loc.setX(-1);
-	m_loc.setY(-1);
-	m_line.setLine(-1,-1,-1,-1);
-	m_wireFlags = NoFlag;
 }
 
-ViewGeometry::ViewGeometry(const ViewGeometry & that  )
-{
-	set(that);
-}
+ViewGeometry::ViewGeometry(const ViewGeometry& that) :
+    m_z(that.m_z),
+    m_loc(that.m_loc),
+    m_line(that.m_line),
+    m_rect(that.m_rect),
+    m_selected(false),
+    m_wireFlags(that.m_wireFlags),
+    m_transform(that.m_transform) { }
 
-ViewGeometry::ViewGeometry(QDomElement & geometry) {
-	m_wireFlags = (WireFlags) geometry.attribute("wireFlags").toInt();
-	m_z = geometry.attribute("z").toDouble();
-	m_loc.setX(geometry.attribute("x").toDouble());
-	m_loc.setY(geometry.attribute("y").toDouble());
+ViewGeometry::ViewGeometry(QDomElement & geometry) :
+    m_z(geometry.attribute("z").toDouble()),
+    m_loc(geometry.attribute("x").toDouble(),
+          geometry.attribute("y").toDouble()),
+    m_wireFlags(static_cast<WireFlags>(geometry.attribute("wireFlags").toInt()))
+{
+
 	QString x1 = geometry.attribute("x1");
 	if (!x1.isEmpty()) {
 		m_line.setLine( geometry.attribute("x1").toDouble(),
@@ -58,45 +65,27 @@ ViewGeometry::ViewGeometry(QDomElement & geometry) {
 	GraphicsUtils::loadTransform(geometry.firstChildElement("transform"), m_transform);
 }
 
-void ViewGeometry::setZ(double z) {
+void ViewGeometry::setZ(double z) noexcept {
 	m_z = z;
-}
-
-double ViewGeometry::z() const {
-	return m_z ;
 }
 
 void ViewGeometry::setLoc(QPointF loc) {
 	m_loc = loc;
 }
 
-QPointF ViewGeometry::loc() const {
-	return m_loc ;
-}
-
 void ViewGeometry::setLine(QLineF loc) {
 	m_line = loc;
 }
 
-QLineF ViewGeometry::line() const {
-	return m_line;
-}
 
 void ViewGeometry::offset(double x, double y) {
 	m_loc.setX(x + m_loc.x());
 	m_loc.setY(y + m_loc.y());
 }
 
-bool ViewGeometry::selected() {
-	return m_selected;
-}
 
 void ViewGeometry::setSelected(bool selected) {
 	m_selected = selected;
-}
-
-QRectF ViewGeometry::rect() const {
-	return m_rect;
 }
 
 void ViewGeometry::setRect(double x, double y, double width, double height)
@@ -111,10 +100,6 @@ void ViewGeometry::setRect(const QRectF & r)
 
 void ViewGeometry::setTransform(QTransform transform) {
 	m_transform = transform;
-}
-
-QTransform ViewGeometry::transform() const {
-	return m_transform;
 }
 
 void ViewGeometry::set(const ViewGeometry & that) {
@@ -151,7 +136,6 @@ void ViewGeometry::setAutoroutable(bool autoroutable) {
 }
 
 bool ViewGeometry::getRouted() const {
-
 	return m_wireFlags.testFlag(RoutedFlag);
 }
 

--- a/src/viewgeometry.h
+++ b/src/viewgeometry.h
@@ -54,20 +54,20 @@ protected:
 	void setWireFlag(bool setting, WireFlag flag);
 
 public:
-	void setZ(double);
-	double z() const;
+	void setZ(double) noexcept;
+	constexpr double z() const noexcept { return m_z; }
 	void setLoc(QPointF);
-	QPointF loc() const;
+	constexpr QPointF loc() const noexcept { return m_loc; }
 	void setLine(QLineF);
-	QLineF line() const;
+	constexpr QLineF line() const noexcept { return m_line; }
 	void offset(double x, double y);
-	bool selected();
+	bool selected() const noexcept { return m_selected; }
 	void setSelected(bool);
-	QRectF rect() const;
+	constexpr QRectF rect() const noexcept { return m_rect; }
 	void setRect(double x, double y, double width, double height);
 	void setRect(const QRectF &);
 	void setTransform(QTransform);
-	QTransform transform() const;
+	QTransform transform() const noexcept { return m_transform; }
 	void set(const ViewGeometry &);
 	void setRouted(bool);
 	bool getRouted() const;


### PR DESCRIPTION
I ran fritzing-app through the static analysis tool my company makes (we have a release coming up and I thought fritzing would be a perfect project to test on) and found a considerable number of places (I know there are more but I have to check the SA results again) where:

1. Members of a class are being initialized twice (once during object construction and then in the body of the constructor)
2. Not all members of a class are initialized. This can lead to undefined behavior
3. One instance of "C-ing" in C++. I believe the objective was to zero out memory on memory allocation, I have fixed that so malloc is not called and instead new. Adding parens after the square brackets causes the memory to be initialized to zero (or a constructor to be called, which I didn't know before researching this). I also eliminated the free call and integrated the logic into the destructor as well. 
4. Using forward decls to cut down on typing. 

Oh, for more information. When you use the constructor list initialization syntax, you are placing the values into the members as the object is being constructed prior to the body of the constructor being called. When you assign a value to a field within the body of the constructor, you are actually doing a second write to that member. PODs do not have a constructor so they must be explicitly initialized either via Non-Static Data Member Initialization (NSDMI) or through the initializer list syntax. The order of member init exactly matches the layout of the members in the class/struct so I had to rearrange in a few places. In the case of class instances, their default constructor is called implicitly so you technically don't need to call their default constructor explicitly but if you don't initialize in order you'll get a warning from the compiler about out of order member initialization which can be bad. 

There are cases where it makes more sense to assign to a member inside the body of the constructor so I left those where it makes sense. 

The other change I made is started using constexpr all the places I could. The downside to this approach is it breaks compatibility with non C++11 compilers. I may have even broken compatibility with C++11 and required C++14 (I'm not sure since C++14 is so useful I use features from it without even thinking). I bring this up because I see references to MSVC 2010 (an ancient but safe compiler target, I would actually recommend MSVC 2015 or later these days if you want/must build with MSVC on windows). 

I am not done fixing what we call severity one violations. But I thought it would be smart to not give too large of a pull request. 