### PR TITLE
More list initialization and NSDMI changes

### DIFF
--- a/src/autoroute/autorouter.cpp
+++ b/src/autoroute/autorouter.cpp
@@ -38,13 +38,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 const QString Autorouter::MaxCyclesName("cmrouter/maxcycles");
 
-Autorouter::Autorouter(PCBSketchWidget * sketchWidget)
-{
-	m_sketchWidget = sketchWidget;
-	m_useBest = m_stopTracing = m_cancelTrace = m_cancelled = false;
-}
-
-Autorouter::~Autorouter(void)
+Autorouter::Autorouter(PCBSketchWidget * sketchWidget) : m_sketchWidget(sketchWidget)
 {
 }
 
@@ -70,7 +64,7 @@ TraceWire * Autorouter::drawOneTrace(QPointF fromPos, QPointF toPos, double widt
 	}
 #endif
 
-	long newID = ItemBase::getNextID();
+	auto newID = ItemBase::getNextID();
 	ViewGeometry viewGeometry;
 	viewGeometry.setWireFlags(m_sketchWidget->getTraceFlag());
 	viewGeometry.setAutoroutable(true);
@@ -78,20 +72,20 @@ TraceWire * Autorouter::drawOneTrace(QPointF fromPos, QPointF toPos, double widt
 	QLineF line(0, 0, toPos.x() - fromPos.x(), toPos.y() - fromPos.y());
 	viewGeometry.setLine(line);
 
-	ItemBase * trace = m_sketchWidget->addItem(m_sketchWidget->referenceModel()->retrieveModelPart(ModuleIDNames::WireModuleIDName),
+	auto trace = m_sketchWidget->addItem(m_sketchWidget->referenceModel()->retrieveModelPart(ModuleIDNames::WireModuleIDName),
 	                   viewLayerPlacement, BaseCommand::SingleView, viewGeometry, newID, -1, NULL);
-	if (trace == NULL) {
+	if (!trace) {
 		// we're in trouble
 		DebugDialog::debug("autorouter unable to draw one trace");
-		return NULL;
+		return nullptr;
 	}
 
 	// addItem calls trace->setSelected(true) so unselect it (TODO: this may no longer be necessary)
 	trace->setSelected(false);
-	TraceWire * traceWire = dynamic_cast<TraceWire *>(trace);
-	if (traceWire == NULL) {
+	auto traceWire = dynamic_cast<TraceWire *>(trace);
+	if (!traceWire) {
 		DebugDialog::debug("autorouter unable to draw one trace as trace");
-		return NULL;
+		return nullptr;
 	}
 
 
@@ -128,8 +122,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 	if (m_pcbType) {
 		collidingItems = m_sketchWidget->scene()->collidingItems(m_board);
 		foreach (QGraphicsItem * item, collidingItems) {
-			JumperItem * jumperItem = dynamic_cast<JumperItem *>(item);
-			if (jumperItem == NULL) continue;
+			auto jumperItem = dynamic_cast<JumperItem *>(item);
+			if (!jumperItem) continue;
 
 			if (jumperItem->getAutoroutable()) {
 				addUndoConnection(false, jumperItem, parentCommand);
@@ -142,8 +136,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 			foreach (ConnectorItem * ci, jumperItem->connector0()->connectedToItems()) both.append(ci);
 			foreach (ConnectorItem * ci, jumperItem->connector1()->connectedToItems()) both.append(ci);
 			foreach (ConnectorItem * connectorItem, both) {
-				TraceWire * w = qobject_cast<TraceWire *>(connectorItem->attachedTo());
-				if (w == NULL) continue;
+				auto w = qobject_cast<TraceWire *>(connectorItem->attachedTo());
+				if (!w) continue;
 				if (!w->isTraceType(m_sketchWidget->getTraceFlag())) continue;
 
 				QList<Wire *> wires;
@@ -156,8 +150,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 			}
 		}
 		foreach (QGraphicsItem * item, collidingItems) {
-			Via * via = dynamic_cast<Via *>(item);
-			if (via == NULL) continue;
+			auto via = dynamic_cast<Via *>(item);
+			if (!via) continue;
 
 			if (via->getAutoroutable()) {
 				addUndoConnection(false, via, parentCommand);
@@ -170,8 +164,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 			foreach (ConnectorItem * ci, via->connectorItem()->connectedToItems()) both.append(ci);
 			foreach (ConnectorItem * ci, via->connectorItem()->getCrossLayerConnectorItem()->connectedToItems()) both.append(ci);
 			foreach (ConnectorItem * connectorItem, both) {
-				TraceWire * w = qobject_cast<TraceWire *>(connectorItem->attachedTo());
-				if (w == NULL) continue;
+				auto w = qobject_cast<TraceWire *>(connectorItem->attachedTo());
+				if (!w) continue;
 				if (!w->isTraceType(m_sketchWidget->getTraceFlag())) continue;
 
 				QList<Wire *> wires;
@@ -187,7 +181,7 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 	else {
 		collidingItems = m_sketchWidget->scene()->items();
 		foreach (QGraphicsItem * item, collidingItems) {
-			SymbolPaletteItem * netLabel = dynamic_cast<SymbolPaletteItem *>(item);
+			auto netLabel = dynamic_cast<SymbolPaletteItem *>(item);
 			if (netLabel == NULL) continue;
 			if (!netLabel->isOnlyNetLabel()) continue;
 
@@ -199,8 +193,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 
 			// deal with the traces connecting the netlabel to the part
 			foreach (ConnectorItem * connectorItem, netLabel->connector0()->connectedToItems()) {
-				TraceWire * w = qobject_cast<TraceWire *>(connectorItem->attachedTo());
-				if (w == NULL) continue;
+				auto w = qobject_cast<TraceWire *>(connectorItem->attachedTo());
+				if (!w) continue;
 				if (!w->isTraceType(m_sketchWidget->getTraceFlag())) continue;
 
 				QList<Wire *> wires;
@@ -216,8 +210,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 
 	QList<TraceWire *> visited;
 	foreach (QGraphicsItem * item, collidingItems) {
-		TraceWire * traceWire = dynamic_cast<TraceWire *>(item);
-		if (traceWire == NULL) continue;
+		auto traceWire = dynamic_cast<TraceWire *>(item);
+		if (!traceWire) continue;
 		if (!traceWire->isTraceType(m_sketchWidget->getTraceFlag())) continue;
 		if (traceWire->getAutoroutable()) continue;
 		if (visited.contains(traceWire)) continue;
@@ -234,8 +228,8 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 	}
 
 	foreach (QGraphicsItem * item, collidingItems) {
-		TraceWire * traceWire = dynamic_cast<TraceWire *>(item);
-		if (traceWire == NULL) continue;
+		auto traceWire = dynamic_cast<TraceWire *>(item);
+		if (!traceWire) continue;
 		if (!traceWire->isTraceType(m_sketchWidget->getTraceFlag())) continue;
 		if (!traceWire->getAutoroutable()) continue;
 
@@ -274,14 +268,14 @@ void Autorouter::addUndoConnection(bool connect, TraceWire * traceWire, QUndoCom
 void Autorouter::addUndoConnection(bool connect, ConnectorItem * connectorItem, BaseCommand::CrossViewType crossView, QUndoCommand * parentCommand)
 {
 	foreach (ConnectorItem * toConnectorItem, connectorItem->connectedToItems()) {
-		VirtualWire * vw = qobject_cast<VirtualWire *>(toConnectorItem->attachedTo());
-		if (vw != NULL) continue;
+		auto vw = qobject_cast<VirtualWire *>(toConnectorItem->attachedTo());
+		if (vw) continue;
 
-		ChangeConnectionCommand * ccc = new ChangeConnectionCommand(m_sketchWidget, crossView,
-		        toConnectorItem->attachedToID(), toConnectorItem->connectorSharedID(),
-		        connectorItem->attachedToID(), connectorItem->connectorSharedID(),
-		        ViewLayer::specFromID(toConnectorItem->attachedToViewLayerID()),
-		        connect, parentCommand);
+        auto ccc = new ChangeConnectionCommand(m_sketchWidget, crossView,
+                toConnectorItem->attachedToID(), toConnectorItem->connectorSharedID(),
+                connectorItem->attachedToID(), connectorItem->connectorSharedID(),
+                ViewLayer::specFromID(toConnectorItem->attachedToViewLayerID()),
+                connect, parentCommand);
 		ccc->setUpdateConnections(false);
 	}
 }
@@ -297,14 +291,14 @@ void Autorouter::clearTracesAndJumpers() {
 
 	foreach (QGraphicsItem * item, (m_board == NULL) ? m_sketchWidget->scene()->items() : m_sketchWidget->scene()->collidingItems(m_board)) {
 		if (m_pcbType) {
-			JumperItem * jumperItem = dynamic_cast<JumperItem *>(item);
+			auto jumperItem = dynamic_cast<JumperItem *>(item);
 			if (jumperItem != NULL) {
 				if (jumperItem->getAutoroutable()) {
 					toDelete.append(jumperItem);
 				}
 				continue;
 			}
-			Via * via = dynamic_cast<Via *>(item);
+			auto via = dynamic_cast<Via *>(item);
 			if (via != NULL) {
 				if (via->getAutoroutable()) {
 					toDelete.append(via);
@@ -313,7 +307,7 @@ void Autorouter::clearTracesAndJumpers() {
 			}
 		}
 		else {
-			SymbolPaletteItem * netLabel = dynamic_cast<SymbolPaletteItem *>(item);
+			auto netLabel = dynamic_cast<SymbolPaletteItem *>(item);
 			if (netLabel != NULL && netLabel->isOnlyNetLabel()) {
 				if (netLabel->getAutoroutable()) {
 					toDelete.append(netLabel);
@@ -322,7 +316,7 @@ void Autorouter::clearTracesAndJumpers() {
 			}
 		}
 
-		TraceWire * traceWire = dynamic_cast<TraceWire *>(item);
+		auto traceWire = dynamic_cast<TraceWire *>(item);
 		if (traceWire != NULL) {
 			if (traceWire->isTraceType(m_sketchWidget->getTraceFlag()) && traceWire->getAutoroutable()) {
 				toDelete.append(traceWire);
@@ -350,8 +344,8 @@ void Autorouter::addToUndo(QUndoCommand * parentCommand)
 	QList<Via *> vias;
 	QList<SymbolPaletteItem *> netLabels;
 	foreach (QGraphicsItem * item, (m_board  == NULL) ? m_sketchWidget->scene()->items() : m_sketchWidget->scene()->collidingItems(m_board)) {
-		TraceWire * wire = dynamic_cast<TraceWire *>(item);
-		if (wire != NULL) {
+		auto wire = dynamic_cast<TraceWire *>(item);
+		if (wire) {
 			if (!wire->getAutoroutable()) continue;
 			if (!wire->isTraceType(m_sketchWidget->getTraceFlag())) continue;
 
@@ -362,8 +356,8 @@ void Autorouter::addToUndo(QUndoCommand * parentCommand)
 			continue;
 		}
 		if (m_pcbType) {
-			JumperItem * jumperItem = dynamic_cast<JumperItem *>(item);
-			if (jumperItem != NULL) {
+			auto jumperItem = dynamic_cast<JumperItem *>(item);
+			if (jumperItem) {
 				jumperItems.append(jumperItem);
 				if (!jumperItem->getAutoroutable()) {
 					continue;
@@ -372,15 +366,16 @@ void Autorouter::addToUndo(QUndoCommand * parentCommand)
 				jumperItem->saveParams();
 				QPointF pos, c0, c1;
 				jumperItem->getParams(pos, c0, c1);
-
+                /// @todo this can cause leaks if the constructors of these
+                /// commands change.
 				new AddItemCommand(m_sketchWidget, BaseCommand::CrossView, ModuleIDNames::JumperModuleIDName, jumperItem->viewLayerPlacement(), jumperItem->getViewGeometry(), jumperItem->id(), false, -1, parentCommand);
 				new ResizeJumperItemCommand(m_sketchWidget, jumperItem->id(), pos, c0, c1, pos, c0, c1, parentCommand);
 				new CheckStickyCommand(m_sketchWidget, BaseCommand::SingleView, jumperItem->id(), false, CheckStickyCommand::RemoveOnly, parentCommand);
 
 				continue;
 			}
-			Via * via = dynamic_cast<Via *>(item);
-			if (via != NULL) {
+			auto via = dynamic_cast<Via *>(item);
+			if (via) {
 				vias.append(via);
 				if (!via->getAutoroutable()) {
 					continue;
@@ -394,8 +389,8 @@ void Autorouter::addToUndo(QUndoCommand * parentCommand)
 			}
 		}
 		else {
-			SymbolPaletteItem * netLabel = dynamic_cast<SymbolPaletteItem *>(item);
-			if (netLabel != NULL && netLabel->isOnlyNetLabel()) {
+			auto netLabel = dynamic_cast<SymbolPaletteItem *>(item);
+			if (netLabel && netLabel->isOnlyNetLabel()) {
 				netLabels.append(netLabel);
 				if (!netLabel->getAutoroutable()) {
 					continue;
@@ -427,8 +422,8 @@ void Autorouter::addToUndo(QUndoCommand * parentCommand)
 
 void Autorouter::addWireToUndo(Wire * wire, QUndoCommand * parentCommand)
 {
-	if (wire == NULL) return;
-
+	if (!wire) return;
+    /// @todo this can cause leaks if the ctor of the commands change
 	new AddItemCommand(m_sketchWidget, BaseCommand::CrossView, ModuleIDNames::WireModuleIDName, wire->viewLayerPlacement(), wire->getViewGeometry(), wire->id(), false, -1, parentCommand);
 	new CheckStickyCommand(m_sketchWidget, BaseCommand::SingleView, wire->id(), false, CheckStickyCommand::RemoveOnly, parentCommand);
 

--- a/src/autoroute/autorouter.cpp
+++ b/src/autoroute/autorouter.cpp
@@ -182,7 +182,7 @@ void Autorouter::initUndo(QUndoCommand * parentCommand)
 		collidingItems = m_sketchWidget->scene()->items();
 		foreach (QGraphicsItem * item, collidingItems) {
 			auto netLabel = dynamic_cast<SymbolPaletteItem *>(item);
-			if (netLabel == NULL) continue;
+			if (!netLabel) continue;
 			if (!netLabel->isOnlyNetLabel()) continue;
 
 			if (netLabel->getAutoroutable()) {
@@ -271,11 +271,11 @@ void Autorouter::addUndoConnection(bool connect, ConnectorItem * connectorItem, 
 		auto vw = qobject_cast<VirtualWire *>(toConnectorItem->attachedTo());
 		if (vw) continue;
 
-        auto ccc = new ChangeConnectionCommand(m_sketchWidget, crossView,
-                toConnectorItem->attachedToID(), toConnectorItem->connectorSharedID(),
-                connectorItem->attachedToID(), connectorItem->connectorSharedID(),
-                ViewLayer::specFromID(toConnectorItem->attachedToViewLayerID()),
-                connect, parentCommand);
+		auto ccc = new ChangeConnectionCommand(m_sketchWidget, crossView,
+				toConnectorItem->attachedToID(), toConnectorItem->connectorSharedID(),
+				connectorItem->attachedToID(), connectorItem->connectorSharedID(),
+				ViewLayer::specFromID(toConnectorItem->attachedToViewLayerID()),
+				connect, parentCommand);
 		ccc->setUpdateConnections(false);
 	}
 }

--- a/src/autoroute/autorouter.h
+++ b/src/autoroute/autorouter.h
@@ -36,15 +36,19 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../connectors/connectoritem.h"
 #include "../commands.h"
 
+class PCBSketchWidget;
+class SymbolPaletteItem;
+class JumperItem;
+class Via;
 class Autorouter : public QObject
 {
 	Q_OBJECT
 
 public:
-	Autorouter(class PCBSketchWidget *);
-	virtual ~Autorouter(void);
+	Autorouter(PCBSketchWidget *);
+	virtual ~Autorouter() = default;
 
-	virtual void start()=0;
+	virtual void start() = 0;
 
 public:
 	static const QString MaxCyclesName;
@@ -55,9 +59,9 @@ protected:
 	virtual void updateRoutingStatus();
 	virtual class TraceWire * drawOneTrace(QPointF fromPos, QPointF toPos, double width, ViewLayer::ViewLayerPlacement);
 	void initUndo(QUndoCommand * parentCommand);
-	void addUndoConnection(bool connect, class SymbolPaletteItem *, QUndoCommand * parentCommand);
-	void addUndoConnection(bool connect, class JumperItem *, QUndoCommand * parentCommand);
-	void addUndoConnection(bool connect, class Via *, QUndoCommand * parentCommand);
+	void addUndoConnection(bool connect, SymbolPaletteItem *, QUndoCommand * parentCommand);
+	void addUndoConnection(bool connect, JumperItem *, QUndoCommand * parentCommand);
+	void addUndoConnection(bool connect, Via *, QUndoCommand * parentCommand);
 	void addUndoConnection(bool connect, TraceWire *, QUndoCommand * parentCommand);
 	void addUndoConnection(bool connect, ConnectorItem *, BaseCommand::CrossViewType, QUndoCommand * parentCommand);
 	void restoreOriginalState(QUndoCommand * parentCommand);
@@ -86,20 +90,20 @@ signals:
 	void disableButtons();
 
 protected:
-	class PCBSketchWidget * m_sketchWidget;
-	QList< QList<class ConnectorItem *>* > m_allPartConnectorItems;
-	bool m_cancelled;
-	bool m_cancelTrace;
-	bool m_stopTracing;
-	bool m_useBest;
-	bool m_bothSidesNow;
-	int m_maximumProgressPart;
-	int m_currentProgressPart;
-	QGraphicsItem * m_board;
-	int m_maxCycles;
-	double m_keepoutPixels;
+	PCBSketchWidget * m_sketchWidget = nullptr;
+	QList< QList<ConnectorItem*>* > m_allPartConnectorItems;
+	bool m_cancelled = false;
+	bool m_cancelTrace = false;
+	bool m_stopTracing = false;
+	bool m_useBest = false;
+	bool m_bothSidesNow = false;
+	int m_maximumProgressPart = 0;
+	int m_currentProgressPart = 0;
+	QGraphicsItem * m_board = nullptr;
+	int m_maxCycles = 0;
+	double m_keepoutPixels = 0.0;
 	QRectF m_maxRect;
-	bool m_pcbType;
+	bool m_pcbType = false;
 };
 
 #endif

--- a/src/autoroute/cmrouter/cmrouter.cpp
+++ b/src/autoroute/cmrouter/cmrouter.cpp
@@ -279,30 +279,21 @@ int prepDeleteTile(Tile * tile, UserData userData) {
 
 ////////////////////////////////////////////////////////////////////
 
-GridEntry::GridEntry(QRectF & r, QGraphicsItem * parent) : QGraphicsRectItem(r, parent)
+GridEntry::GridEntry(QRectF & r, QGraphicsItem * parent) : QGraphicsRectItem(r, parent),
+    m_drawn(false)
 {
-	m_drawn = false;
 	setAcceptedMouseButtons(Qt::NoButton);
 	setAcceptHoverEvents(false);
 }
 
-bool GridEntry::drawn() {
-	return m_drawn;
-}
-
-void GridEntry::setDrawn(bool d) {
-	m_drawn = d;
-}
-
 ////////////////////////////////////////////////////////////////////
 
-CMRouter::CMRouter(PCBSketchWidget * sketchWidget, ItemBase * board, bool adjustIf) : QObject()
+CMRouter::CMRouter(PCBSketchWidget * sketchWidget, ItemBase * board, bool adjustIf) : 
+    QObject(),
+    m_board(board),
+    m_sketchWidget(sketchWidget)
+
 {
-	m_board = board;
-	m_sketchWidget = sketchWidget;
-
-	m_unionPlane = m_union90Plane = NULL;
-
 	if (m_board) {
 		m_maxRect = m_board->sceneBoundingRect();
 	}
@@ -320,10 +311,6 @@ CMRouter::CMRouter(PCBSketchWidget * sketchWidget, ItemBase * board, bool adjust
 	qrectToTile(m_maxRect, m_tileMaxRect);
 
 	setUpWidths(m_sketchWidget->getAutorouterTraceWidth());
-}
-
-CMRouter::~CMRouter()
-{
 }
 
 Plane * CMRouter::initPlane(bool rotate90) {

--- a/src/autoroute/cmrouter/cmrouter.h
+++ b/src/autoroute/cmrouter/cmrouter.h
@@ -53,22 +53,22 @@ public:
 
 public:
 	GridEntry(QRectF &, QGraphicsItem * parent);
-	bool drawn();
-	void setDrawn(bool);
+	constexpr bool drawn() const noexcept { return m_drawn; }
+	void setDrawn(bool value) noexcept { m_drawn = value; }
 
 protected:
 	bool m_drawn;
 };
 
 ////////////////////////////////////
-
+class PCBSketchWidget;
 class CMRouter : public QObject
 {
 	Q_OBJECT
 
 public:
-	CMRouter(class PCBSketchWidget *, ItemBase * board, bool adjustIf);
-	~CMRouter(void);
+	CMRouter(PCBSketchWidget *, ItemBase * board, bool adjustIf);
+	~CMRouter() = default;
 
 public:
 	enum OverlapType {
@@ -109,13 +109,13 @@ protected:
 	QRectF m_maxRect90;
 	TileRect m_overlappingTileRect;
 	QList<Plane *> m_planes;
-	Plane * m_unionPlane;
-	Plane * m_union90Plane;
-	ItemBase * m_board;
+	Plane * m_unionPlane = nullptr;
+	Plane * m_union90Plane = nullptr;
+	ItemBase * m_board = nullptr;
 	QRectF m_maxRect;
 	QString m_error;
-	PCBSketchWidget * m_sketchWidget;
-	double m_keepoutPixels;
+	PCBSketchWidget * m_sketchWidget = nullptr;
+	double m_keepoutPixels = 0.0;
 };
 
 #endif

--- a/src/autoroute/drc.cpp
+++ b/src/autoroute/drc.cpp
@@ -237,7 +237,7 @@ DRC::DRC(PCBSketchWidget * sketchWidget, ItemBase * board) :
 	CancelledMessage = tr("DRC was cancelled.");
 }
 
-DRC::~DRC(void)
+DRC::~DRC()
 {
 	if (m_displayItem) {
 		delete m_displayItem;

--- a/src/autoroute/drc.cpp
+++ b/src/autoroute/drc.cpp
@@ -224,7 +224,7 @@ static QString CancelledMessage;
 ///////////////////////////////////////////
 
 DRC::DRC(PCBSketchWidget * sketchWidget, ItemBase * board) :
-    m_sketchWidget(widget),
+    m_sketchWidget(sketchWidget),
     m_board(board),
     m_keepout(0.0),
     m_plusImage(nullptr),

--- a/src/autoroute/drc.cpp
+++ b/src/autoroute/drc.cpp
@@ -173,10 +173,10 @@ DRCResultsDialog::DRCResultsDialog(const QString & message, const QStringList & 
 }
 
 DRCResultsDialog::~DRCResultsDialog() {
-	if (m_displayItem != nullptr && m_sketchWidget != nullptr) {
+	if (m_displayItem && m_sketchWidget) {
 		delete m_displayItem;
 	}
-	if (m_displayImage != nullptr) {
+	if (m_displayImage) {
 		delete m_displayImage;
 	}
 	foreach (CollidingThing * collidingThing, m_collidingThings) {
@@ -186,7 +186,7 @@ DRCResultsDialog::~DRCResultsDialog() {
 }
 
 void DRCResultsDialog::pressedSlot(QListWidgetItem * item) {
-	if (item == nullptr) return;
+	if (!item) return;
 
 	int ix = item->data(Qt::UserRole).toInt();
 	CollidingThing * collidingThing = m_collidingThings.at(ix);
@@ -201,7 +201,7 @@ void DRCResultsDialog::pressedSlot(QListWidgetItem * item) {
 }
 
 void DRCResultsDialog::releasedSlot(QListWidgetItem * item) {
-	if (item == nullptr) return;
+	if (!item) return;
 
 	int ix = item->data(Qt::UserRole).toInt();
 	CollidingThing * collidingThing = m_collidingThings.at(ix);
@@ -223,17 +223,18 @@ static QString CancelledMessage;
 
 ///////////////////////////////////////////
 
-DRC::DRC(PCBSketchWidget * sketchWidget, ItemBase * board)
+DRC::DRC(PCBSketchWidget * sketchWidget, ItemBase * board) :
+    m_sketchWidget(widget),
+    m_board(board),
+    m_keepout(0.0),
+    m_plusImage(nullptr),
+    m_minusImage(nullptr),
+    m_displayImage(nullptr),
+    m_displayItem(nullptr),
+    m_cancelled(false),
+    m_maxProgress(0)
 {
 	CancelledMessage = tr("DRC was cancelled.");
-
-	m_cancelled = false;
-	m_sketchWidget = sketchWidget;
-	m_board = board;
-	m_displayItem = nullptr;
-	m_displayImage = nullptr;
-	m_plusImage = nullptr;
-	m_minusImage = nullptr;
 }
 
 DRC::~DRC(void)
@@ -305,7 +306,7 @@ bool DRC::startAux(QString & message, QStringList & messages, QList<CollidingThi
 	QList< QList<ConnectorItem *> > singletons;
 	foreach (QGraphicsItem * item, m_sketchWidget->scene()->items()) {
 		ConnectorItem * connectorItem = dynamic_cast<ConnectorItem *>(item);
-		if (connectorItem == nullptr) continue;
+		if (!connectorItem) continue;
 		if (!connectorItem->attachedTo()->isEverVisible()) continue;
 		if (connectorItem->attachedTo()->getRatsnest()) continue;
 		if (visited.contains(connectorItem)) continue;
@@ -673,13 +674,13 @@ void DRC::splitNetPrep(QDomDocument * masterDoc, QList<ConnectorItem *> & equi, 
 	QSet<QString> wireIDs;
 	foreach (ConnectorItem * equ, equi) {
 		ItemBase * itemBase = equ->attachedTo();
-		if (itemBase == nullptr) continue;
+		if (!itemBase) continue;
 
 		if (itemBase->itemType() == ModelPart::Wire) {
 			wireIDs.insert(QString::number(itemBase->id()));
 		}
 
-		if (equ->connector() == nullptr) {
+		if (!equ->connector()) {
 			// this shouldn't happen
 			itemBase->debugInfo("!!!!!!!!!!!!!!!!!!!!!!!!!!!!! missing connector !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 			equ->debugInfo("missing connector");
@@ -909,7 +910,7 @@ void DRC::splitSubs(QDomDocument * doc, QDomElement & root, const QString & part
 
 void DRC::updateDisplay() {
 	QPixmap pixmap = QPixmap::fromImage(*m_displayImage);
-	if (m_displayItem == nullptr) {
+	if (!m_displayItem) {
 		m_displayItem = new QGraphicsPixmapItem(pixmap);
 		m_displayItem->setPos(m_board->sceneBoundingRect().topLeft());
 		m_sketchWidget->scene()->addItem(m_displayItem);
@@ -961,7 +962,7 @@ void DRC::extendBorder(const double keepout, QImage * image) {
 			const int x1 = std::max(x - ikeepout, 0);
 			const int x2 = std::min(x + ikeepout, w);
 			// extend border by keepout
-			int dx;
+			auto dx = 0;
 			for (int dy = y1; dy < y2; ++dy) {
 				uchar * r = image->scanLine(dy);
 				// This section is often the hotspot for creating copper layers,
@@ -986,7 +987,7 @@ void DRC::checkHoles(QStringList & messages, QList<CollidingThing *> & colliding
 	QRectF boardRect = m_board->sceneBoundingRect();
 	foreach (QGraphicsItem * item, m_sketchWidget->scene()->collidingItems(m_board)) {
 		NonConnectorItem * nci = dynamic_cast<NonConnectorItem *>(item);
-		if (nci == nullptr) continue;
+		if (!nci) continue;
 
 		QRectF ncibr = nci->sceneBoundingRect();
 		if (boardRect.contains(ncibr)) continue;
@@ -1032,7 +1033,7 @@ void DRC::checkCopperBoth(QStringList & messages, QList<CollidingThing *> & coll
 	QList<ItemBase *> visited;
 	foreach (QGraphicsItem * item, m_sketchWidget->scene()->items()) {
 		ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
-		if (itemBase == nullptr) continue;
+		if (!itemBase) continue;
 		if (!itemBase->isEverVisible()) continue;
 		if (itemBase->modelPart()->isCore()) continue;
 
@@ -1070,8 +1071,8 @@ void DRC::checkCopperBoth(QStringList & messages, QList<CollidingThing *> & coll
 
 		QDomDocument doc;
 		QString errorStr;
-		int errorLine;
-		int errorColumn;
+		auto errorLine = 0;
+		auto errorColumn = 0;
 		if (!doc.setContent(svg, &errorStr, &errorLine, &errorColumn)) {
 			DebugDialog::debug(QString("itembase svg xml failure %1 %2 %3 %4").arg(itemBase->id()).arg(errorStr).arg(errorLine).arg(errorColumn));
 			continue;
@@ -1134,7 +1135,7 @@ QList<ConnectorItem *> DRC::missingCopper(const QString & layerName, ViewLayer::
 
 	foreach (ConnectorItem * connectorItem, itemBase->cachedConnectorItems()) {
 		SvgIdLayer * svgIdLayer = connectorItem->connector()->fullPinInfo(itemBase->viewID(), viewLayerID);
-		if (svgIdLayer == nullptr) {
+		if (!svgIdLayer) {
 			DebugDialog::debug(QString("missing pin info for %1").arg(itemBase->id()));
 			missing << connectorItem;
 			continue;

--- a/src/autoroute/drc.h
+++ b/src/autoroute/drc.h
@@ -48,18 +48,21 @@ struct Markers {
 	QString outID;
 };
 
+class PCBSketchWidget;
+class ItemBase;
+class ConnectorItem;
 class DRC : public QObject
 {
 	Q_OBJECT
 
 public:
-	DRC(class PCBSketchWidget *, class ItemBase * board);
+	DRC(PCBSketchWidget *, ItemBase * board);
 	virtual ~DRC();
 
 	QStringList start(bool showOkMessage, double keepoutMils);
 
 public:
-	static void splitNetPrep(QDomDocument * masterDoc, QList<class ConnectorItem *> & equi, const Markers &, QList<QDomElement> & net, QList<QDomElement> & alsoNet, QList<QDomElement> & notNet, bool checkIntersection);
+	static void splitNetPrep(QDomDocument * masterDoc, QList<ConnectorItem *> & equi, const Markers &, QList<QDomElement> & net, QList<QDomElement> & alsoNet, QList<QDomElement> & notNet, bool checkIntersection);
 	static void extendBorder(double keepoutImagePixels, QImage * image);
 
 public slots:
@@ -97,8 +100,8 @@ protected:
 	static void splitSubs(QDomDocument *, QDomElement & root, const QString & partID, const Markers &, const QStringList & svgIDs,  const QStringList & terminalIDs, const QList<ItemBase *> &, QHash<QString, QString> & both, bool checkIntersection);
 
 protected:
-	class PCBSketchWidget * m_sketchWidget;
-	class ItemBase * m_board;
+	PCBSketchWidget * m_sketchWidget;
+	ItemBase * m_board;
 	double m_keepout;
 	QImage * m_plusImage;
 	QImage * m_minusImage;

--- a/src/autoroute/drc.h
+++ b/src/autoroute/drc.h
@@ -54,7 +54,7 @@ class DRC : public QObject
 
 public:
 	DRC(class PCBSketchWidget *, class ItemBase * board);
-	virtual ~DRC(void);
+	virtual ~DRC();
 
 	QStringList start(bool showOkMessage, double keepoutMils);
 

--- a/src/autoroute/mazerouter/mazerouter.cpp
+++ b/src/autoroute/mazerouter/mazerouter.cpp
@@ -511,6 +511,8 @@ MazeRouter::MazeRouter(PCBSketchWidget * sketchWidget, QGraphicsItem * board, bo
     m_spareImage(nullptr),
     m_spareImage2(nullptr),
     m_temporaryBoard(false),
+    m_costFunction(nullptr),
+    m_jumperWillFitFunction(nullptr),
     m_grid(nullptr),
     m_cleanupCount(0),
     m_netLabelIndex(-1),
@@ -2586,7 +2588,7 @@ ConnectorItem * MazeRouter::findAnchor(GridPoint gp, const QRectF & gridRect, Tr
 		double d0 = GraphicsUtils::distanceSqd(p0, center);
 		double d1 = GraphicsUtils::distanceSqd(p1, center);
 		double dx, dy, distanceSegment;
-		bool atEndpoint;
+		bool atEndpoint = false;
 		GraphicsUtils::distanceFromLine(center.x(), center.y(), p0.x(), p0.y(), p1.x(), p1.y(), dx, dy, distanceSegment, atEndpoint);
 		if (atEndpoint) {
 			DebugDialog::debug("at endpoint shouldn't happen");

--- a/src/autoroute/mazerouter/mazerouter.h
+++ b/src/autoroute/mazerouter/mazerouter.h
@@ -183,7 +183,7 @@ class MazeRouter : public Autorouter
 
 public:
 	MazeRouter(class PCBSketchWidget *, QGraphicsItem * board, bool adjustIf);
-	~MazeRouter(void);
+	~MazeRouter();
 
 	void start();
 
@@ -249,15 +249,15 @@ protected:
 	int m_halfGridJumperSize;
 	double m_gridPixels;
 	double m_standardWireWidth;
-	QImage * m_displayImage[2];
+	QImage * m_displayImage[2] = { nullptr, nullptr };
 	QImage * m_boardImage;
 	QImage * m_spareImage;
 	QImage * m_spareImage2;
-	QGraphicsPixmapItem * m_displayItem[2];
+	QGraphicsPixmapItem * m_displayItem[2] = { nullptr, nullptr };
 	bool m_temporaryBoard;
 	CostFunction m_costFunction;
 	JumperWillFitFunction m_jumperWillFitFunction;
-	uint m_traceColors[2];
+	uint m_traceColors[2] = { 0 };
 	Grid * m_grid;
 	int m_cleanupCount;
 	int m_netLabelIndex;

--- a/src/autoroute/panelizer.cpp
+++ b/src/autoroute/panelizer.cpp
@@ -106,8 +106,6 @@ int allObstacles(Tile * tile, UserData userData) {
 
 static int PlanePairIndex = 0;
 
-static double Worst = std::numeric_limits<double>::max() / 4;
-
 int roomOn(Tile * tile, TileRect & tileRect, BestPlace * bestPlace)
 {
 	int w = tileRect.xmaxi - tileRect.xmini;
@@ -196,27 +194,18 @@ int roomOnRight(Tile * tile, UserData userData)
 }
 
 
-BestPlace::BestPlace() {
-	bestTile = NULL;
-	bestArea = Worst;
-}
+PanelItem::PanelItem(const PanelItem& from) : 
+    boardName(from.boardName),
+    path(from.path),
+    required(from.required),
+    maxOptional(from.maxOptional),
+    optionalPriority(from.optionalPriority),
+    produced(from.produced),
+    boardSizeInches(from.boardSizeInches),
+    boardID(from.boardID),
+    refPanelItem(from.refPanelItem) 
+{ 
 
-PanelItem::PanelItem() {
-	produced = 0;
-	boardID = 0;
-	refPanelItem = NULL;
-}
-
-PanelItem::PanelItem(PanelItem * from) {
-	this->produced = from->produced;
-	this->boardName = from->boardName;
-	this->path = from->path;
-	this->required = from->required;
-	this->maxOptional = from->maxOptional;
-	this->optionalPriority = from->optionalPriority;
-	this->boardSizeInches = from->boardSizeInches;
-	this->boardID = from->boardID;
-	this->refPanelItem = from;
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/src/autoroute/panelizer.h
+++ b/src/autoroute/panelizer.h
@@ -28,7 +28,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../items/itembase.h"
 #include "cmrouter/tile.h"
 
-
+constexpr double Worst = std::numeric_limits<double>::max() / 4;
 struct PlanePair
 {
 	Plane * thePlane;
@@ -46,51 +46,50 @@ struct PanelItem {
 	// per window
 	QString boardName;
 	QString path;
-	int required;
-	int maxOptional;
-	int optionalPriority;
-	int produced;
+	int required = 0;
+	int maxOptional = 0;
+	int optionalPriority = 0;
+	int produced = 0;
 	QSizeF boardSizeInches;
-	long boardID;
-	PanelItem * refPanelItem;
+	long boardID = 0;
+	PanelItem * refPanelItem = nullptr;
 
 	// per instance
-	double x, y;
-	bool rotate90;
-	PlanePair * planePair;
+	double x = 0.0, y = 0.0;
+	bool rotate90 = false;
+	PlanePair * planePair = nullptr;
 
-	PanelItem();
+	PanelItem() = default;
+    PanelItem(const PanelItem& item);
 
-	PanelItem(PanelItem * from);
+	PanelItem(PanelItem * from) : PanelItem(*from) { }
 };
 
 struct BestPlace
 {
-	Tile * bestTile;
+	Tile * bestTile = nullptr;
 	TileRect bestTileRect;
 	TileRect maxRect;
-	int width;
-	int height;
-	double bestArea;
-	bool rotate90;
-	Plane* plane;
-
-	BestPlace();
+	int width = 0;
+	int height = 0;
+	double bestArea = Worst;
+	bool rotate90 = false;
+	Plane* plane = nullptr;
 };
 
 struct PanelType {
-	double width;
-	double height;
-	double c1;
-	double c2;
+	double width = 0.0;
+	double height = 0.0;
+	double c1 = 0.0;
+	double c2 = 0.0;
 	QString name;
 };
 
 struct PanelParams
 {
 	QList<PanelType *> panelTypes;
-	double panelSpacing;
-	double panelBorder;
+	double panelSpacing = 0.0;
+	double panelBorder = 0.0;
 	QString prefix;
 };
 
@@ -100,11 +99,9 @@ struct LayerThing {
 	SVG2gerber::ForWhy forWhy;
 	QString suffix;
 
-	LayerThing(const QString & n, LayerList ll, SVG2gerber::ForWhy fw, const QString & s) {
-		layerList = ll;
-		name = n;
-		forWhy = fw;
-		suffix = s;
+	LayerThing(const QString & n, LayerList ll, SVG2gerber::ForWhy fw, const QString & s) 
+        : layerList(ll), name(n), forWhy(fw), suffix(s)
+    {
 	}
 };
 

--- a/src/connectors/connectoritem.cpp
+++ b/src/connectors/connectoritem.cpp
@@ -927,8 +927,10 @@ QPointF ConnectorItem::sceneAdjustedTerminalPoint(ConnectorItem * connectee) {
 				}
 				else {
 					QPointF current = this->mapToScene(QPointF(el));
-					double candidateX, candidateY, candidateDistance;
-					bool atEndpoint;
+					double candidateX = 0.0;
+                    double candidateY = 0.0;
+                    double candidateDistance = 0.0;
+					bool atEndpoint = false;
 					GraphicsUtils::distanceFromLine(anchor.x(), anchor.y(), prev.x(), prev.y(), current.x(), current.y(),
 					                                candidateX, candidateY, candidateDistance, atEndpoint);
 					if (candidateDistance < newDistance) {
@@ -2781,7 +2783,7 @@ void ConnectorItem::updateWireCursor(Qt::KeyboardModifiers modifiers)
 
 void ConnectorItem::updateLegCursor(QPointF p, Qt::KeyboardModifiers modifiers)
 {
-	int bendpointIndex;
+	int bendpointIndex = 0;
 	CursorLocation cursorLocation = findLocation(p, bendpointIndex);
 	QCursor cursor;
 	switch (cursorLocation) {

--- a/src/connectors/connectoritem.cpp
+++ b/src/connectors/connectoritem.cpp
@@ -229,7 +229,7 @@ parts editor support
 /////////////////////////////////////////////////////////
 
 static Bezier UndoBezier;
-static BezierDisplay * TheBezierDisplay = NULL;
+static BezierDisplay * TheBezierDisplay = nullptr;
 
 static const double StandardLegConnectorDrawEnabledLength = 5;  // pixels
 static const double StandardLegConnectorDetectLength = 9;       // pixels
@@ -287,14 +287,14 @@ QColor addColor(QColor & color, int offset)
 /////////////////////////////////////////////////////////////
 
 ConnectorItemAction::ConnectorItemAction(QAction * action) : QAction(action) {
-	m_connectorItem = NULL;
+	m_connectorItem = nullptr;
 	this->setText(action->text());
 	this->setStatusTip(action->statusTip());
 	this->setCheckable(action->isCheckable());
 }
 
 ConnectorItemAction::ConnectorItemAction(const QString & title, QObject * parent) : QAction(title, parent) {
-	m_connectorItem = NULL;
+	m_connectorItem = nullptr;
 }
 
 void ConnectorItemAction::setConnectorItem(ConnectorItem * c) {
@@ -308,18 +308,13 @@ ConnectorItem * ConnectorItemAction::connectorItem() {
 /////////////////////////////////////////////////////////
 
 ConnectorItem::ConnectorItem( Connector * connector, ItemBase * attachedTo )
-	: NonConnectorItem(attachedTo)
+	: NonConnectorItem(attachedTo),
+    m_connector(connector),
+    m_overConnectorItem(nullptr)
 {
 	// initialize m_connectorT, otherwise will trigger qWarning("QLine::unitVector: New line does not have unit length");
 	// TODO: figure out why paint is being called with m_connectorT not initialized
-	m_groundFillSeed = false;
-	m_connectorDetectT = m_connectorDrawT = 0;
-	m_draggingCurve = m_draggingLeg = m_rubberBandLeg = m_bigDot = m_hybrid = false;
-	m_hoverEnterSpaceBarWasPressed = m_spaceBarWasPressed = false;
-	m_overConnectorItem = NULL;
-	m_connectorHovering = false;
-	m_connector = connector;
-	if (connector != NULL) {
+	if (connector) {
 		connector->addViewItem(this);
 	}
 	setAcceptHoverEvents(true);
@@ -334,12 +329,12 @@ ConnectorItem::~ConnectorItem() {
 	m_equalPotentialDisplayItems.removeOne(this);
 	//DebugDialog::debug(QString("deleting connectorItem %1").arg((long) this, 0, 16));
 	foreach (ConnectorItem * connectorItem, m_connectedTo) {
-		if (connectorItem != NULL) {
+		if (connectorItem) {
 			//DebugDialog::debug(QString("temp remove %1 %2").arg(this->attachedToID()).arg(connectorItem->attachedToID()));
 			connectorItem->tempRemove(this, this->attachedToID() != connectorItem->attachedToID());
 		}
 	}
-	if (this->connector() != NULL) {
+	if (this->connector()) {
 		this->connector()->removeViewItem(this);
 	}
 	clearCurves();
@@ -364,7 +359,7 @@ void ConnectorItem::hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) {
 	*/
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL && infoGraphicsView->spaceBarIsPressed()) {
+	if (infoGraphicsView && infoGraphicsView->spaceBarIsPressed()) {
 		m_hoverEnterSpaceBarWasPressed = true;
 		event->ignore();
 		return;
@@ -375,14 +370,14 @@ void ConnectorItem::hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) {
 	bool setDefaultCursor = true;
 	m_hoverEnterSpaceBarWasPressed = false;
 	setHoverColor();
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->hoverEnterConnectorItem(event, this);
 		if (m_rubberBandLeg) {
 			updateLegCursor(event->pos(), event->modifiers());
 			setDefaultCursor = false;
 		}
 	}
-	if (this->m_attachedTo != NULL) {
+	if (this->m_attachedTo) {
 		if (this->attachedToItemType() == ModelPart::Wire) {
 			updateWireCursor(event->modifiers());
 			setDefaultCursor = false;
@@ -402,13 +397,13 @@ void ConnectorItem::hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) {
 	QList<ConnectorItem *> visited;
 	restoreColor(visited);
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->hoverLeaveConnectorItem(event, this);
 	}
 
 	CursorMaster::instance()->removeCursor(this);
 
-	if (this->m_attachedTo != NULL) {
+	if (this->m_attachedTo) {
 		m_attachedTo->hoverLeaveConnectorItem(event, this);
 	}
 
@@ -422,7 +417,7 @@ void ConnectorItem::hoverMoveEvent ( QGraphicsSceneHoverEvent * event ) {
 		return;
 	}
 
-	if (this->m_attachedTo != NULL) {
+	if (this->m_attachedTo) {
 		m_attachedTo->hoverMoveConnectorItem(event, this);
 	}
 
@@ -448,7 +443,7 @@ void ConnectorItem::connectorHover(ItemBase * itemBase, bool hovering) {
 		QList<ConnectorItem *> visited;
 		restoreColor(visited);
 	}
-	if (this->m_attachedTo != NULL) {
+	if (this->m_attachedTo) {
 		m_attachedTo->connectorHover(this, itemBase, hovering);
 	}
 }
@@ -464,7 +459,7 @@ void ConnectorItem::connectTo(ConnectorItem * connected) {
 	//DebugDialog::debug(QString("connect to cc:%4 this:%1 to:%2 %3").arg((long) this, 0, 16).arg((long) connected, 0, 16).arg(connected->attachedTo()->modelPartShared()->title()).arg(m_connectedTo.count()) );
 	QList<ConnectorItem *> visited;
 	restoreColor(visited);
-	if (m_attachedTo != NULL) {
+	if (m_attachedTo) {
 		m_attachedTo->connectionChange(this, connected, true);
 	}
 }
@@ -475,7 +470,7 @@ ConnectorItem * ConnectorItem::removeConnection(ItemBase * itemBase) {
 		if (m_connectedTo[i]->attachedTo() == itemBase) {
 			ConnectorItem * removed = m_connectedTo[i];
 			m_connectedTo.removeAt(i);
-			if (m_attachedTo != NULL) {
+			if (m_attachedTo) {
 				m_attachedTo->connectionChange(this, removed, false);
 			}
 			restoreColor(visited);
@@ -487,11 +482,11 @@ ConnectorItem * ConnectorItem::removeConnection(ItemBase * itemBase) {
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void ConnectorItem::removeConnection(ConnectorItem * connectedItem, bool emitChange) {
-	if (connectedItem == NULL) return;
+	if (!connectedItem) return;
 
 	m_connectedTo.removeOne(connectedItem);
 	QList<ConnectorItem *> visited;
@@ -579,7 +574,7 @@ void ConnectorItem::restoreColor(QList<ConnectorItem *> & visited)
 }
 
 void ConnectorItem::setConnectedColor() {
-	if (m_attachedTo == NULL) return;
+	if (!m_attachedTo) return;
 
 	QBrush brush;
 	QPen pen;
@@ -589,7 +584,7 @@ void ConnectorItem::setConnectedColor() {
 }
 
 void ConnectorItem::setNormalColor() {
-	if (m_attachedTo == NULL) return;
+	if (!m_attachedTo) return;
 
 	QBrush brush;
 	QPen pen;
@@ -599,7 +594,7 @@ void ConnectorItem::setNormalColor() {
 }
 
 void ConnectorItem::setUnconnectedColor() {
-	if (m_attachedTo == NULL) return;
+	if (!m_attachedTo) return;
 
 	QBrush brush;
 	QPen pen;
@@ -609,7 +604,7 @@ void ConnectorItem::setUnconnectedColor() {
 }
 
 void ConnectorItem::setHoverColor() {
-	if (m_attachedTo == NULL) return;
+	if (!m_attachedTo) return;
 
 	QBrush brush;
 	QPen pen;
@@ -655,10 +650,10 @@ void ConnectorItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 			m_draggingCurve = false;
 			if (TheBezierDisplay) {
 				delete TheBezierDisplay;
-				TheBezierDisplay = NULL;
+				TheBezierDisplay = nullptr;
 			}
 
-			if (infoGraphicsView != NULL) {
+			if (infoGraphicsView) {
 				infoGraphicsView->prepLegCurveChange(this, m_draggingLegIndex, &UndoBezier, m_legCurves.at(m_draggingLegIndex), false);
 			}
 
@@ -668,7 +663,7 @@ void ConnectorItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 		if (m_oldPolygon.count() < m_legPolygon.count()) {
 			// we inserted a bendpoint
 			InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-			if (infoGraphicsView != NULL) {
+			if (infoGraphicsView) {
 				infoGraphicsView->prepLegBendpointChange(
 				    this,
 				    m_oldPolygon.count(),
@@ -685,17 +680,17 @@ void ConnectorItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
 		}
 
 		bool changeConnections = m_draggingLegIndex == m_legPolygon.count() - 1;
-		if (to != NULL && changeConnections) {
+		if (to && changeConnections) {
 			// center endpoint in the target connectorItem
-			reposition(to->sceneAdjustedTerminalPoint(NULL), m_draggingLegIndex);
+			reposition(to->sceneAdjustedTerminalPoint(nullptr), m_draggingLegIndex);
 		}
-		if (infoGraphicsView != NULL) {
+		if (infoGraphicsView) {
 			infoGraphicsView->prepLegBendpointMove(this, m_draggingLegIndex, mapToScene(m_oldPolygon.at(m_draggingLegIndex)), mapToScene(m_legPolygon.at(m_draggingLegIndex)), to, changeConnections);
 		}
 		return;
 	}
 
-	if (this->m_attachedTo != NULL && m_attachedTo->acceptsMouseReleaseConnectorEvent(this, event)) {
+	if (this->m_attachedTo && m_attachedTo->acceptsMouseReleaseConnectorEvent(this, event)) {
 		m_attachedTo->mouseReleaseConnectorEvent(this, event);
 		return;
 	}
@@ -723,7 +718,7 @@ void ConnectorItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
 		return;
 	}
 
-	if (this->m_attachedTo != NULL && m_attachedTo->acceptsMouseDoubleClickConnectorEvent(this, event)) {
+	if (this->m_attachedTo && m_attachedTo->acceptsMouseDoubleClickConnectorEvent(this, event)) {
 		m_attachedTo->mouseDoubleClickConnectorEvent(this);
 		return;
 	}
@@ -736,7 +731,7 @@ void ConnectorItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
 	if (m_rubberBandLeg && m_draggingLeg) {
 		if (m_draggingCurve) {
 			Bezier * bezier = m_legCurves.at(m_draggingLegIndex);
-			if (bezier != NULL && !bezier->isEmpty()) {
+			if (bezier && !bezier->isEmpty()) {
 				prepareGeometryChange();
 				bezier->recalc(event->pos());
 				calcConnectorEnd();
@@ -792,7 +787,7 @@ void ConnectorItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
 		return;
 	}
 
-	if (this->m_attachedTo != NULL && m_attachedTo->acceptsMouseMoveConnectorEvent(this, event)) {
+	if (this->m_attachedTo && m_attachedTo->acceptsMouseMoveConnectorEvent(this, event)) {
 		m_attachedTo->mouseMoveConnectorEvent(this, event);
 		return;
 	}
@@ -817,7 +812,7 @@ void ConnectorItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
 	clearEqualPotentialDisplay();
 
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL && infographics->spaceBarIsPressed()) {
+	if (infographics && infographics->spaceBarIsPressed()) {
 		event->ignore();
 		return;
 	}
@@ -832,11 +827,11 @@ void ConnectorItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
 		//connectorItem->debugInfo("display eqp");
 	}
 
-	if (m_rubberBandLeg && this->m_attachedTo != NULL && m_attachedTo->acceptsMousePressLegEvent(this, event)) {
+	if (m_rubberBandLeg && this->m_attachedTo && m_attachedTo->acceptsMousePressLegEvent(this, event)) {
 		if (legMousePressEvent(event)) return;
 	}
 
-	if (this->m_attachedTo != NULL && m_attachedTo->acceptsMousePressConnectorEvent(this, event)) {
+	if (this->m_attachedTo && m_attachedTo->acceptsMousePressConnectorEvent(this, event)) {
 		m_attachedTo->mousePressConnectorEvent(this, event);
 		return;
 	}
@@ -863,7 +858,7 @@ void ConnectorItem::attachedMoved(bool includeRatsnest, QList<ConnectorItem *> &
 	allTo.remove(this);
 	foreach (ConnectorItem * toConnectorItem, allTo) {
 		ItemBase * itemBase = toConnectorItem->attachedTo();
-		if (itemBase == NULL) continue;
+		if (!itemBase) continue;
 		if (!itemBase->isVisible()) {
 			//this->debugInfo("continue");
 			//itemBase->debugInfo("    ");
@@ -878,7 +873,7 @@ void ConnectorItem::attachedMoved(bool includeRatsnest, QList<ConnectorItem *> &
 }
 
 ConnectorItem * ConnectorItem::firstConnectedToIsh() {
-	if (m_connectedTo.count() <= 0) return NULL;
+	if (m_connectedTo.count() <= 0) return nullptr;
 
 	foreach (ConnectorItem * connectorItem, m_connectedTo) {
 		if (connectorItem->attachedTo()->getRatsnest()) continue;
@@ -896,7 +891,7 @@ ConnectorItem * ConnectorItem::firstConnectedToIsh() {
 		return connectorItem;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void ConnectorItem::setTerminalPoint(QPointF p) {
@@ -917,10 +912,10 @@ QPointF ConnectorItem::adjustedTerminalPoint() {
 
 QPointF ConnectorItem::sceneAdjustedTerminalPoint(ConnectorItem * connectee) {
 
-	if ((connectee != NULL) && !m_circular && !m_shape.isEmpty() && (connectee->attachedToItemType() == ModelPart::Wire)) {
+	if (connectee && !m_circular && !m_shape.isEmpty() && (connectee->attachedToItemType() == ModelPart::Wire)) {
 		Wire * wire = qobject_cast<Wire *>(connectee->attachedTo());
-		if ((wire != NULL) && !wire->getRatsnest()) {
-			QPointF anchor = wire->otherConnector(connectee)->sceneAdjustedTerminalPoint(NULL);
+		if (wire && !wire->getRatsnest()) {
+			QPointF anchor = wire->otherConnector(connectee)->sceneAdjustedTerminalPoint(nullptr);
 			double newX = 0, newY = 0, newDistance = MAX_DOUBLE;
 			int count = m_shape.elementCount();
 
@@ -1019,79 +1014,79 @@ void ConnectorItem::setOverConnectorItem(ConnectorItem * connectorItem) {
 
 
 const QString & ConnectorItem::connectorSharedID() {
-	if (m_connector == NULL) return ___emptyString___;
+	if (!m_connector) return ___emptyString___;
 
 	return m_connector->connectorSharedID();
 }
 
 const QString & ConnectorItem::connectorSharedReplacedby() {
-	if (m_connector == NULL) return ___emptyString___;
+	if (!m_connector) return ___emptyString___;
 
 	return m_connector->connectorSharedReplacedby();
 }
 
 ErcData * ConnectorItem::connectorSharedErcData() {
-	if (m_connector == NULL) return NULL;
+	if (!m_connector) return nullptr;
 
 	return m_connector->connectorSharedErcData();
 }
 
 const QString & ConnectorItem::connectorSharedName() {
-	if (m_connector == NULL) return ___emptyString___;
+	if (!m_connector) return ___emptyString___;
 
 	return m_connector->connectorSharedName();
 }
 
 const QString & ConnectorItem::connectorSharedDescription() {
-	if (m_connector == NULL) return ___emptyString___;
+	if (!m_connector) return ___emptyString___;
 
 	return m_connector->connectorSharedDescription();
 }
 
 const QString & ConnectorItem::busID() {
-	if (m_connector == NULL) return ___emptyString___;
+	if (!m_connector) return ___emptyString___;
 
 	return m_connector->busID();
 }
 
 ModelPartShared * ConnectorItem::modelPartShared() {
-	if (m_attachedTo == NULL) return NULL;
+	if (!m_attachedTo) return nullptr;
 
 	return m_attachedTo->modelPartShared();
 }
 
 ModelPart * ConnectorItem::modelPart() {
-	if (m_attachedTo == NULL) return NULL;
+	if (!m_attachedTo) return nullptr;
 
 	return m_attachedTo->modelPart();
 }
 
 Bus * ConnectorItem::bus() {
-	if (m_connector == NULL) return NULL;
+	if (!m_connector) return nullptr;
 
 	return m_connector->bus();
 }
 
 ViewLayer::ViewLayerID ConnectorItem::attachedToViewLayerID() {
-	if (m_attachedTo == NULL) return ViewLayer::UnknownLayer;
+	if (!m_attachedTo) return ViewLayer::UnknownLayer;
 
 	return m_attachedTo->viewLayerID();
 }
 
 ViewLayer::ViewLayerPlacement ConnectorItem::attachedToViewLayerPlacement() {
-	if (m_attachedTo == NULL) return ViewLayer::UnknownPlacement;
+	if (!m_attachedTo) return ViewLayer::UnknownPlacement;
 
 	return m_attachedTo->viewLayerPlacement();
 }
 
 ViewLayer::ViewID ConnectorItem::attachedToViewID() {
-	if (m_attachedTo == NULL) return ViewLayer::UnknownView;
+	if (!m_attachedTo) return ViewLayer::UnknownView;
 
 	return m_attachedTo->viewID();
 }
 
 Connector::ConnectorType ConnectorItem::connectorType() {
-	if (m_connector == NULL) return Connector::Unknown;
+	if (!m_connector) return Connector::Unknown;
 
 	return m_connector->connectorType();
 }
@@ -1135,7 +1130,7 @@ void ConnectorItem::saveInstance(QXmlStreamWriter & writer) {
 			writer.writeEndElement();
 
 			Bezier * bezier = m_legCurves.at(i);
-			if (bezier == NULL) {
+			if (!bezier) {
 				writer.writeStartElement("bezier");
 				writer.writeEndElement();
 			}
@@ -1189,7 +1184,7 @@ Wire * ConnectorItem::directlyWiredTo(ConnectorItem * source, ConnectorItem * ta
 }
 
 Wire * ConnectorItem::directlyWiredToAux(ConnectorItem * source, ConnectorItem * target, ViewGeometry::WireFlags flags, QList<ConnectorItem *> & visited) {
-	if (visited.contains(source)) return NULL;
+	if (visited.contains(source)) return nullptr;
 
 	QList<ConnectorItem *> equals;
 	equals << source;
@@ -1206,7 +1201,7 @@ Wire * ConnectorItem::directlyWiredToAux(ConnectorItem * source, ConnectorItem *
 	foreach (ConnectorItem * fromItem, equals) {
 		foreach (ConnectorItem * toConnectorItem, fromItem->m_connectedTo) {
 			ItemBase * toItem = toConnectorItem->attachedTo();
-			if (toItem == NULL) {
+			if (!toItem) {
 				continue;  // shouldn't happen
 			}
 
@@ -1238,7 +1233,7 @@ Wire * ConnectorItem::directlyWiredToAux(ConnectorItem * source, ConnectorItem *
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 bool ConnectorItem::isConnectedToPart() {
@@ -1249,7 +1244,7 @@ bool ConnectorItem::isConnectedToPart() {
 	ConnectorItem * thisCrossConnectorItem = this->getCrossLayerConnectorItem();
 	QList<ConnectorItem *> busConnectedItems;
 	Bus * b = bus();
-	if (b != NULL) {
+	if (b) {
 		attachedTo()->busConnectorItems(b, this, busConnectedItems);
 	}
 
@@ -1280,7 +1275,7 @@ bool ConnectorItem::isConnectedToPart() {
 		}
 
 		ConnectorItem * crossConnectorItem = connectorItem->getCrossLayerConnectorItem();
-		if (crossConnectorItem != NULL) {
+		if (crossConnectorItem) {
 			if (!tempItems.contains(crossConnectorItem)) {
 				tempItems.append(crossConnectorItem);
 			}
@@ -1293,7 +1288,7 @@ bool ConnectorItem::isConnectedToPart() {
 		}
 
 		Bus * bus = connectorItem->bus();
-		if (bus != NULL) {
+		if (bus) {
 			QList<ConnectorItem *> busConnectedItems;
 			connectorItem->attachedTo()->busConnectorItems(bus, connectorItem, busConnectedItems);
 			foreach (ConnectorItem * busConnectedItem, busConnectedItems) {
@@ -1320,8 +1315,8 @@ void ConnectorItem::collectEqualPotential(QList<ConnectorItem *> & connectorItem
 		ConnectorItem * connectorItem = tempItems[i];
 		//connectorItem->debugInfo("testing eqp");
 
-		Wire * fromWire = (connectorItem->attachedToItemType() == ModelPart::Wire) ? qobject_cast<Wire *>(connectorItem->attachedTo()) : NULL;
-		if (fromWire != NULL) {
+		Wire * fromWire = (connectorItem->attachedToItemType() == ModelPart::Wire) ? qobject_cast<Wire *>(connectorItem->attachedTo()) : nullptr;
+		if (fromWire) {
 			if (fromWire->hasAnyFlag(skipFlags)) {
 				// don't add this kind of wire
 				continue;
@@ -1330,7 +1325,7 @@ void ConnectorItem::collectEqualPotential(QList<ConnectorItem *> & connectorItem
 		else {
 			if (crossLayers) {
 				ConnectorItem * crossConnectorItem = connectorItem->getCrossLayerConnectorItem();
-				if (crossConnectorItem != NULL) {
+				if (crossConnectorItem) {
 					if (!tempItems.contains(crossConnectorItem)) {
 						tempItems.append(crossConnectorItem);
 					}
@@ -1345,7 +1340,7 @@ void ConnectorItem::collectEqualPotential(QList<ConnectorItem *> & connectorItem
 		foreach (ConnectorItem * cto, connectorItem->connectedToItems()) {
 			if (tempItems.contains(cto)) continue;
 
-			if ((skipFlags & ViewGeometry::NormalFlag) && (fromWire == NULL) && (cto->attachedToItemType() != ModelPart::Wire)) {
+			if ((skipFlags & ViewGeometry::NormalFlag) && (!fromWire) && (cto->attachedToItemType() != ModelPart::Wire)) {
 				// direct (part-to-part) connections not allowed
 				continue;
 			}
@@ -1354,7 +1349,7 @@ void ConnectorItem::collectEqualPotential(QList<ConnectorItem *> & connectorItem
 		}
 
 		Bus * bus = connectorItem->bus();
-		if (bus != NULL) {
+		if (bus) {
 			QList<ConnectorItem *> busConnectedItems;
 			connectorItem->attachedTo()->busConnectorItems(bus, connectorItem, busConnectedItems);
 #ifndef QT_NO_DEBUG
@@ -1418,7 +1413,7 @@ void ConnectorItem::collectPart(ConnectorItem * connectorItem, QList<ConnectorIt
 	if (partsConnectors.contains(connectorItem)) return;
 
 	ConnectorItem * crossConnectorItem = connectorItem->getCrossLayerConnectorItem();
-	if (crossConnectorItem != NULL) {
+	if (crossConnectorItem) {
 		if (partsConnectors.contains(crossConnectorItem)) {
 			return;
 		}
@@ -1524,7 +1519,7 @@ void ConnectorItem::updateTooltip() {
 }
 
 void ConnectorItem::clearConnector() {
-	m_connector = NULL;
+	m_connector = nullptr;
 }
 
 
@@ -1569,10 +1564,10 @@ bool ConnectorItem::isEverVisible() {
 
 bool ConnectorItem::isGrounded(ConnectorItem * c1, ConnectorItem * c2) {
 	QList<ConnectorItem *> connectorItems;
-	if (c1 != NULL) {
+	if (c1) {
 		connectorItems.append(c1);
 	}
-	if (c2 != NULL) {
+	if (c2) {
 		connectorItems.append(c2);
 	}
 	collectEqualPotential(connectorItems, true, ViewGeometry::NoFlag);
@@ -1595,9 +1590,9 @@ bool ConnectorItem::isGrounded() {
 }
 
 ConnectorItem * ConnectorItem::getCrossLayerConnectorItem() {
-	if (m_connector == NULL) return NULL;
-	if (m_attachedTo == NULL) return NULL;
-	if (m_attachedTo->viewID() != ViewLayer::PCBView) return NULL;
+	if (!m_connector) return nullptr;
+	if (!m_attachedTo) return nullptr;
+	if (m_attachedTo->viewID() != ViewLayer::PCBView) return nullptr;
 
 	ViewLayer::ViewLayerID viewLayerID = attachedToViewLayerID();
 	if (viewLayerID == ViewLayer::Copper0) {
@@ -1607,7 +1602,7 @@ ConnectorItem * ConnectorItem::getCrossLayerConnectorItem() {
 		return m_connector->connectorItemByViewLayerID(this->attachedToViewID(), ViewLayer::Copper0);
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 bool ConnectorItem::isInLayers(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
@@ -1615,7 +1610,7 @@ bool ConnectorItem::isInLayers(ViewLayer::ViewLayerPlacement viewLayerPlacement)
 }
 
 bool ConnectorItem::isCrossLayerConnectorItem(ConnectorItem * candidate) {
-	if (candidate == NULL) return false;
+	if (!candidate) return false;
 
 	ConnectorItem * cross = getCrossLayerConnectorItem();
 	return cross == candidate;
@@ -1665,7 +1660,7 @@ void ConnectorItem::paintLeg(QPainter * painter)
 
 	bool hasCurves = false;
 	foreach (Bezier * bezier, m_legCurves) {
-		if (bezier != NULL && !bezier->isEmpty()) {
+		if (bezier && !bezier->isEmpty()) {
 			hasCurves = true;
 			break;
 		}
@@ -1697,7 +1692,7 @@ void ConnectorItem::paintLeg(QPainter * painter)
 
 	// now draw the connector
 	Bezier * bezier = m_legCurves.at(m_legCurves.count() - 2);
-	bool connectorIsCurved = (bezier != NULL && !bezier->isEmpty());
+	bool connectorIsCurved = (bezier && !bezier->isEmpty());
 	Bezier left, right;
 	QPainterPath path;
 	if (connectorIsCurved) {
@@ -1756,7 +1751,7 @@ void ConnectorItem::paintLeg(QPainter * painter, bool hasCurves)
 
 ConnectorItem * ConnectorItem::chooseFromSpec(ViewLayer::ViewLayerPlacement viewLayerPlacement) {
 	ConnectorItem * crossConnectorItem = getCrossLayerConnectorItem();
-	if (crossConnectorItem == NULL) return this;
+	if (!crossConnectorItem) return this;
 
 	ViewLayer::ViewLayerID basis = ViewLayer::Copper0;
 	switch (viewLayerPlacement) {
@@ -1789,7 +1784,7 @@ bool ConnectorItem::connectedToWires() {
 	}
 
 	ConnectorItem * crossConnectorItem = getCrossLayerConnectorItem();
-	if (crossConnectorItem == NULL) return false;
+	if (!crossConnectorItem) return false;
 
 	foreach (ConnectorItem * toConnectorItem, crossConnectorItem->connectedToItems()) {
 		if (toConnectorItem->attachedToItemType() == ModelPart::Wire) {
@@ -1805,16 +1800,16 @@ void ConnectorItem::displayRatsnest(QList<ConnectorItem *> & partConnectorItems,
 	bool gotFormerColor = false;
 	QColor formerColor;
 
-	VirtualWire * vw = NULL;
+	VirtualWire * vw = nullptr;
 	foreach (ConnectorItem * fromConnectorItem, partConnectorItems) {
 		foreach (ConnectorItem * toConnectorItem, fromConnectorItem->connectedToItems()) {
 			vw = qobject_cast<VirtualWire *>(toConnectorItem->attachedTo());
-			if (vw != NULL) break;
+			if (vw) break;
 		}
-		if (vw != NULL) break;
+		if (vw) break;
 	}
 
-	if (vw != NULL) {
+	if (vw) {
 		formerColorWasNamed = vw->colorWasNamed();
 		formerColor = vw->color();
 		gotFormerColor = true;
@@ -1822,7 +1817,7 @@ void ConnectorItem::displayRatsnest(QList<ConnectorItem *> & partConnectorItems,
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView == NULL) return;
+	if (!infoGraphicsView) return;
 
 	if (partConnectorItems.count() < 2) return;
 
@@ -1856,11 +1851,11 @@ void ConnectorItem::clearRatsnestDisplay(QList<ConnectorItem *> & connectorItems
 
 	QSet<VirtualWire *> ratsnests;
 	foreach (ConnectorItem * fromConnectorItem, connectorItems) {
-		if (fromConnectorItem == NULL) continue;
+		if (!fromConnectorItem) continue;
 
 		foreach (ConnectorItem * toConnectorItem, fromConnectorItem->connectedToItems()) {
 			VirtualWire * vw = qobject_cast<VirtualWire *>(toConnectorItem->attachedTo());
-			if (vw != NULL) {
+			if (vw) {
 				ratsnests.insert(vw);
 			}
 		}
@@ -1868,13 +1863,13 @@ void ConnectorItem::clearRatsnestDisplay(QList<ConnectorItem *> & connectorItems
 
 	foreach (VirtualWire * vw, ratsnests.values()) {
 		ConnectorItem * c1 = vw->connector0()->firstConnectedToIsh();
-		if (c1 != NULL) {
+		if (c1) {
 			vw->connector0()->tempRemove(c1, false);
 			c1->tempRemove(vw->connector0(), false);
 		}
 
 		ConnectorItem * c2 = vw->connector1()->firstConnectedToIsh();
-		if (c2 != NULL) {
+		if (c2) {
 			vw->connector1()->tempRemove(c2, false);
 			c2->tempRemove(vw->connector1(), false);
 		}
@@ -1917,7 +1912,7 @@ void ConnectorItem::debugInfo(const QString & msg)
 {
 
 #ifndef QT_NO_DEBUG
-	QPointF p = sceneAdjustedTerminalPoint(NULL);
+	QPointF p = sceneAdjustedTerminalPoint(nullptr);
 	QString s = QString("%1 cid:%2 cname:%3 title:%4 id:%5 type:%6 inst:%7 vlid:%8 vid:%9 spec:%10 flg:%11 hy:%12 bus:%13 r:%14 sw:%15 pos:(%16 %17)")
 	            .arg(msg)
 	            .arg(this->connectorSharedID())
@@ -1952,14 +1947,14 @@ double ConnectorItem::minDimension() {
 ConnectorItem * ConnectorItem::findConnectorUnder(bool useTerminalPoint, bool allowAlready, const QList<ConnectorItem *> & exclude, bool displayDragTooltip, ConnectorItem * other)
 {
 	QList<QGraphicsItem *> items = useTerminalPoint
-	                               ? this->scene()->items(this->sceneAdjustedTerminalPoint(NULL))
+	                               ? this->scene()->items(this->sceneAdjustedTerminalPoint(nullptr))
 	                               : this->scene()->items(mapToScene(this->rect()));  // only wires use rect
 	QList<ConnectorItem *> candidates;
 	// for the moment, take the topmost ConnectorItem that doesn't belong to me
 	foreach (QGraphicsItem * item, items) {
 		ConnectorItem * connectorItemUnder = dynamic_cast<ConnectorItem *>(item);
-		if (connectorItemUnder == NULL) continue;
-		if (connectorItemUnder->connector() == NULL) continue;  // shouldn't happen
+		if (!connectorItemUnder) continue;
+		if (!connectorItemUnder->connector()) continue;  // shouldn't happen
 		if (attachedTo()->childItems().contains(connectorItemUnder)) continue;  // don't use own connectors
 		if (!this->connectionIsAllowed(connectorItemUnder)) {
 			continue;
@@ -1975,7 +1970,7 @@ ConnectorItem * ConnectorItem::findConnectorUnder(bool useTerminalPoint, bool al
 		candidates.append(connectorItemUnder);
 	}
 
-	ConnectorItem * candidate = NULL;
+	ConnectorItem * candidate = nullptr;
 	if (candidates.count() == 1) {
 		candidate = candidates[0];
 	}
@@ -1984,23 +1979,23 @@ ConnectorItem * ConnectorItem::findConnectorUnder(bool useTerminalPoint, bool al
 		candidate = candidates[0];
 	}
 
-	if (m_overConnectorItem != NULL && candidate != m_overConnectorItem) {
-		m_overConnectorItem->connectorHover(NULL, false);
+	if (m_overConnectorItem&& candidate != m_overConnectorItem) {
+		m_overConnectorItem->connectorHover(nullptr, false);
 	}
-	if (candidate != NULL && candidate != m_overConnectorItem) {
-		candidate->connectorHover(NULL, true);
+	if (candidate && candidate != m_overConnectorItem) {
+		candidate->connectorHover(nullptr, true);
 	}
 
 	m_overConnectorItem = candidate;
 
-	if (candidate == NULL) {
+	if (!candidate) {
 		if (this->connectorHovering()) {
-			this->connectorHover(NULL, false);
+			this->connectorHover(nullptr, false);
 		}
 	}
 	else {
 		if (!this->connectorHovering()) {
-			this->connectorHover(NULL, true);
+			this->connectorHover(nullptr, true);
 		}
 	}
 
@@ -2014,7 +2009,7 @@ ConnectorItem * ConnectorItem::findConnectorUnder(bool useTerminalPoint, bool al
 void ConnectorItem::displayTooltip(ConnectorItem * ci, ConnectorItem * other)
 {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView == NULL) return;
+	if (!infoGraphicsView) return;
 
 	// Activate tooltip for destination connector. based on a patch submitted by bryant.mairs
 	QString text;
@@ -2055,11 +2050,11 @@ void ConnectorItem::displayTooltip(ConnectorItem * ci, ConnectorItem * other)
 
 ConnectorItem * ConnectorItem::releaseDrag() {
 	ConnectorItem * result = m_overConnectorItem;
-	if (m_overConnectorItem != NULL) {
-		m_overConnectorItem->connectorHover(NULL, false);
+	if (m_overConnectorItem) {
+		m_overConnectorItem->connectorHover(nullptr, false);
 
 		// clean up
-		setOverConnectorItem(NULL);
+		setOverConnectorItem(nullptr);
 		clearConnectorHover();
 		QList<ConnectorItem *> visited;
 		restoreColor(visited);
@@ -2077,7 +2072,7 @@ void ConnectorItem::resetLeg(const QPolygonF & poly, bool relative, bool active,
 {
 	if (!m_rubberBandLeg) return;
 
-	ConnectorItem * target = NULL;
+	ConnectorItem * target = nullptr;
 	foreach (ConnectorItem * connectorItem, this->m_connectedTo) {
 		if (connectorItem->connectorType() == Connector::Female) {
 			target = connectorItem;
@@ -2085,7 +2080,7 @@ void ConnectorItem::resetLeg(const QPolygonF & poly, bool relative, bool active,
 		}
 	}
 
-	if (target == NULL) {
+	if (!target) {
 		setLeg(poly, relative, why);
 		return;
 	}
@@ -2103,7 +2098,7 @@ void ConnectorItem::resetLeg(const QPolygonF & poly, bool relative, bool active,
 
 	//DebugDialog::debug("connectorItem prepareGeometryChange 1");
 	prepareGeometryChange();
-	QPointF sceneNewLast = target->sceneAdjustedTerminalPoint(NULL);
+	QPointF sceneNewLast = target->sceneAdjustedTerminalPoint(nullptr);
 	QPointF sceneOldLast = poly.last();
 
 	for (int i = 1; i < m_legPolygon.count(); i++) {
@@ -2145,7 +2140,7 @@ QString ConnectorItem::makeLegSvg(QPointF offset, double dpi, double printerScal
 	for (int i = 1; i < m_legPolygon.count(); i++) {
 		QPointF p = m_legPolygon.at(i);
 		Bezier * bezier = m_legCurves.at(i - 1);
-		if (bezier == NULL || bezier->isEmpty()) {
+		if (!bezier || bezier->isEmpty()) {
 			data += "L";
 			data += TextUtils::pointToSvgString(mapToScene(p), offset, dpi, printerScale);
 		}
@@ -2234,7 +2229,7 @@ QPainterPath ConnectorItem::shapeAux(double width) const
 	path.moveTo(m_legPolygon.at(0));
 	for (int i = 1; i < m_legPolygon.count(); i++) {
 		Bezier * bezier = m_legCurves.at(i - 1);
-		if (bezier != NULL && !bezier->isEmpty()) {
+		if (bezier && !bezier->isEmpty()) {
 			path.cubicTo(bezier->cp0(), bezier->cp1(), m_legPolygon.at(i));
 		}
 		else {
@@ -2252,7 +2247,7 @@ void ConnectorItem::repositionTarget()
 	// this connector is connected to another part which is being dragged
 	foreach (ConnectorItem * connectorItem, this->m_connectedTo) {
 		if (connectorItem->connectorType() == Connector::Female) {
-			reposition(connectorItem->sceneAdjustedTerminalPoint(NULL), m_legPolygon.count() - 1);
+			reposition(connectorItem->sceneAdjustedTerminalPoint(nullptr), m_legPolygon.count() - 1);
 			break;
 		}
 	}
@@ -2280,7 +2275,7 @@ void ConnectorItem::repoly(const QPolygonF & poly, bool relative)
 
 	foreach (QPointF p, poly) {
 		m_legPolygon.append(relative ? p : mapFromScene(p));
-		m_legCurves.append(NULL);
+		m_legCurves.append(nullptr);
 	}
 	//foreach (QPointF p, m_legPolygon) DebugDialog::debug(QString("point a %1 %2").arg(p.x()).arg(p.y()));
 	calcConnectorEnd();
@@ -2302,7 +2297,7 @@ void ConnectorItem::calcConnectorEnd()
 	double detectlen = qMax(0.5, qMin(lineLen, StandardLegConnectorDetectLength));
 
 	Bezier * bezier = m_legCurves.at(m_legCurves.count() - 2);
-	if (bezier == NULL || bezier->isEmpty()) {
+	if (!bezier || bezier->isEmpty()) {
 		m_connectorDrawEnd = QPointF(p1 - QPointF(dx * drawlen / lineLen, dy * drawlen / lineLen));
 		m_connectorDetectEnd = QPointF(p1 - QPointF(dx * detectlen / lineLen, dy * detectlen / lineLen));
 		return;
@@ -2372,8 +2367,8 @@ void ConnectorItem::setRubberBandLeg(QColor color, double strokeWidth, QLineF pa
 	setPos(parentLine.p1());
 	m_legPolygon.append(QPointF(0,0));
 	m_legPolygon.append(parentLine.p2() - parentLine.p1());
-	m_legCurves.append(NULL);
-	m_legCurves.append(NULL);
+	m_legCurves.append(nullptr);
+	m_legCurves.append(nullptr);
 	m_legStrokeWidth = strokeWidth;
 	m_legColor = color;
 	reposition(m_attachedTo->mapToScene(parentLine.p2()), 1);
@@ -2414,7 +2409,7 @@ bool ConnectorItem::legMousePressEvent(QGraphicsSceneMouseEvent *event) {
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->prepLegSelection(this->attachedTo());
 	}
 
@@ -2436,7 +2431,7 @@ bool ConnectorItem::legMousePressEvent(QGraphicsSceneMouseEvent *event) {
 		if (curvyWiresIndicated(event->modifiers())) {
 			m_draggingLegIndex = bendpointIndex - 1;
 			Bezier * bezier = m_legCurves.at(m_draggingLegIndex);
-			if (bezier == NULL) {
+			if (!bezier) {
 				bezier = new Bezier();
 				m_legCurves.replace(m_draggingLegIndex, bezier);
 			}
@@ -2478,7 +2473,7 @@ bool ConnectorItem::legMousePressEvent(QGraphicsSceneMouseEvent *event) {
 ConnectorItem::CursorLocation ConnectorItem::findLocation(QPointF location, int & bendpointIndex) {
 	QPainterPath path;
 	Bezier * bezier = m_legCurves.at(m_legCurves.count() - 2);
-	if (bezier == NULL || bezier->isEmpty()) {
+	if (!bezier || bezier->isEmpty()) {
 		path.moveTo(m_connectorDetectEnd);
 		path.lineTo(m_legPolygon.last());
 	}
@@ -2500,7 +2495,7 @@ ConnectorItem::CursorLocation ConnectorItem::findLocation(QPointF location, int 
 		QPainterPath path;
 		path.moveTo(m_legPolygon.at(i));
 		Bezier * bezier = m_legCurves.at(i);
-		if (bezier != NULL && !bezier->isEmpty()) {
+		if (bezier && !bezier->isEmpty()) {
 			path.cubicTo(bezier->cp0(), bezier->cp1(), m_legPolygon.at(i + 1));
 		}
 		else {
@@ -2541,7 +2536,7 @@ void ConnectorItem::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setActiveConnectorItem(this);
 	}
 
@@ -2564,7 +2559,7 @@ void ConnectorItem::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 		QAction * addAction = menu.addAction(tr("Add bendpoint"));
 		addAction->setData(1);
 		Bezier * bezier = m_legCurves.at(bendpointIndex - 1);
-		if (bezier != NULL && !bezier->isEmpty()) {
+		if (bezier && !bezier->isEmpty()) {
 			QAction * straightenAction = menu.addAction(tr("Straighten curve"));
 			straightenAction->setData(2);
 		}
@@ -2575,7 +2570,7 @@ void ConnectorItem::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 			}
 			else if (selectedAction->data().toInt() == 2) {
 				InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-				if (infoGraphicsView != NULL) {
+				if (infoGraphicsView) {
 					Bezier newBezier;
 					infoGraphicsView->prepLegCurveChange(this, bendpointIndex - 1,bezier, &newBezier, true);
 				}
@@ -2610,7 +2605,7 @@ void ConnectorItem::insertBendpoint(QPointF p, int bendpointIndex)
 	m_oldPolygon = m_legPolygon;
 	insertBendpointAux(p, bendpointIndex);
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->prepLegBendpointChange(this, m_oldPolygon.count(), m_legPolygon.count(), bendpointIndex, p,
 		        &UndoBezier, m_legCurves.at(bendpointIndex - 1), m_legCurves.at(bendpointIndex), false);
 	}
@@ -2622,9 +2617,9 @@ Bezier * ConnectorItem::insertBendpointAux(QPointF p, int bendpointIndex)
 {
 	UndoBezier.clear();
 	m_legPolygon.insert(bendpointIndex, p);
-	m_legCurves.insert(bendpointIndex, NULL);
+	m_legCurves.insert(bendpointIndex, nullptr);
 	Bezier * bezier = m_legCurves.at(bendpointIndex - 1);
-	if (bezier == NULL || bezier->isEmpty()) return NULL;
+	if (!bezier || bezier->isEmpty()) return nullptr;
 
 	QPointF p0 = m_legPolygon.at(bendpointIndex - 1);
 	QPointF p1 = m_legPolygon.at(bendpointIndex + 1);
@@ -2636,7 +2631,7 @@ Bezier * ConnectorItem::insertBendpointAux(QPointF p, int bendpointIndex)
 	bezier->split(t, left, right);
 	replaceBezier(bendpointIndex - 1, &left);
 	replaceBezier(bendpointIndex, &right);
-	return NULL;
+	return nullptr;
 }
 
 void ConnectorItem::removeBendpoint(int bendpointIndex)
@@ -2665,7 +2660,7 @@ void ConnectorItem::removeBendpoint(int bendpointIndex)
 	if (bezier) delete bezier;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->prepLegBendpointChange(this, m_oldPolygon.count(), m_legPolygon.count(), bendpointIndex, p, &b0, &b1, &b2, false);
 	}
 
@@ -2677,7 +2672,7 @@ void ConnectorItem::removeBendpoint(int bendpointIndex)
 void ConnectorItem::clearCurves()
 {
 	foreach (Bezier * bezier, m_legCurves) {
-		if (bezier != NULL) delete bezier;
+		if (bezier) delete bezier;
 	}
 	m_legCurves.clear();
 }
@@ -2696,7 +2691,7 @@ void ConnectorItem::addLegBendpoint(int index, QPointF p, const Bezier * bezierL
 	prepareGeometryChange();
 
 	m_legPolygon.insert(index, p);
-	m_legCurves.insert(index, NULL);
+	m_legCurves.insert(index, nullptr);
 	replaceBezier(index - 1, bezierLeft);
 	replaceBezier(index, bezierRight);
 	calcConnectorEnd();
@@ -2732,7 +2727,7 @@ const QVector<Bezier *> & ConnectorItem::beziers()
 void ConnectorItem::replaceBezier(int index, const Bezier * newBezier)
 {
 	Bezier * bezier = m_legCurves.at(index);
-	if (bezier == NULL && newBezier == NULL) {
+	if (!bezier && !newBezier) {
 	}
 	else if (bezier && newBezier) {
 		bezier->copy(newBezier);
@@ -2774,7 +2769,7 @@ void ConnectorItem::updateWireCursor(Qt::KeyboardModifiers modifiers)
 		if (modifiers & altOrMetaModifier()) {
 			//DebugDialog::debug("uwc alt");
 			Wire * wire = qobject_cast<Wire *>(attachedTo());
-			if (wire != NULL && wire->canChainMultiple()) {
+			if (wire && wire->canChainMultiple()) {
 				//DebugDialog::debug("uwc make wire");
 				cursor = *CursorMaster::MakeWireCursor;
 			}
@@ -2812,7 +2807,7 @@ void ConnectorItem::updateLegCursor(QPointF p, Qt::KeyboardModifiers modifiers)
 bool ConnectorItem::curvyWiresIndicated(Qt::KeyboardModifiers modifiers)
 {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView == NULL) return true;
+	if (!infoGraphicsView) return true;
 
 	return infoGraphicsView->curvyWiresIndicated(modifiers);
 }
@@ -2851,7 +2846,7 @@ void ConnectorItem::setGroundFillSeed(bool seed)
 
 ViewGeometry::WireFlags ConnectorItem::getSkipFlags() {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView == NULL) return ViewGeometry::RatsnestFlag;
+	if (!infoGraphicsView) return ViewGeometry::RatsnestFlag;
 
 	return (ViewGeometry::RatsnestFlag | ViewGeometry::NormalFlag | ViewGeometry::PCBTraceFlag | ViewGeometry::SchematicTraceFlag) ^ infoGraphicsView->getTraceFlag();
 }

--- a/src/connectors/connectoritem.h
+++ b/src/connectors/connectoritem.h
@@ -43,7 +43,7 @@ public:
 protected:
 	ConnectorItem * m_connectorItem;
 };
-
+class ItemBase;
 class ConnectorItem : public NonConnectorItem, public CursorKeyListener
 {
 	Q_OBJECT
@@ -53,7 +53,7 @@ public:
 	~ConnectorItem();
 
 	Connector * connector();
-	void connectorHover(class ItemBase *, bool hovering);
+	void connectorHover(ItemBase *, bool hovering);
 	bool connectorHovering();
 	void clearConnectorHover();
 	void connectTo(ConnectorItem *);
@@ -204,29 +204,29 @@ protected:
 	QList< QPointer<ConnectorItem> > m_connectedTo;
 	QPointF m_terminalPoint;
 	QPointer<ConnectorItem> m_overConnectorItem;
-	bool m_connectorHovering;
-	bool m_spaceBarWasPressed;
-	bool m_hoverEnterSpaceBarWasPressed;
-	bool m_hybrid;
-	bool m_bigDot;
-	bool m_rubberBandLeg;
+	bool m_connectorHovering = false;
+	bool m_spaceBarWasPressed = false;
+	bool m_hoverEnterSpaceBarWasPressed = false;
+	bool m_hybrid = false;
+	bool m_bigDot = false;
+	bool m_rubberBandLeg = false;
 	QPolygonF m_oldPolygon;
-	bool m_draggingLeg;
-	bool m_draggingCurve;
-	int m_draggingLegIndex;
-	bool m_activeStretch;
+	bool m_draggingLeg = false;
+	bool m_draggingCurve = false;
+	int m_draggingLegIndex = 0;
+	bool m_activeStretch = false;
 	QPointF m_holdPos;
 	QPolygonF m_legPolygon;
 	QVector<class Bezier *> m_legCurves;
-	double m_legStrokeWidth;
+	double m_legStrokeWidth = 0.0;
 	QColor m_legColor;
-	bool m_insertBendpointPossible;
+	bool m_insertBendpointPossible = false;
 	QPointF m_connectorDetectEnd;
 	QPointF m_connectorDrawEnd;
-	double m_connectorDrawT;
-	double m_connectorDetectT;
-	bool m_groundFillSeed;
-	int m_moveCount;
+	double m_connectorDrawT = 0.0;
+	double m_connectorDetectT = 0.0;
+	bool m_groundFillSeed = false;
+	int m_moveCount = 0;
 
 protected:
 	static QList<ConnectorItem *>  m_equalPotentialDisplayItems;

--- a/src/dialogs/prefsdialog.h
+++ b/src/dialogs/prefsdialog.h
@@ -96,9 +96,9 @@ protected:
 	QHash<QString, QString> m_settings;
 	QHash<QString, QString> m_tempSettings;
 	QString m_name;
-	class TranslatorListModel * m_translatorListModel;
-	bool m_cleared;
-	int m_wheelMapping;
+	class TranslatorListModel * m_translatorListModel = nullptr;
+	bool m_cleared = false;
+	int m_wheelMapping = 0;
 	ViewInfoThing m_viewInfoThings[3];
 };
 

--- a/src/dialogs/setcolordialog.cpp
+++ b/src/dialogs/setcolordialog.cpp
@@ -36,13 +36,17 @@ static const int BUTTON_WIDTH = 150;
 
 /////////////////////////////////////
 
-SetColorDialog::SetColorDialog(const QString & message, QColor & currentColor, QColor & standardColor, bool askPrefs, QWidget *parent) : QDialog(parent)
+SetColorDialog::SetColorDialog(const QString & message, QColor & currentColor, QColor & standardColor, bool askPrefs, QWidget *parent) : QDialog(parent),
+    m_message(message),
+    m_currentColor(currentColor),
+    m_standardColor(standardColor),
+    m_selectedColor(currentColor),
+    m_currentColorLabel(nullptr),
+    m_standardColorLabel(nullptr),
+    m_customColorLabel(nullptr),
+    m_selectedColorLabel(nullptr),
+    m_prefsCheckBox(nullptr)
 {
-	m_prefsCheckBox = NULL;
-	m_message = message;
-	m_currentColor = m_selectedColor = currentColor;
-	m_standardColor = standardColor;
-
 	this->setWindowTitle(tr("%1 Color...").arg(message));
 
 	QVBoxLayout * vLayout = new QVBoxLayout(this);
@@ -103,13 +107,6 @@ SetColorDialog::SetColorDialog(const QString & message, QColor & currentColor, Q
 	this->setLayout(vLayout);
 }
 
-SetColorDialog::~SetColorDialog() {
-}
-
-const QColor & SetColorDialog::selectedColor() {
-	return m_selectedColor;
-}
-
 void SetColorDialog::selectCurrent() {
 	setColor(m_currentColor);
 }
@@ -131,7 +128,7 @@ void SetColorDialog::selectCustom() {
 }
 
 bool SetColorDialog::isPrefsColor() {
-	if (m_prefsCheckBox == NULL) return false;
+	if (!m_prefsCheckBox) return false;
 
 	return m_prefsCheckBox->isChecked();
 }

--- a/src/dialogs/setcolordialog.h
+++ b/src/dialogs/setcolordialog.h
@@ -33,9 +33,9 @@ class SetColorDialog : public QDialog
 
 public:
 	SetColorDialog(const QString & message, QColor & currentColor, QColor & standardColor, bool askPrefs, QWidget *parent = 0);
-	~SetColorDialog();
+	~SetColorDialog() = default;
 
-	const QColor & selectedColor();
+	const QColor & selectedColor() const noexcept { return m_selectedColor; }
 	bool isPrefsColor();
 
 protected:

--- a/src/fapplication.cpp
+++ b/src/fapplication.cpp
@@ -338,16 +338,6 @@ void RegenerateDatabaseThread::run() {
 
 FApplication::FApplication( int & argc, char ** argv) : QApplication(argc, argv)
 {
-	m_fServer = NULL;
-	m_spaceBarIsPressed = false;
-	m_mousePressed = false;
-	m_referenceModel = NULL;
-	m_started = false;
-	m_updateDialog = NULL;
-	m_lastTopmostWindow = NULL;
-	m_serviceType = NoService;
-	m_splash = NULL;
-
 	m_arguments = arguments();
 }
 

--- a/src/fapplication.h
+++ b/src/fapplication.h
@@ -71,8 +71,8 @@ protected:
 	void writeResponse(QTcpSocket *, int code, const QString & codeString, const QString & mimeType, const QString & message);
 
 protected:
-	int m_socketDescriptor;
-	bool m_done;
+	int m_socketDescriptor = 0;
+	bool m_done = false;
 
 protected:
 	static QMutex m_busy;

--- a/src/fapplication.h
+++ b/src/fapplication.h
@@ -96,8 +96,8 @@ protected:
 protected:
 	QString m_dbFileName;
 	QString m_error;
-	QDialog * m_progressDialog;
-	ReferenceModel * m_referenceModel;
+	QDialog * m_progressDialog = nullptr;
+	ReferenceModel * m_referenceModel = nullptr;
 };
 
 ////////////////////////////////////////////////////
@@ -203,15 +203,15 @@ protected:
 	};
 
 protected:
-	bool m_spaceBarIsPressed;
-	bool m_mousePressed;
+	bool m_spaceBarIsPressed = false;
+	bool m_mousePressed = false;
 	QTranslator m_translator;
-	ReferenceModel * m_referenceModel;
-	bool m_started;
+	ReferenceModel * m_referenceModel = nullptr;
+	bool m_started = false;
 	QStringList m_filesToLoad;
 	QString m_libPath;
 	QString m_translationPath;
-	class UpdateDialog * m_updateDialog;
+	class UpdateDialog * m_updateDialog = nullptr;
 	QTimer m_activationTimer;
 	QPointer<class FritzingWindow> m_lastTopmostWindow;
 	QList<QWidget *> m_orderedTopLevelWidgets;
@@ -219,16 +219,16 @@ protected:
 	QStringList m_externalProcessArgs;
 	QString m_externalProcessName;
 	QString m_externalProcessPath;
-	ServiceType m_serviceType;
-	int m_progressIndex;
-	class FSplashScreen * m_splash;
+	ServiceType m_serviceType = NoService;
+	int m_progressIndex = 0;
+	class FSplashScreen * m_splash = nullptr;
 	QString m_outputFolder;
 	QString m_portRootFolder;
 	QString m_panelFilename;
 	QHash<QString, struct LockedFile *> m_lockedFiles;
-	bool m_panelizerCustom;
-	int m_portNumber;
-	FServer * m_fServer;
+	bool m_panelizerCustom = false;
+	int m_portNumber = 0;
+	FServer * m_fServer = nullptr;
 	QString m_buildType;
 };
 

--- a/src/items/layerkinpaletteitem.cpp
+++ b/src/items/layerkinpaletteitem.cpp
@@ -36,11 +36,9 @@ static QString IDString("-_-_-text-_-_-%1");
 ////////////////////////////////////////////////
 
 LayerKinPaletteItem::LayerKinPaletteItem(PaletteItemBase * chief, ModelPart * modelPart, ViewLayer::ViewID viewID, const ViewGeometry & viewGeometry, long id, QMenu* itemMenu)
-	: PaletteItemBase(modelPart, viewID, viewGeometry, id, itemMenu)
-
+	: PaletteItemBase(modelPart, viewID, viewGeometry, id, itemMenu), 
+    m_layerKinChief(chief), m_ok(false), m_passMouseEvents(false)
 {
-	m_passMouseEvents = false;
-	m_layerKinChief = chief;
 	setFlag(QGraphicsItem::ItemIsSelectable, true);
 	m_modelPart->removeViewItem(this);  // we don't need to save layerkin
 }

--- a/src/items/stripboard.h
+++ b/src/items/stripboard.h
@@ -106,8 +106,8 @@ protected:
 	QList<StripConnector *> m_strips;
 	QList<class BusShared *> m_buses;
 	QString m_beforeCut;
-	int m_x;
-	int m_y;
+	int m_x = 0;
+	int m_y = 0;
 	QString m_layout;
 };
 

--- a/src/mainwindow/fritzingwindow.cpp
+++ b/src/mainwindow/fritzingwindow.cpp
@@ -42,7 +42,6 @@ FritzingWindow::FritzingWindow(const QString &untitledFileName, int &untitledFil
 	: QMainWindow(parent, f)
 {
 	___fritzingTitle___ = QObject::tr("Fritzing");
-	m_readOnly = false;
 
 	// Let's set the icon
 	this->setWindowIcon(QIcon(QPixmap(":resources/images/fritzing_icon.png")));

--- a/src/mainwindow/fritzingwindow.h
+++ b/src/mainwindow/fritzingwindow.h
@@ -74,12 +74,12 @@ protected:
 	virtual bool anyModified();
 
 protected:
-	class WaitPushUndoStack * m_undoStack;
+	class WaitPushUndoStack * m_undoStack = nullptr;
 	QString m_fwFilename;
-	bool m_readOnly;
-	QAction *m_closeAct;
+	bool m_readOnly = false;
+	QAction *m_closeAct = nullptr;
 	QDir m_tempDir;
-	QStatusBar *m_statusBar;
+	QStatusBar *m_statusBar = nullptr;
 
 protected:
 	static QStringList OtherKnownExtensions;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -795,25 +795,25 @@ protected:
 
 
 	// View Menu
-	QMenu *m_viewMenu;
-	QAction *m_zoomInAct;
-	QAction *m_zoomInShortcut;
-	QAction *m_zoomOutAct;
-	QAction *m_fitInWindowAct;
-	QAction *m_actualSizeAct;
-	QAction *m_100PercentSizeAct;
-	QAction *m_alignToGridAct;
-	QAction *m_showGridAct;
-	QAction *m_setGridSizeAct;
-	QAction *m_setBackgroundColorAct;
-	QAction *m_colorWiresByLengthAct;
-	QAction *m_showWelcomeAct;
-	QAction *m_showBreadboardAct;
-	QAction *m_showSchematicAct;
-	QAction *m_showProgramAct;
-	QAction *m_showPCBAct;
-	QAction *m_showPartsBinIconViewAct;
-	QAction *m_showPartsBinListViewAct;
+	QMenu *m_viewMenu = nullptr;
+	QAction *m_zoomInAct = nullptr;
+	QAction *m_zoomInShortcut = nullptr;
+	QAction *m_zoomOutAct = nullptr;
+	QAction *m_fitInWindowAct = nullptr;
+	QAction *m_actualSizeAct = nullptr;
+	QAction *m_100PercentSizeAct = nullptr;
+	QAction *m_alignToGridAct = nullptr;
+	QAction *m_showGridAct = nullptr;
+	QAction *m_setGridSizeAct = nullptr;
+	QAction *m_setBackgroundColorAct = nullptr;
+	QAction *m_colorWiresByLengthAct = nullptr;
+	QAction *m_showWelcomeAct = nullptr;
+	QAction *m_showBreadboardAct = nullptr;
+	QAction *m_showSchematicAct = nullptr;
+	QAction *m_showProgramAct = nullptr;
+	QAction *m_showPCBAct = nullptr;
+	QAction *m_showPartsBinIconViewAct = nullptr;
+	QAction *m_showPartsBinListViewAct = nullptr;
 	//QAction *m_toggleToolbarAct;
 	int m_numFixedActionsInViewMenu;
 

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -642,8 +642,8 @@ protected:
 
 protected:
 
-	QUndoGroup *m_undoGroup;
-	QUndoView *m_undoView;
+	QUndoGroup *m_undoGroup = nullptr;
+	QUndoView *m_undoView = nullptr;
 
 	QPointer<SketchAreaWidget> m_breadboardWidget;
 	QPointer<class BreadboardSketchWidget> m_breadboardGraphicsView;
@@ -655,7 +655,7 @@ protected:
 	QPointer<class PCBSketchWidget> m_pcbGraphicsView;
 
 	QPointer<SketchAreaWidget> m_welcomeWidget;
-	class WelcomeView * m_welcomeView;
+	class WelcomeView * m_welcomeView = nullptr;
 
 	QPointer<class BinManager> m_binManager;
 	QPointer<QWidget> m_tabWidget;
@@ -664,9 +664,9 @@ protected:
 	QPointer<class HtmlInfoView> m_infoView;
 	QPointer<QToolBar> m_toolbar;
 
-	bool m_closing;
-	bool m_dontClose;
-	bool m_firstOpen;
+	bool m_closing = false;
+	bool m_dontClose = false;
+	bool m_firstOpen = false;
 
 	QPointer<SketchAreaWidget> m_currentWidget;
 	QPointer<SketchWidget> m_currentGraphicsView;
@@ -815,7 +815,7 @@ protected:
 	QAction *m_showPartsBinIconViewAct = nullptr;
 	QAction *m_showPartsBinListViewAct = nullptr;
 	//QAction *m_toggleToolbarAct;
-	int m_numFixedActionsInViewMenu;
+	int m_numFixedActionsInViewMenu = 0;
 
 	// Window Menu
 	QMenu *m_windowMenu = nullptr;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -674,124 +674,124 @@ protected:
 	//QToolBar *m_fileToolBar;
 	//QToolBar *m_editToolBar;
 
-	QAction *m_raiseWindowAct;
+	QAction *m_raiseWindowAct = nullptr;
 
 	// Fritzing Menu
-	QMenu *m_fritzingMenu;
-	QAction *m_aboutAct;
-	QAction *m_preferencesAct;
-	QAction *m_quitAct;
-	QAction *m_exceptionAct;
+	QMenu *m_fritzingMenu = nullptr;
+	QAction *m_aboutAct = nullptr;
+	QAction *m_preferencesAct = nullptr;
+	QAction *m_quitAct = nullptr;
+	QAction *m_exceptionAct = nullptr;
 
 	// File Menu
 	enum { MaxRecentFiles = 10 };
 
-	QMenu *m_fileMenu;
-	QAction *m_newAct;
-	QAction *m_openAct;
-	QAction *m_revertAct;
-	QMenu *m_openRecentFileMenu;
-	QAction *m_openRecentFileActs[MaxRecentFiles];
-	QMenu *m_openExampleMenu;
-	QAction *m_saveAct;
-	QAction *m_saveAsAct;
-	QAction *m_pageSetupAct;
-	QAction *m_printAct;
-	QAction *m_shareOnlineAct;
+	QMenu *m_fileMenu = nullptr;
+	QAction *m_newAct = nullptr;
+	QAction *m_openAct = nullptr;
+	QAction *m_revertAct = nullptr;
+	QMenu *m_openRecentFileMenu = nullptr;
+	QAction *m_openRecentFileActs[MaxRecentFiles] = { nullptr };
+	QMenu *m_openExampleMenu = nullptr;
+	QAction *m_saveAct = nullptr;
+	QAction *m_saveAsAct = nullptr;
+	QAction *m_pageSetupAct = nullptr;
+	QAction *m_printAct = nullptr;
+	QAction *m_shareOnlineAct = nullptr;
 
-	QAction * m_launchExternalProcessAct;
+	QAction * m_launchExternalProcessAct = nullptr;
 
-	QMenu *m_zOrderMenu;
-	QMenu *m_zOrderWireMenu;
-	QAction *m_bringToFrontAct;
-	QAction *m_bringForwardAct;
-	QAction *m_sendBackwardAct;
-	QAction *m_sendToBackAct;
-	class WireAction *m_bringToFrontWireAct;
-	class WireAction *m_bringForwardWireAct;
-	class WireAction *m_sendBackwardWireAct;
-	class WireAction *m_sendToBackWireAct;
+	QMenu *m_zOrderMenu = nullptr;
+	QMenu *m_zOrderWireMenu = nullptr;
+	QAction *m_bringToFrontAct = nullptr;
+	QAction *m_bringForwardAct = nullptr;
+	QAction *m_sendBackwardAct = nullptr;
+	QAction *m_sendToBackAct = nullptr;
+	class WireAction *m_bringToFrontWireAct = nullptr;
+	class WireAction *m_bringForwardWireAct = nullptr;
+	class WireAction *m_sendBackwardWireAct = nullptr;
+	class WireAction *m_sendToBackWireAct = nullptr;
 
-	QMenu *m_alignMenu;
-	QAction * m_alignVerticalCenterAct;
-	QAction * m_alignHorizontalCenterAct;
-	QAction * m_alignTopAct;
-	QAction * m_alignLeftAct;
-	QAction * m_alignBottomAct;
-	QAction * m_alignRightAct;
+	QMenu *m_alignMenu = nullptr;
+	QAction * m_alignVerticalCenterAct = nullptr;
+	QAction * m_alignHorizontalCenterAct = nullptr;
+	QAction * m_alignTopAct = nullptr;
+	QAction * m_alignLeftAct = nullptr;
+	QAction * m_alignBottomAct = nullptr;
+	QAction * m_alignRightAct = nullptr;
 
 	// Export Menu
-	QMenu *m_exportMenu;
-	QAction *m_exportJpgAct;
-	QAction *m_exportPngAct;
-	QAction *m_exportPdfAct;
-	QAction *m_exportEagleAct;
-	QAction *m_exportGerberAct;
-	QAction *m_exportEtchablePdfAct;
-	QAction *m_exportEtchableSvgAct;
-	QAction *m_exportBomAct;
-	QAction *m_exportNetlistAct;
-	QAction *m_exportSpiceNetlistAct;
-	QAction *m_exportSvgAct;
+	QMenu *m_exportMenu = nullptr;
+	QAction *m_exportJpgAct = nullptr;
+	QAction *m_exportPngAct = nullptr;
+	QAction *m_exportPdfAct = nullptr;
+	QAction *m_exportEagleAct = nullptr;
+	QAction *m_exportGerberAct = nullptr;
+	QAction *m_exportEtchablePdfAct = nullptr;
+	QAction *m_exportEtchableSvgAct = nullptr;
+	QAction *m_exportBomAct = nullptr;
+	QAction *m_exportNetlistAct = nullptr;
+	QAction *m_exportSpiceNetlistAct = nullptr;
+	QAction *m_exportSvgAct = nullptr;
 
 	// Edit Menu
-	QMenu *m_editMenu;
-	QAction *m_undoAct;
-	QAction *m_redoAct;
-	QAction *m_cutAct;
-	QAction *m_copyAct;
-	QAction *m_pasteAct;
-	QAction *m_pasteInPlaceAct;
-	QAction *m_duplicateAct;
-	QAction *m_deleteAct;
-	QAction *m_deleteMinusAct;
-	class WireAction *m_deleteWireAct;
-	class WireAction *m_deleteWireMinusAct;
-	QAction *m_selectAllAct;
-	QAction *m_deselectAct;
-	QAction *m_addNoteAct;
+	QMenu *m_editMenu = nullptr;
+	QAction *m_undoAct = nullptr;
+	QAction *m_redoAct = nullptr;
+	QAction *m_cutAct = nullptr;
+	QAction *m_copyAct = nullptr;
+	QAction *m_pasteAct = nullptr;
+	QAction *m_pasteInPlaceAct = nullptr;
+	QAction *m_duplicateAct = nullptr;
+	QAction *m_deleteAct = nullptr;
+	QAction *m_deleteMinusAct = nullptr;
+	class WireAction *m_deleteWireAct = nullptr;
+	class WireAction *m_deleteWireMinusAct = nullptr;
+	QAction *m_selectAllAct = nullptr;
+	QAction *m_deselectAct = nullptr;
+	QAction *m_addNoteAct = nullptr;
 
 	// Part Menu
-	QMenu *m_partMenu;
-	QAction *m_infoViewOnHoverAction;
-	QAction *m_exportNormalizedSvgAction;
-	QAction *m_exportNormalizedFlattenedSvgAction;
-	QAction *m_dumpAllPartsAction;
-	QAction *m_testConnectorsAction;
-	QAction *m_openInPartsEditorNewAct;
-	QMenu *m_addToBinMenu;
+	QMenu *m_partMenu = nullptr;
+	QAction *m_infoViewOnHoverAction = nullptr;
+	QAction *m_exportNormalizedSvgAction = nullptr;
+	QAction *m_exportNormalizedFlattenedSvgAction = nullptr;
+	QAction *m_dumpAllPartsAction = nullptr;
+	QAction *m_testConnectorsAction = nullptr;
+	QAction *m_openInPartsEditorNewAct = nullptr;
+	QMenu *m_addToBinMenu = nullptr;
 
 
-	QMenu *m_rotateMenu;
-	QAction *m_rotate90cwAct;
-	QAction *m_rotate180Act;
-	QAction *m_rotate90ccwAct;
-	QAction *m_rotate45ccwAct;
-	QAction *m_rotate45cwAct;
+	QMenu *m_rotateMenu = nullptr;
+	QAction *m_rotate90cwAct = nullptr;
+	QAction *m_rotate180Act = nullptr;
+	QAction *m_rotate90ccwAct = nullptr;
+	QAction *m_rotate45ccwAct = nullptr;
+	QAction *m_rotate45cwAct = nullptr;
 
-	QAction *m_moveLockAct;
-	QAction *m_stickyAct;
-	QAction *m_selectMoveLockAct;
-	QAction *m_flipHorizontalAct;
-	QAction *m_flipVerticalAct;
-	QAction *m_showPartLabelAct;
-	QAction *m_saveBundledPart;
-	QAction *m_disconnectAllAct;
-	QAction *m_selectAllObsoleteAct;
-	QAction *m_swapObsoleteAct;
-	QAction *m_findPartInSketchAct;
-	QAction * m_openProgramWindowAct;
+	QAction *m_moveLockAct = nullptr;
+	QAction *m_stickyAct = nullptr;
+	QAction *m_selectMoveLockAct = nullptr;
+	QAction *m_flipHorizontalAct = nullptr;
+	QAction *m_flipVerticalAct = nullptr;
+	QAction *m_showPartLabelAct = nullptr;
+	QAction *m_saveBundledPart = nullptr;
+	QAction *m_disconnectAllAct = nullptr;
+	QAction *m_selectAllObsoleteAct = nullptr;
+	QAction *m_swapObsoleteAct = nullptr;
+	QAction *m_findPartInSketchAct = nullptr;
+	QAction * m_openProgramWindowAct = nullptr;
 
-	QAction *m_addBendpointAct;
-	QAction *m_convertToViaAct;
-	QAction *m_convertToBendpointAct;
-	QAction * m_convertToBendpointSeparator;
-	QAction *m_flattenCurveAct;
-	QAction *m_showAllLayersAct;
-	QAction *m_hideAllLayersAct;
+	QAction *m_addBendpointAct = nullptr;
+	QAction *m_convertToViaAct = nullptr;
+	QAction *m_convertToBendpointAct = nullptr;
+	QAction * m_convertToBendpointSeparator = nullptr;
+	QAction *m_flattenCurveAct = nullptr;
+	QAction *m_showAllLayersAct = nullptr;
+	QAction *m_hideAllLayersAct = nullptr;
 
-	QAction *m_hidePartSilkscreenAct;
-	QAction *m_regeneratePartsDatabaseAct;
+	QAction *m_hidePartSilkscreenAct = nullptr;
+	QAction *m_regeneratePartsDatabaseAct = nullptr;
 
 
 	// View Menu
@@ -818,73 +818,73 @@ protected:
 	int m_numFixedActionsInViewMenu;
 
 	// Window Menu
-	QMenu *m_windowMenu;
-	QAction *m_minimizeAct;
-	QAction *m_togglePartLibraryAct;
-	QAction *m_toggleInfoAct;
-	QAction *m_toggleUndoHistoryAct;
-	QAction *m_toggleDebuggerOutputAct;
-	QAction *m_windowMenuSeparator;
+	QMenu *m_windowMenu = nullptr;
+	QAction *m_minimizeAct = nullptr;
+	QAction *m_togglePartLibraryAct = nullptr;
+	QAction *m_toggleInfoAct = nullptr;
+	QAction *m_toggleUndoHistoryAct = nullptr;
+	QAction *m_toggleDebuggerOutputAct = nullptr;
+	QAction *m_windowMenuSeparator = nullptr;
 
 	// Trace Menu
-	QMenu *m_pcbTraceMenu;
-	QMenu *m_schematicTraceMenu;
-	QMenu *m_breadboardTraceMenu;
-	QAction *m_newAutorouteAct;
-	QAction *m_orderFabAct;
-	QAction *m_activeLayerTopAct;
-	QAction *m_activeLayerBottomAct;
-	QAction *m_activeLayerBothAct;
-	QAction *m_viewFromBelowToggleAct;
-	QAction *m_viewFromBelowAct;
-	QAction *m_viewFromAboveAct;
-	class WireAction *m_createTraceWireAct;
-	class WireAction *m_createWireWireAct;
-	QAction *m_createJumperAct;
-	QAction *m_changeTraceLayerAct;
-	class WireAction *m_changeTraceLayerWireAct;
-	QAction *m_excludeFromAutorouteAct;
-	class WireAction *m_excludeFromAutorouteWireAct;
-	QAction * m_showUnroutedAct;
-	QAction *m_selectAllTracesAct;
-	QAction *m_selectAllWiresAct;
-	QAction *m_selectAllCopperFillAct;
-	QAction *m_updateRoutingStatusAct;
-	QAction *m_selectAllExcludedTracesAct;
-	QAction *m_selectAllIncludedTracesAct;
-	QAction *m_selectAllJumperItemsAct;
-	QAction *m_selectAllViasAct;
-	QAction *m_groundFillAct;
-	QAction *m_removeGroundFillAct;
-	QAction *m_copperFillAct;
-	class ConnectorItemAction *m_setOneGroundFillSeedAct;
-	QAction *m_setGroundFillSeedsAct;
-	QAction *m_clearGroundFillSeedsAct;
-	QAction *m_setGroundFillKeepoutAct;
-	QAction *m_newDesignRulesCheckAct;
-	QAction *m_autorouterSettingsAct;
-	QAction *m_fabQuoteAct;
-	QAction *m_tidyWiresAct;
-	QAction *m_checkLoadedTracesAct;
+	QMenu *m_pcbTraceMenu = nullptr;
+	QMenu *m_schematicTraceMenu = nullptr;
+	QMenu *m_breadboardTraceMenu = nullptr;
+	QAction *m_newAutorouteAct = nullptr;
+	QAction *m_orderFabAct = nullptr;
+	QAction *m_activeLayerTopAct = nullptr;
+	QAction *m_activeLayerBottomAct = nullptr;
+	QAction *m_activeLayerBothAct = nullptr;
+	QAction *m_viewFromBelowToggleAct = nullptr;
+	QAction *m_viewFromBelowAct = nullptr;
+	QAction *m_viewFromAboveAct = nullptr;
+	class WireAction *m_createTraceWireAct = nullptr;
+	class WireAction *m_createWireWireAct = nullptr;
+	QAction *m_createJumperAct = nullptr;
+	QAction *m_changeTraceLayerAct = nullptr;
+	class WireAction *m_changeTraceLayerWireAct = nullptr;
+	QAction *m_excludeFromAutorouteAct = nullptr;
+	class WireAction *m_excludeFromAutorouteWireAct = nullptr;
+	QAction * m_showUnroutedAct = nullptr;
+	QAction *m_selectAllTracesAct = nullptr;
+	QAction *m_selectAllWiresAct = nullptr;
+	QAction *m_selectAllCopperFillAct = nullptr;
+	QAction *m_updateRoutingStatusAct = nullptr;
+	QAction *m_selectAllExcludedTracesAct = nullptr;
+	QAction *m_selectAllIncludedTracesAct = nullptr;
+	QAction *m_selectAllJumperItemsAct = nullptr;
+	QAction *m_selectAllViasAct = nullptr;
+	QAction *m_groundFillAct = nullptr;
+	QAction *m_removeGroundFillAct = nullptr;
+	QAction *m_copperFillAct = nullptr;
+	class ConnectorItemAction *m_setOneGroundFillSeedAct = nullptr;
+	QAction *m_setGroundFillSeedsAct = nullptr;
+	QAction *m_clearGroundFillSeedsAct = nullptr;
+	QAction *m_setGroundFillKeepoutAct = nullptr;
+	QAction *m_newDesignRulesCheckAct = nullptr;
+	QAction *m_autorouterSettingsAct = nullptr;
+	QAction *m_fabQuoteAct = nullptr;
+	QAction *m_tidyWiresAct = nullptr;
+	QAction *m_checkLoadedTracesAct = nullptr;
 
 	// Help Menu
-	QMenu *m_helpMenu;
-	QAction *m_openHelpAct;
-	QAction *m_openDonateAct;
-	QAction *m_examplesAct;
-	QAction *m_partsRefAct;
-	QAction *m_visitFritzingDotOrgAct;
-	QAction *m_checkForUpdatesAct;
-	QAction *m_aboutQtAct;
-	QAction *m_reportBugAct;
-	QAction *m_enableDebugAct;
-	QAction *m_partsEditorHelpAct;
-	QAction *m_tipsAndTricksAct;
-	QAction *m_firstTimeHelpAct;
+	QMenu *m_helpMenu = nullptr;
+	QAction *m_openHelpAct = nullptr;
+	QAction *m_openDonateAct = nullptr;
+	QAction *m_examplesAct = nullptr;
+	QAction *m_partsRefAct = nullptr;
+	QAction *m_visitFritzingDotOrgAct = nullptr;
+	QAction *m_checkForUpdatesAct = nullptr;
+	QAction *m_aboutQtAct = nullptr;
+	QAction *m_reportBugAct = nullptr;
+	QAction *m_enableDebugAct = nullptr;
+	QAction *m_partsEditorHelpAct = nullptr;
+	QAction *m_tipsAndTricksAct = nullptr;
+	QAction *m_firstTimeHelpAct = nullptr;
 
 	// Wire Color Menu
-	QMenu * m_breadboardWireColorMenu;
-	QMenu * m_schematicWireColorMenu;
+	QMenu * m_breadboardWireColorMenu = nullptr;
+	QMenu * m_schematicWireColorMenu = nullptr;
 
 	// Dot icons
 	QIcon m_dotIcon;

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -892,11 +892,11 @@ protected:
 
 	QList<SketchToolButton*> m_rotateButtons;
 	QList<SketchToolButton*> m_flipButtons;
-	QStackedWidget * m_activeLayerButtonWidget;
-	QStackedWidget * m_viewFromButtonWidget;
+	QStackedWidget * m_activeLayerButtonWidget = nullptr;
+	QStackedWidget * m_viewFromButtonWidget = nullptr;
 
-	bool m_comboboxChanged;
-	bool m_restarting;
+	bool m_comboboxChanged = false;
+	bool m_restarting = false;
 
 	QStringList m_alienFiles;
 	QString m_alienPartsMsg;
@@ -921,35 +921,35 @@ protected:
 	QString m_backupFileNameAndPath;
 	QTimer m_autosaveTimer;
 	QTimer m_fireQuoteTimer;
-	bool m_autosaveNeeded;
-	bool m_backingUp;
+	bool m_autosaveNeeded = false;
+	bool m_backingUp = false;
 	QString m_bundledSketchName;
 	RoutingStatus m_routingStatus;
-	bool m_orderFabEnabled;
-	bool m_closeSilently;
+	bool m_orderFabEnabled = false;
+	bool m_closeSilently = false;
 	QString m_fzzFolder;
 	QHash<QString, struct LockedFile *> m_fzzFiles;
 	SwapTimer m_swapTimer;
 	QPointer<Wire> m_activeWire;
 	QPointer<ConnectorItem> m_activeConnectorItem;
-	bool m_addedToTemp;
+	bool m_addedToTemp = false;
 	QString m_settingsPrefix;
-	bool m_convertedSchematic;
-	bool m_useOldSchematic;
-	bool m_noSchematicConversion;
-	int m_initialTab;
+	bool m_convertedSchematic = false;
+	bool m_useOldSchematic = false;
+	bool m_noSchematicConversion = false;
+	int m_initialTab = 0;
 
 	// dock management
 	QList<FDockWidget*> m_docks;
-	FDockWidget* m_topDock;
-	FDockWidget* m_bottomDock;
+	FDockWidget* m_topDock = nullptr;
+	FDockWidget* m_bottomDock = nullptr;
 	QString m_oldTopDockStyle;
 	QString m_oldBottomDockStyle;
-	bool m_dontKeepMargins;
+	bool m_dontKeepMargins = false;
 	QPointer<QDialog> m_rolloverQuoteDialog;
-	bool m_obsoleteSMDOrientation;
-	QWidget * m_orderFabButton;
-	int m_fireQuoteDelay;
+	bool m_obsoleteSMDOrientation = false;
+	QWidget * m_orderFabButton = nullptr;
+	int m_fireQuoteDelay = 0;
 
 public:
 	static int AutosaveTimeoutMinutes;

--- a/src/partsbinpalette/searchlineedit.cpp
+++ b/src/partsbinpalette/searchlineedit.cpp
@@ -24,25 +24,17 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QPainter>
 #include <QImage>
 #include <QPixmap>
+#include <memory>
+std::unique_ptr<QPixmap> SearchFieldPixmap;
 
-static QPixmap * SearchFieldPixmap;
-
-SearchLineEdit::SearchLineEdit(QWidget * parent) : QLineEdit(parent)
+SearchLineEdit::SearchLineEdit(QWidget * parent) : QLineEdit(parent), m_decoy(true)
 {
-	SearchFieldPixmap = NULL;
-	setDecoy(true);
+	SearchFieldPixmap.reset();
 }
 
-SearchLineEdit::~SearchLineEdit()
-{
-}
 
 void SearchLineEdit::cleanup() {
-	if (SearchFieldPixmap != NULL) {
-		delete SearchFieldPixmap;
-		SearchFieldPixmap = NULL;
-	}
-
+	SearchFieldPixmap.reset();
 }
 
 void SearchLineEdit::mousePressEvent(QMouseEvent * event) {
@@ -52,8 +44,8 @@ void SearchLineEdit::mousePressEvent(QMouseEvent * event) {
 
 void SearchLineEdit::paintEvent(QPaintEvent * event) {
 	QLineEdit::paintEvent(event);
-	if (SearchFieldPixmap == NULL) {
-		SearchFieldPixmap = new QPixmap(":/resources/images/icons/searchField.png");
+	if (!SearchFieldPixmap) {
+		SearchFieldPixmap.reset(new QPixmap(":/resources/images/icons/searchField.png"));
 	}
 	if (SearchFieldPixmap == NULL) return;
 	if (SearchFieldPixmap->isNull()) return;
@@ -99,6 +91,3 @@ void SearchLineEdit::setDecoy(bool d) {
 	setCursor(Qt::IBeamCursor);
 }
 
-bool SearchLineEdit::decoy() {
-	return m_decoy;
-}

--- a/src/partsbinpalette/searchlineedit.h
+++ b/src/partsbinpalette/searchlineedit.h
@@ -28,11 +28,11 @@ class SearchLineEdit : public QLineEdit {
 	Q_OBJECT
 
 public:
-	SearchLineEdit(QWidget * parent = NULL);
-	~SearchLineEdit();
+	SearchLineEdit(QWidget * parent = nullptr);
+	~SearchLineEdit() = default;
 
-	void setDecoy(bool);
-	bool decoy();
+	void setDecoy(bool value) noexcept { m_decoy = value; }
+	constexpr bool decoy() noexcept { return m_decoy; }
 
 public:
 	static void cleanup();

--- a/src/partsbinpalette/searchlineedit.h
+++ b/src/partsbinpalette/searchlineedit.h
@@ -31,8 +31,8 @@ public:
 	SearchLineEdit(QWidget * parent = nullptr);
 	~SearchLineEdit() = default;
 
-	void setDecoy(bool value) noexcept { m_decoy = value; }
-	constexpr bool decoy() noexcept { return m_decoy; }
+	void setDecoy(bool value);
+	constexpr bool decoy() const noexcept { return m_decoy; }
 
 public:
 	static void cleanup();

--- a/src/partseditor/pegraphicsitem.h
+++ b/src/partseditor/pegraphicsitem.h
@@ -74,22 +74,22 @@ protected slots:
 	void restoreColor();
 
 protected:
-	bool m_highlighted;
-	bool m_flash;
+	bool m_highlighted = false;
+	bool m_flash = false;
 	QDomElement  m_element;
 	QPointF m_offset;
-	bool m_showTerminalPoint;
-	bool m_showMarquee;
+	bool m_showTerminalPoint = false;
+	bool m_showMarquee = false;
 	QPointF m_terminalPoint;
 	QPointF m_pendingTerminalPoint;
-	bool m_dragTerminalPoint;
+	bool m_dragTerminalPoint = false;
 	QPointF m_dragTerminalOrigin;
 	QPointF m_terminalPointOrigin;
-	bool m_drawHighlight;
-	int m_wheelAccum;
-	qreal m_savedOpacity;
-	bool m_pick;
-	class ItemBase * m_itemBase;
+	bool m_drawHighlight = false;
+	int m_wheelAccum = 0;
+	qreal m_savedOpacity = 0;
+	bool m_pick = false;
+	class ItemBase * m_itemBase = nullptr;
 };
 
 #endif /* PEGRAPHICSITEM_H_ */

--- a/src/partseditor/pemainwindow.cpp
+++ b/src/partseditor/pemainwindow.cpp
@@ -288,39 +288,29 @@ void IconSketchWidget::addViewLayers() {
 
 ////////////////////////////////////////////////////
 
-ViewThing::ViewThing() {
-	itemBase = NULL;
-	document = NULL;
-	svgChangeCount = 0;
-	everZoomed = false;
-	sketchWidget = NULL;
-	firstTime = true;
-	busMode = false;
-}
-
-/////////////////////////////////////////////////////
-
 PEMainWindow::PEMainWindow(ReferenceModel * referenceModel, QWidget * parent)
-	: MainWindow(referenceModel, parent)
+	: MainWindow(referenceModel, parent),
+    m_useNextPick(false),
+    m_inPickMode(false),
+    m_gaveSaveWarning(false),
+    m_canSave(false),
+    m_guid(TextUtils::getRandText()),
+    m_prefix("prefix0000"),
+    m_fileIndex(0),
+    m_peToolView(nullptr),
+    m_peSvgView(nullptr),
+    m_connectorsView(nullptr)
 {
+    m_settingsPrefix = "pe/";
 	m_viewThings.insert(ViewLayer::BreadboardView, new ViewThing);
 	m_viewThings.insert(ViewLayer::SchematicView, new ViewThing);
 	m_viewThings.insert(ViewLayer::PCBView, new ViewThing);
 	m_viewThings.insert(ViewLayer::IconView, new ViewThing);
 
-	m_useNextPick = m_inPickMode = false;
 	m_autosaveTimer.stop();
 	disconnect(&m_autosaveTimer, SIGNAL(timeout()), this, SLOT(backupSketch()));
-	m_gaveSaveWarning = m_canSave = false;
-	m_settingsPrefix = "pe/";
-	m_guid = TextUtils::getRandText();
-	m_prefix = "prefix0000";
-	m_fileIndex = 0;
 	m_userPartsFolderPath = FolderUtils::getUserPartsPath()+"/user/";
 	m_userPartsFolderSvgPath = FolderUtils::getUserPartsPath()+"/svg/user/";
-	m_peToolView = NULL;
-	m_peSvgView = NULL;
-	m_connectorsView = NULL;
 }
 
 PEMainWindow::~PEMainWindow()
@@ -711,7 +701,7 @@ QMenu *PEMainWindow::breadboardWireMenu() {
 }
 
 QMenu *PEMainWindow::breadboardItemMenu() {
-	return NULL;
+	return nullptr;
 }
 
 QMenu *PEMainWindow::schematicWireMenu() {
@@ -719,7 +709,7 @@ QMenu *PEMainWindow::schematicWireMenu() {
 }
 
 QMenu *PEMainWindow::schematicItemMenu() {
-	return NULL;
+	return nullptr;
 }
 
 QMenu *PEMainWindow::pcbWireMenu() {
@@ -727,7 +717,7 @@ QMenu *PEMainWindow::pcbWireMenu() {
 }
 
 QMenu *PEMainWindow::pcbItemMenu() {
-	return NULL;
+	return nullptr;
 }
 
 bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
@@ -738,8 +728,8 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 	m_pcbGraphicsView->setLayerActive(ViewLayer::Silkscreen1, true);
 	m_pcbGraphicsView->setLayerActive(ViewLayer::Silkscreen0, true);
 
-	ModelPart * originalModelPart = NULL;
-	if (paletteItem == NULL) {
+	ModelPart * originalModelPart = nullptr;
+	if (paletteItem == nullptr) {
 		// this shouldn't happen
 		originalModelPart = m_referenceModel->retrieveModelPart("generic_ic_dip_8_300mil");
 	}
@@ -832,7 +822,7 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 
 	if (hasLegID && !RubberBandLegWarning) {
 		RubberBandLegWarning = true;
-		QMessageBox::warning(NULL, tr("Parts Editor"),
+		QMessageBox::warning(nullptr, tr("Parts Editor"),
 		                     tr("This part has bendable legs. ") +
 		                     tr("This version of the Parts Editor does not yet support editing bendable legs, and the legs may not be displayed correctly in breadboard view . ") +
 		                     tr("If you make changes to breadboard view, or change connector metadata, the legs may no longer work. ") +
@@ -860,17 +850,17 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 	}
 
 	foreach (ViewThing * viewThing, m_viewThings.values()) {
-		if (viewThing->sketchWidget == NULL) continue;
+		if (viewThing->sketchWidget == nullptr) continue;
 
 		ItemBase * itemBase = originalModelPart->viewItem(viewThing->sketchWidget->viewID());
-		if (itemBase == NULL) continue;
+		if (itemBase == nullptr) continue;
 
 		viewThing->referenceFile = getSvgReferenceFile(itemBase->filename());
 
 		if (!itemBase->hasCustomSVG()) {
 			QFile file(itemBase->filename());
 			if (!file.open(QFile::ReadOnly)) {
-				QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to load '%1'. Please close the parts editor without saving and try again.").arg(itemBase->filename()));
+				QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to load '%1'. Please close the parts editor without saving and try again.").arg(itemBase->filename()));
 				continue;
 			}
 
@@ -880,7 +870,7 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 			QString svgPath = makeSvgPath2(viewThing->sketchWidget);
 			bool result = writeXml(m_userPartsFolderSvgPath + svgPath, removeGorn(svg), true);
 			if (!result) {
-				QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to write svg to  %1").arg(svgPath));
+				QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to write svg to  %1").arg(svgPath));
 				return false;
 			}
 
@@ -947,14 +937,14 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 		QString svgPath = makeSvgPath2(viewThing->sketchWidget);
 		bool result = writeXml(m_userPartsFolderSvgPath + svgPath, removeGorn(svg), true);
 		if (!result) {
-			QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to write svg to  %1").arg(svgPath));
+			QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to write svg to  %1").arg(svgPath));
 			return false;
 		}
 
 		QDomElement view = views.firstChildElement(ViewLayer::viewIDXmlName(viewThing->sketchWidget->viewID()));
 		QDomElement layers = view.firstChildElement("layers");
 		if (layers.isNull()) {
-			QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to parse fzp file  %1").arg(originalModelPart->path()));
+			QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to parse fzp file  %1").arg(originalModelPart->path()));
 			return false;
 		}
 
@@ -974,11 +964,11 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 }
 
 void PEMainWindow::initZoom() {
-	if (m_peToolView == NULL) return;
-	if (m_currentGraphicsView == NULL) return;
+	if (m_peToolView == nullptr) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	ViewThing * viewThing = m_viewThings.value(m_currentGraphicsView->viewID());
-	if (viewThing->itemBase == NULL) return;
+	if (viewThing->itemBase == nullptr) return;
 
 	if (!viewThing->everZoomed) {
 		viewThing->everZoomed = true;
@@ -1072,7 +1062,7 @@ void PEMainWindow::changeSpecialProperty(const QString & name, const QString & v
 	QHash<QString, QString> oldProperties = getOldProperties();
 
 	if (value.isEmpty()) {
-		QMessageBox::warning(NULL, tr("Blank not allowed"), tr("The value of '%1' can not be blank.").arg(name));
+		QMessageBox::warning(nullptr, tr("Blank not allowed"), tr("The value of '%1' can not be blank.").arg(name));
 		m_metadataView->resetProperty(name, value);
 		return;
 	}
@@ -1084,7 +1074,7 @@ void PEMainWindow::changeSpecialProperty(const QString & name, const QString & v
 	QHash<QString, QString> newProperties(oldProperties);
 	newProperties.insert(name, value);
 
-	ChangePropertiesCommand * cpc = new ChangePropertiesCommand(this, oldProperties, newProperties, NULL);
+	ChangePropertiesCommand * cpc = new ChangePropertiesCommand(this, oldProperties, newProperties, nullptr);
 	cpc->setText(tr("Change %1 to %2").arg(name).arg(value));
 	cpc->setSkipFirstRedo();
 	changeProperties(newProperties, false);
@@ -1109,7 +1099,7 @@ void PEMainWindow::metadataChanged(const QString & name, const QString & value)
 			values.removeOne(moduleID);
 		}
 		if (values.count() > 0) {
-			QMessageBox::warning(NULL, tr("Must be unique"), tr("Variant '%1' is in use. The variant name must be unique.").arg(value));
+			QMessageBox::warning(nullptr, tr("Must be unique"), tr("Variant '%1' is in use. The variant name must be unique.").arg(value));
 			return;
 		}
 
@@ -1125,7 +1115,7 @@ void PEMainWindow::metadataChanged(const QString & name, const QString & value)
 	QString oldValue = element.text();
 	if (oldValue == value) return;
 
-	ChangeMetadataCommand * cmc = new ChangeMetadataCommand(this, name, oldValue, value, NULL);
+	ChangeMetadataCommand * cmc = new ChangeMetadataCommand(this, name, oldValue, value, nullptr);
 	cmc->setText(menuText);
 	cmc->setSkipFirstRedo();
 	changeMetadata(name, value, false);
@@ -1158,7 +1148,7 @@ void PEMainWindow::tagsChanged(const QStringList & newTags)
 		tag = tag.nextSiblingElement("tag");
 	}
 
-	ChangeTagsCommand * ctc = new ChangeTagsCommand(this, oldTags, newTags, NULL);
+	ChangeTagsCommand * ctc = new ChangeTagsCommand(this, oldTags, newTags, nullptr);
 	ctc->setText(tr("Change tags"));
 	ctc->setSkipFirstRedo();
 	changeTags(newTags, false);
@@ -1192,19 +1182,19 @@ void PEMainWindow::propertiesChanged(const QHash<QString, QString> & newProperti
 
 	QStringList keys = newProperties.keys();
 	if (keys.contains("family", Qt::CaseInsensitive)) {
-		QMessageBox::warning(NULL, tr("Duplicate problem"), tr("Duplicate 'family' property not allowed"));
+		QMessageBox::warning(nullptr, tr("Duplicate problem"), tr("Duplicate 'family' property not allowed"));
 		return;
 	}
 
 	if (keys.contains("variant", Qt::CaseInsensitive)) {
-		QMessageBox::warning(NULL, tr("Duplicate problem"), tr("Duplicate 'variant' property not allowed"));
+		QMessageBox::warning(nullptr, tr("Duplicate problem"), tr("Duplicate 'variant' property not allowed"));
 		return;
 	}
 
 	// called from metadataView
 	QHash<QString, QString> oldProperties = getOldProperties();
 
-	ChangePropertiesCommand * cpc = new ChangePropertiesCommand(this, oldProperties, newProperties, NULL);
+	ChangePropertiesCommand * cpc = new ChangePropertiesCommand(this, oldProperties, newProperties, nullptr);
 	cpc->setText(tr("Change properties"));
 	cpc->setSkipFirstRedo();
 	changeProperties(newProperties, false);
@@ -1268,7 +1258,7 @@ void PEMainWindow::connectorMetadataChanged(ConnectorMetadata * cmd)
 	ConnectorMetadata oldcmd;
 	fillInMetadata(connector, oldcmd);
 
-	ChangeConnectorMetadataCommand * ccmc = new ChangeConnectorMetadataCommand(this, &oldcmd, cmd, NULL);
+	ChangeConnectorMetadataCommand * ccmc = new ChangeConnectorMetadataCommand(this, &oldcmd, cmd, nullptr);
 	ccmc->setText(tr("Change connector %1").arg(cmd->connectorName));
 	bool skipFirstRedo = (sender() == m_connectorsView);
 	if (skipFirstRedo) {
@@ -1347,7 +1337,7 @@ void PEMainWindow::initSvgTree(SketchWidget * sketchWidget, ItemBase * itemBase,
 			if (parent0.attribute("id") == "copper1") ;
 			else if (parent1.attribute("id") == "copper0") ;
 			else {
-				QMessageBox::warning(NULL, tr("SVG problem"),
+				QMessageBox::warning(nullptr, tr("SVG problem"),
 				                     tr("This version of the new Parts Editor can not deal with separate copper0 and copper1 layers in '%1'. ").arg(itemBase->filename()) +
 				                     tr("So editing may produce an invalid PCB view image"));
 			}
@@ -1428,9 +1418,9 @@ void PEMainWindow::initSvgTree(SketchWidget * sketchWidget, ItemBase * itemBase,
 		QString svgID, terminalID;
 		bool ok = ViewLayer::getConnectorSvgIDs(connector, sketchWidget->viewID(), svgID, terminalID);
 		if (ok) {
-			PEGraphicsItem * terminalItem = pegiHash.value(terminalID, NULL);
+			PEGraphicsItem * terminalItem = pegiHash.value(terminalID, nullptr);
 			PEGraphicsItem * pegi = pegiHash.value(svgID);
-			if (pegi == NULL) {
+			if (pegi == nullptr) {
 				DebugDialog::debug(QString("missing pegi for svg id %1").arg(svgID));
 			}
 			else {
@@ -1480,7 +1470,7 @@ void PEMainWindow::initConnectors(bool updateConnectorsView) {
 
 void PEMainWindow::switchedConnector(int ix)
 {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	switchedConnector(ix, m_currentGraphicsView);
 }
@@ -1519,7 +1509,7 @@ void PEMainWindow::switchedConnector(int ix, SketchWidget * sketchWidget)
 
 void PEMainWindow::loadImage()
 {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	QStringList extras;
 	extras.append("");
@@ -1563,14 +1553,14 @@ void PEMainWindow::loadImage()
 		newReferenceFile = getSvgReferenceFile(origPath);
 		QFile origFile(origPath);
 		if (!origFile.open(QFile::ReadOnly)) {
-			QMessageBox::warning(NULL, tr("Conversion problem"), tr("Unable to load '%1'").arg(origPath));
+			QMessageBox::warning(nullptr, tr("Conversion problem"), tr("Unable to load '%1'").arg(origPath));
 			return;
 		}
 
 		svg = origFile.readAll();
 		origFile.close();
 		if (svg.contains("coreldraw", Qt::CaseInsensitive) && svg.contains("cdata", Qt::CaseInsensitive)) {
-			QMessageBox::warning(NULL, tr("Conversion problem"),
+			QMessageBox::warning(nullptr, tr("Conversion problem"),
 			                     tr("The SVG file '%1' appears to have been exported from CorelDRAW without the 'presentation attributes' setting. ").arg(origPath) +
 			                     tr("Please re-export the SVG file using that setting, and try loading again.")
 			                    );
@@ -1589,7 +1579,7 @@ void PEMainWindow::loadImage()
 			bool reallyFixed = false;
 			TextUtils::fixFonts(svg, destFont, reallyFixed);
 			if (reallyFixed) {
-				QMessageBox::information(NULL, tr("Fonts"),
+				QMessageBox::information(nullptr, tr("Fonts"),
 				                         tr("Fritzing currently only supports OCRA and Droid fonts--these have been substituted in for the fonts in '%1'").arg(origPath));
 			}
 		}
@@ -1602,7 +1592,7 @@ void PEMainWindow::loadImage()
 			                  tr("so for Fritzing parts it is best to use PNG and JPG only as placeholders.")
 			                  ;
 
-			QMessageBox::information(NULL, tr("Use of PNG and JPG discouraged"), message);
+			QMessageBox::information(nullptr, tr("Use of PNG and JPG discouraged"), message);
 
 		}
 
@@ -1610,13 +1600,13 @@ void PEMainWindow::loadImage()
 			svg = createSvgFromImage(origPath);
 		}
 		catch (const QString & msg) {
-			QMessageBox::warning(NULL, tr("Conversion problem"), tr("Unable to load image file '%1': \n\n%2").arg(origPath).arg(msg));
+			QMessageBox::warning(nullptr, tr("Conversion problem"), tr("Unable to load image file '%1': \n\n%2").arg(origPath).arg(msg));
 			return;
 		}
 	}
 
 	if (svg.isEmpty()) {
-		QMessageBox::warning(NULL, tr("Conversion problem"), tr("Unable to load image file '%1'").arg(origPath));
+		QMessageBox::warning(nullptr, tr("Conversion problem"), tr("Unable to load image file '%1'").arg(origPath));
 		return;
 	}
 
@@ -1626,7 +1616,7 @@ void PEMainWindow::loadImage()
 	QDomDocument doc;
 	bool result = doc.setContent(svg.toUtf8(), &errorStr, &errorLine, &errorColumn);
 	if (!result) {
-		QMessageBox::warning(NULL, tr("SVG problem"), tr("Unable to parse '%1': %2 line:%3 column:%4").arg(origPath).arg(errorStr).arg(errorLine).arg(errorColumn));
+		QMessageBox::warning(nullptr, tr("SVG problem"), tr("Unable to parse '%1': %2 line:%3 column:%4").arg(origPath).arg(errorStr).arg(errorLine).arg(errorColumn));
 		return;
 	}
 
@@ -1643,7 +1633,7 @@ void PEMainWindow::loadImage()
 			                  tr("but for now please modify the file according to the instructions in the link.")
 			                  ;
 
-			QMessageBox::warning(NULL, tr("SVG problem"), message);
+			QMessageBox::warning(nullptr, tr("SVG problem"), message);
 			return;
 		}
 	}
@@ -1653,7 +1643,7 @@ void PEMainWindow::loadImage()
 	QString newPath = m_userPartsFolderSvgPath + makeSvgPath2(m_currentGraphicsView);
 	bool success = writeXml(newPath, removeGorn(svg), true);
 	if (!success) {
-		QMessageBox::warning(NULL, tr("Copy problem"), tr("Unable to make a local copy of: '%1'").arg(origPath));
+		QMessageBox::warning(nullptr, tr("Copy problem"), tr("Unable to make a local copy of: '%1'").arg(origPath));
 		return;
 	}
 
@@ -1766,7 +1756,7 @@ void PEMainWindow::changeSvg(SketchWidget * sketchWidget, const QString & filena
 			delete lk;
 		}
 		delete viewThing->itemBase;
-		viewThing->itemBase = NULL;
+		viewThing->itemBase = nullptr;
 	}
 
 	updateChangeCount(sketchWidget, changeDirection);
@@ -1798,7 +1788,7 @@ void PEMainWindow::reload(bool firstTime)
 	QList<ItemBase *> toDelete;
 
 	foreach (ViewThing * viewThing, m_viewThings.values()) {
-		if (viewThing->sketchWidget == NULL) continue;
+		if (viewThing->sketchWidget == nullptr) continue;
 
 		foreach (QGraphicsItem * item, viewThing->sketchWidget->scene()->items()) {
 			ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
@@ -1820,10 +1810,10 @@ void PEMainWindow::reload(bool firstTime)
 	viewGeometry.setLoc(QPointF(0, 0));
 
 	QList<ItemBase *> itemBases;
-	itemBases << m_iconGraphicsView->addItem(modelPart, m_iconGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, NULL);
-	itemBases <<  m_breadboardGraphicsView->addItem(modelPart, m_breadboardGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, NULL);
-	itemBases <<  m_schematicGraphicsView->addItem(modelPart, m_schematicGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, NULL);
-	itemBases <<  m_pcbGraphicsView->addItem(modelPart, m_pcbGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, NULL);
+	itemBases << m_iconGraphicsView->addItem(modelPart, m_iconGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, nullptr);
+	itemBases <<  m_breadboardGraphicsView->addItem(modelPart, m_breadboardGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, nullptr);
+	itemBases <<  m_schematicGraphicsView->addItem(modelPart, m_schematicGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, nullptr);
+	itemBases <<  m_pcbGraphicsView->addItem(modelPart, m_pcbGraphicsView->defaultViewLayerPlacement(modelPart), BaseCommand::SingleView, viewGeometry, newID, -1, nullptr);
 
 	foreach (ItemBase * itemBase, itemBases) {
 		ViewThing * viewThing = m_viewThings.value(itemBase->viewID());
@@ -1877,7 +1867,7 @@ void PEMainWindow::reload(bool firstTime)
 }
 
 void PEMainWindow::busModeChanged(bool state) {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	if (!state) {
 		foreach (ViewThing * viewThing, m_viewThings.values()) {
@@ -1932,7 +1922,7 @@ void PEMainWindow::busModeChanged(bool state) {
 }
 
 void PEMainWindow::pickModeChanged(bool state) {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	// never actually get state == false;
 	m_inPickMode = state;
@@ -2034,7 +2024,7 @@ void PEMainWindow::relocateConnector(PEGraphicsItem * pegi)
 		return;
 	}
 
-	RelocateConnectorSvgCommand * rcsc = new RelocateConnectorSvgCommand(this, m_currentGraphicsView, svgID, terminalID, oldGorn, oldGornTerminal, newGorn, "", NULL);
+	RelocateConnectorSvgCommand * rcsc = new RelocateConnectorSvgCommand(this, m_currentGraphicsView, svgID, terminalID, oldGorn, oldGornTerminal, newGorn, "", nullptr);
 	rcsc->setText(tr("Relocate connector %1").arg(currentConnectorElement.attribute("name")));
 	m_undoStack->waitPush(rcsc, SketchWidget::PropChangeDelay);
 }
@@ -2104,7 +2094,7 @@ void PEMainWindow::relocateConnectorSvg(SketchWidget * sketchWidget, const QStri
 
 	foreach (QGraphicsItem * item, sketchWidget->scene()->items()) {
 		PEGraphicsItem * pegi = dynamic_cast<PEGraphicsItem *>(item);
-		if (pegi == NULL) continue;
+		if (pegi == nullptr) continue;
 
 		QDomElement element = pegi->element();
 		if (element.attribute("gorn").compare(newGorn) == 0) {
@@ -2163,9 +2153,9 @@ bool PEMainWindow::saveAs(bool overWrite)
 	if (overWrite) {
 		foreach (QWidget *widget, QApplication::topLevelWidgets()) {
 			MainWindow *mainWindow = qobject_cast<MainWindow *>(widget);
-			if (mainWindow == NULL) continue;
+			if (mainWindow == nullptr) continue;
 
-			if (qobject_cast<PEMainWindow *>(mainWindow) != NULL) continue;
+			if (qobject_cast<PEMainWindow *>(mainWindow) != nullptr) continue;
 
 			allWindows.append(mainWindow);
 			if (mainWindow->usesPart(m_originalModuleID)) {
@@ -2230,7 +2220,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 			QHash<QString, QString> svgHash;
 			foreach (QGraphicsItem * item, viewThing->sketchWidget->scene()->items()) {
 				ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
-				if (itemBase == NULL) continue;
+				if (itemBase == nullptr) continue;
 
 				if (itemBase->layerKinChief() == viewThing->itemBase) continue;
 
@@ -2348,7 +2338,7 @@ bool PEMainWindow::saveAs(bool overWrite)
 	}
 
 	ModelPart * modelPart = m_referenceModel->retrieveModelPart(m_originalModuleID);
-	if (modelPart == NULL) {
+	if (modelPart == nullptr) {
 		modelPart = m_referenceModel->loadPart(fzpPath, true);
 		modelPart->setAlien(true);
 		emit addToMyPartsSignal(modelPart, peAlienFiles);
@@ -2380,26 +2370,26 @@ void PEMainWindow::updateChangeCount(SketchWidget * sketchWidget, int changeDire
 
 PEGraphicsItem * PEMainWindow::findConnectorItem()
 {
-	if (m_currentGraphicsView == NULL) return NULL;
+	if (m_currentGraphicsView == nullptr) return nullptr;
 
 	QDomElement connector = m_connectorList.at(m_peToolView->currentConnectorIndex());
-	if (connector.isNull()) return NULL;
+	if (connector.isNull()) return nullptr;
 
 	QString svgID, terminalID;
 	bool ok = ViewLayer::getConnectorSvgIDs(connector, m_currentGraphicsView->viewID(), svgID, terminalID);
-	if (!ok) return NULL;
+	if (!ok) return nullptr;
 
 	QList<PEGraphicsItem *> pegiList = getPegiList(m_currentGraphicsView);
 	foreach (PEGraphicsItem * pegi, pegiList) {
 		if (pegi->element().attribute("id") == svgID) return pegi;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void PEMainWindow::terminalPointChanged(const QString & how) {
 	PEGraphicsItem * pegi = findConnectorItem();
-	if (pegi == NULL) return;
+	if (pegi == nullptr) return;
 
 	QRectF r = pegi->rect();
 	QPointF p = r.center();
@@ -2425,7 +2415,7 @@ void PEMainWindow::terminalPointChanged(const QString & how) {
 void PEMainWindow::terminalPointChanged(const QString & coord, double value)
 {
 	PEGraphicsItem * pegi = findConnectorItem();
-	if (pegi == NULL) return;
+	if (pegi == nullptr) return;
 
 	QPointF p = pegi->terminalPoint();
 	if (coord == "x") {
@@ -2448,7 +2438,7 @@ void PEMainWindow::terminalPointChangedAux(PEGraphicsItem * pegi, QPointF before
 
 	QDomElement currentConnectorElement = m_connectorList.at(m_peToolView->currentConnectorIndex());
 
-	MoveTerminalPointCommand * mtpc = new MoveTerminalPointCommand(this, this->m_currentGraphicsView, currentConnectorElement.attribute("id"), pegi->rect().size(), before, after, NULL);
+	MoveTerminalPointCommand * mtpc = new MoveTerminalPointCommand(this, this->m_currentGraphicsView, currentConnectorElement.attribute("id"), pegi->rect().size(), before, after, nullptr);
 	mtpc->setText(tr("Move terminal point"));
 	m_undoStack->waitPush(mtpc, SketchWidget::PropChangeDelay);
 }
@@ -2487,7 +2477,7 @@ void PEMainWindow::moveTerminalPoint(SketchWidget * sketchWidget, const QString 
 		return;
 	}
 
-	PEGraphicsItem * connectorPegi = NULL;
+	PEGraphicsItem * connectorPegi = nullptr;
 	QList<PEGraphicsItem *> pegiList = getPegiList(sketchWidget);
 	foreach (PEGraphicsItem * pegi, pegiList) {
 		QDomElement pegiElement = pegi->element();
@@ -2495,7 +2485,7 @@ void PEMainWindow::moveTerminalPoint(SketchWidget * sketchWidget, const QString 
 			connectorPegi = pegi;
 		}
 	}
-	if (connectorPegi == NULL) return;
+	if (connectorPegi == nullptr) return;
 
 	if (centered) {
 		pElement.removeAttribute("terminalId");
@@ -2594,13 +2584,13 @@ void PEMainWindow::showInOS(QWidget *parent, const QString &pathIn)
 	Q_UNUSED(parent);
 	FolderUtils::showInFolder(pathIn);
 	QClipboard *clipboard = QApplication::clipboard();
-	if (clipboard != NULL) {
+	if (clipboard != nullptr) {
 		clipboard->setText(pathIn);
 	}
 }
 
 void PEMainWindow::showInOS() {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	ViewThing * viewThing = m_viewThings.value(m_currentGraphicsView->viewID());
 	showInOS(this, viewThing->itemBase->filename());
@@ -2652,7 +2642,7 @@ bool PEMainWindow::canSave() {
 void PEMainWindow::tabWidget_currentChanged(int index) {
 	MainWindow::tabWidget_currentChanged(index);
 
-	if (m_peToolView == NULL) return;
+	if (m_peToolView == nullptr) return;
 
 	switchedConnector(m_peToolView->currentConnectorIndex());
 
@@ -2660,7 +2650,7 @@ void PEMainWindow::tabWidget_currentChanged(int index) {
 	m_peSvgView->setChildrenVisible(enabled);
 	m_peToolView->setChildrenVisible(enabled);
 
-	if (m_currentGraphicsView == NULL) {
+	if (m_currentGraphicsView == nullptr) {
 		// update title when switching to connector and metadata view
 		setTitle();
 	}
@@ -2712,7 +2702,7 @@ void PEMainWindow::removedConnectorsAux(QList<QDomElement> & connectors)
 
 	QString newPath = saveFzp();
 
-	ChangeFzpCommand * cfc = new ChangeFzpCommand(this, originalPath, newPath, NULL);
+	ChangeFzpCommand * cfc = new ChangeFzpCommand(this, originalPath, newPath, nullptr);
 	QString message;
 	if (connectors.count() == 1) {
 		message = tr("Remove connector");
@@ -2761,7 +2751,7 @@ QString PEMainWindow::getPartTitle() {
 
 void PEMainWindow::killPegi() {
 	foreach (ViewThing * viewThing, m_viewThings.values()) {
-		if (viewThing->sketchWidget == NULL) continue;
+		if (viewThing->sketchWidget == nullptr) continue;
 
 		foreach (QGraphicsItem * item, viewThing->sketchWidget->scene()->items()) {
 			PEGraphicsItem * pegi = dynamic_cast<PEGraphicsItem *>(item);
@@ -2777,7 +2767,7 @@ bool PEMainWindow::loadFzp(const QString & path) {
 	int errorColumn;
 	bool result = m_fzpDocument.setContent(&file, &errorStr, &errorLine, &errorColumn);
 	if (!result) {
-		QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to load fzp from %1").arg(path));
+		QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to load fzp from %1").arg(path));
 		return false;
 	}
 
@@ -2832,7 +2822,7 @@ void PEMainWindow::connectorCountChanged(int newCount) {
 		tempDoc.setContent(m_removedConnector);
 		connectorModel = tempDoc.documentElement();
 		if (connectorModel.isNull()) {
-			QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to create new connector--you may have to start over."));
+			QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to create new connector--you may have to start over."));
 			return;
 		}
 	}
@@ -2862,7 +2852,7 @@ void PEMainWindow::connectorCountChanged(int newCount) {
 
 	QString newPath = saveFzp();
 
-	ChangeFzpCommand * cfc = new ChangeFzpCommand(this, originalPath, newPath, NULL);
+	ChangeFzpCommand * cfc = new ChangeFzpCommand(this, originalPath, newPath, nullptr);
 	QString message;
 	if (newCount - connectorList.count() == 1) {
 		message = tr("Add connector");
@@ -3001,7 +2991,7 @@ void PEMainWindow::updateWireMenu() {
 	// and that wire is cached by the menu in Wire::mousePressEvent
 
 	Wire * wire = m_activeWire;
-	m_activeWire = NULL;
+	m_activeWire = nullptr;
 
 	m_deleteBusConnectionAct->setWire(wire);
 	m_deleteBusConnectionAct->setEnabled(true);
@@ -3009,10 +2999,10 @@ void PEMainWindow::updateWireMenu() {
 
 void PEMainWindow::deleteBusConnection() {
 	WireAction * wireAction = qobject_cast<WireAction *>(sender());
-	if (wireAction == NULL) return;
+	if (wireAction == nullptr) return;
 
 	Wire * wire = wireAction->wire();
-	if (wire == NULL) return;
+	if (wire == nullptr) return;
 
 	QList<Wire *> wires;
 	QList<ConnectorItem *> ends;
@@ -3038,7 +3028,7 @@ void PEMainWindow::deleteBusConnection() {
 	QString busID = bus.attribute("id");
 
 	if (nodeMember0.isNull() || nodeMember1.isNull()) {
-		QMessageBox::critical(NULL, tr("Parts Editor"), tr("Internal connections are very messed up."));
+		QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Internal connections are very messed up."));
 		return;
 	}
 
@@ -3072,10 +3062,10 @@ void PEMainWindow::newWireSlot(Wire * wire) {
 void PEMainWindow::wireChangedSlot(Wire* wire, const QLineF &, const QLineF &, QPointF, QPointF, ConnectorItem * fromOnWire, ConnectorItem * to) {
 	wire->deleteLater();
 
-	if (to == NULL) return;
+	if (to == nullptr) return;
 
 	ConnectorItem * from = wire->otherConnector(fromOnWire)->firstConnectedToIsh();
-	if (from == NULL) return;
+	if (from == nullptr) return;
 
 	QDomElement root = m_fzpDocument.documentElement();
 	QDomElement buses = root.firstChildElement("buses");
@@ -3296,7 +3286,7 @@ bool PEMainWindow::eventFilter(QObject *object, QEvent *event)
 	//qDebug() << "event" << event->type();
 	if (event->type() == QEvent::FocusIn) {
 		QLineEdit * lineEdit = qobject_cast<QLineEdit *>(object);
-		if (lineEdit != NULL) {
+		if (lineEdit != nullptr) {
 			if (lineEdit->window() == this) {
 				qDebug() << "inc focus";
 				m_inFocusWidgets << lineEdit;
@@ -3304,7 +3294,7 @@ bool PEMainWindow::eventFilter(QObject *object, QEvent *event)
 		}
 		else {
 			QTextEdit * textEdit = qobject_cast<QTextEdit *>(object);
-			if (textEdit != NULL && textEdit->window() == this) {
+			if (textEdit != nullptr && textEdit->window() == this) {
 				qDebug() << "inc focus";
 				m_inFocusWidgets << textEdit;
 			}
@@ -3312,7 +3302,7 @@ bool PEMainWindow::eventFilter(QObject *object, QEvent *event)
 	}
 	if (event->type() == QEvent::FocusOut) {
 		QLineEdit * lineEdit = qobject_cast<QLineEdit *>(object);
-		if (lineEdit != NULL) {
+		if (lineEdit != nullptr) {
 			if (lineEdit->window() == this) {
 				qDebug() << "dec focus";
 				m_inFocusWidgets.removeOne(lineEdit);
@@ -3320,7 +3310,7 @@ bool PEMainWindow::eventFilter(QObject *object, QEvent *event)
 		}
 		else {
 			QTextEdit * textEdit = qobject_cast<QTextEdit *>(object);
-			if (textEdit != NULL && textEdit->window() == this) {
+			if (textEdit != nullptr && textEdit->window() == this) {
 				qDebug() << "inc focus";
 				m_inFocusWidgets.removeOne(textEdit);
 			}
@@ -3356,7 +3346,7 @@ QList<PEGraphicsItem *> PEMainWindow::getPegiList(SketchWidget * sketchWidget) {
 	QList<PEGraphicsItem *> pegiList;
 	foreach (QGraphicsItem * item, sketchWidget->scene()->items()) {
 		PEGraphicsItem * pegi = dynamic_cast<PEGraphicsItem *>(item);
-		if (pegi == NULL) continue;
+		if (pegi == nullptr) continue;
 
 		pegiList.append(pegi);
 		/*
@@ -3379,7 +3369,7 @@ void PEMainWindow::deleteBuses() {
 	foreach (ViewThing * viewThing, m_viewThings.values()) {
 		foreach (QGraphicsItem * item, viewThing->sketchWidget->scene()->items()) {
 			Wire * wire = dynamic_cast<Wire *>(item);
-			if (wire == NULL) continue;
+			if (wire == nullptr) continue;
 
 			toDelete << wire;
 		}
@@ -3392,7 +3382,7 @@ void PEMainWindow::deleteBuses() {
 
 void PEMainWindow::connectorsTypeChanged(Connector::ConnectorType ct)
 {
-	QUndoCommand * parentCommand = NULL;
+	QUndoCommand * parentCommand = nullptr;
 
 	QDomElement root = m_fzpDocument.documentElement();
 	QDomElement connectors = root.firstChildElement("connectors");
@@ -3401,7 +3391,7 @@ void PEMainWindow::connectorsTypeChanged(Connector::ConnectorType ct)
 		ConnectorMetadata oldCmd;
 		fillInMetadata(connector, oldCmd);
 		if (oldCmd.connectorType != ct) {
-			if (parentCommand == NULL) {
+			if (parentCommand == nullptr) {
 				parentCommand = new QUndoCommand(tr("Change all connectors to %1").arg(Connector::connectorNameFromType(ct)));
 			}
 			ConnectorMetadata cmd = oldCmd;
@@ -3436,7 +3426,7 @@ void PEMainWindow::smdChanged(const QString & after) {
 
 	ViewThing * viewThing = m_viewThings.value(ViewLayer::PCBView);
 	ItemBase * itemBase = viewThing->itemBase;
-	if (itemBase == NULL) return;
+	if (itemBase == nullptr) return;
 
 	QFile file(itemBase->filename());
 	QDomDocument svgDoc;
@@ -3445,7 +3435,7 @@ void PEMainWindow::smdChanged(const QString & after) {
 	QDomElement svgCopper0 = TextUtils::findElementWithAttribute(svgRoot, "id", "copper0");
 	QDomElement svgCopper1 = TextUtils::findElementWithAttribute(svgRoot, "id", "copper1");
 	if (svgCopper0.isNull() && svgCopper1.isNull()) {
-		QMessageBox::critical(NULL, tr("Parts Editor"), tr("Unable to parse '%1'").arg(itemBase->filename()));
+		QMessageBox::critical(nullptr, tr("Parts Editor"), tr("Unable to parse '%1'").arg(itemBase->filename()));
 		return;
 	}
 
@@ -3495,7 +3485,7 @@ void PEMainWindow::smdChanged(const QString & after) {
 	QString svg = TextUtils::svgNSOnly(svgDoc.toString());
 	writeXml(newPath, removeGorn(svg), true);
 
-	ChangeSMDCommand * csc = new ChangeSMDCommand(this, before, after, itemBase->filename(), newPath, NULL);
+	ChangeSMDCommand * csc = new ChangeSMDCommand(this, before, after, itemBase->filename(), newPath, nullptr);
 	csc->setText(tr("Change to %1").arg(after));
 	m_undoStack->waitPush(csc, SketchWidget::PropChangeDelay);
 }
@@ -3598,16 +3588,16 @@ void PEMainWindow::reusePCB()
 }
 
 void PEMainWindow::reuseImage(ViewLayer::ViewID viewID) {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	ViewThing * afterViewThing = m_viewThings.value(viewID);
-	if (afterViewThing->itemBase == NULL) return;
+	if (afterViewThing->itemBase == nullptr) return;
 
 	QString afterFilename = afterViewThing->itemBase->filename();
 
 	ViewThing * beforeViewThing = m_viewThings.value(m_currentGraphicsView->viewID());
 
-	ChangeSvgCommand * csc = new ChangeSvgCommand(this, m_currentGraphicsView, beforeViewThing->itemBase->filename(), afterFilename, NULL);
+	ChangeSvgCommand * csc = new ChangeSvgCommand(this, m_currentGraphicsView, beforeViewThing->itemBase->filename(), afterFilename, nullptr);
 	QFileInfo info(afterFilename);
 	csc->setText(QString("Load '%1'").arg(info.fileName()));
 	m_undoStack->waitPush(csc, SketchWidget::PropChangeDelay);
@@ -3624,7 +3614,7 @@ void PEMainWindow::updateFileMenu() {
 	enabled.insert(ViewLayer::SchematicView, true);
 	enabled.insert(ViewLayer::PCBView, true);
 	bool enableAll = true;
-	if (m_currentGraphicsView == NULL) {
+	if (m_currentGraphicsView == nullptr) {
 		enableAll = false;
 	}
 	else {
@@ -3637,7 +3627,7 @@ void PEMainWindow::updateFileMenu() {
 	m_reusePCBAct->setEnabled(enableAll && enabled.value(ViewLayer::PCBView));
 	*/
 
-	bool enabled = m_currentGraphicsView != NULL && m_currentGraphicsView->viewID() == ViewLayer::IconView;
+	bool enabled = m_currentGraphicsView != nullptr && m_currentGraphicsView->viewID() == ViewLayer::IconView;
 	m_reuseBreadboardAct->setEnabled(enabled);
 	m_reuseSchematicAct->setEnabled(enabled);
 	m_reusePCBAct->setEnabled(enabled);
@@ -3669,7 +3659,7 @@ void PEMainWindow::updateLayerMenu(bool resetLayout) {
 	MainWindow::updateLayerMenu(resetLayout);
 
 	bool enabled = false;
-	if (m_currentGraphicsView != NULL) {
+	if (m_currentGraphicsView != nullptr) {
 		switch (m_currentGraphicsView->viewID()) {
 		case ViewLayer::BreadboardView:
 		case ViewLayer::SchematicView:
@@ -3684,11 +3674,11 @@ void PEMainWindow::updateLayerMenu(bool resetLayout) {
 }
 
 void PEMainWindow::hideOtherViews() {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	ViewLayer::ViewID afterViewID = m_currentGraphicsView->viewID();
 	ItemBase * afterItemBase = m_viewThings.value(afterViewID)->itemBase;
-	if (afterItemBase == NULL) return;
+	if (afterItemBase == nullptr) return;
 	QString afterFilename = afterItemBase->filename();
 
 	QList<ViewLayer::ViewID> viewIDList;
@@ -3736,7 +3726,7 @@ void PEMainWindow::hideOtherViews() {
 	}
 
 	QString newPath = saveFzp();
-	ChangeFzpCommand * cfc = new ChangeFzpCommand(this, originalPath, newPath, NULL);
+	ChangeFzpCommand * cfc = new ChangeFzpCommand(this, originalPath, newPath, nullptr);
 	cfc->setText(tr("Make only %1 view visible").arg(m_currentGraphicsView->viewName()));
 	m_undoStack->waitPush(cfc, SketchWidget::PropChangeDelay);
 }
@@ -3755,7 +3745,7 @@ QString PEMainWindow::makeNewVariant(const QString & family)
 }
 
 void PEMainWindow::updateAssignedConnectors() {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 
 	QDomDocument * doc = m_viewThings.value(m_currentGraphicsView->viewID())->document;
 	if (doc) m_peToolView->showAssignedConnectors(doc, m_currentGraphicsView->viewID());
@@ -3799,7 +3789,7 @@ void PEMainWindow::connectorWarning() {
 		foreach (ViewLayer::ViewID viewID, unassigned.keys()) {
 			if (unassigned.value(viewID) > 0) viewCount++;
 		}
-		QMessageBox::warning(NULL, tr("Parts Editor"),
+		QMessageBox::warning(nullptr, tr("Parts Editor"),
 		                     tr("This part has %n unassigned connectors ", "", unassignedTotal) +
 		                     tr("across %n views. ", "", viewCount) +
 		                     tr("Until all connectors are assigned to SVG elements, the part will not work correctly. ") +
@@ -3825,7 +3815,7 @@ void PEMainWindow::showing(SketchWidget * sketchWidget) {
 }
 
 bool PEMainWindow::anyMarquee() {
-	if (m_currentGraphicsView == NULL) return false;
+	if (m_currentGraphicsView == nullptr) return false;
 
 	QList<PEGraphicsItem *> pegiList = getPegiList(m_currentGraphicsView);
 	foreach (PEGraphicsItem * pegi, pegiList) {
@@ -3838,11 +3828,11 @@ bool PEMainWindow::anyMarquee() {
 }
 
 bool PEMainWindow::anyVisible() {
-	if (m_currentGraphicsView == NULL) return false;
+	if (m_currentGraphicsView == nullptr) return false;
 
 	foreach (QGraphicsItem * item, m_currentGraphicsView->scene()->items()) {
 		PEGraphicsItem * pegi = dynamic_cast<PEGraphicsItem *>(item);
-		if (pegi == NULL) continue;
+		if (pegi == nullptr) continue;
 
 		return pegi->isVisible();
 	}
@@ -3853,7 +3843,7 @@ bool PEMainWindow::anyVisible() {
 void PEMainWindow::changeReferenceFile(ViewLayer::ViewID viewID, const QString referenceFile)
 {
 	ViewThing * viewThing = m_viewThings.value(viewID);
-	if (viewThing == NULL) {
+	if (viewThing == nullptr) {
 		// shouldn't happen
 		DebugDialog::debug(QString("missing view thing for %1").arg(viewID));
 		return;
@@ -3877,7 +3867,7 @@ void PEMainWindow::insertDesc(const QString & referenceFile, QString & svg) {
 void PEMainWindow::itemAddedSlot(ModelPart *, ItemBase * itemBase, ViewLayer::ViewLayerPlacement, const ViewGeometry &, long id, SketchWidget *) {
 	Q_UNUSED(id);
 
-	if (itemBase == NULL) return;
+	if (itemBase == nullptr) return;
 	if (itemBase->viewID() != m_currentGraphicsView->viewID()) return;
 
 	QDomElement element;
@@ -3891,7 +3881,7 @@ void PEMainWindow::itemAddedSlot(ModelPart *, ItemBase * itemBase, ViewLayer::Vi
 }
 
 void PEMainWindow::itemMovedSlot(ItemBase * itemBase) {
-	if (itemBase == NULL) return;
+	if (itemBase == nullptr) return;
 	if (itemBase->viewID() != m_currentGraphicsView->viewID()) return;
 
 	foreach (PEGraphicsItem * pegi, getPegiList(m_currentGraphicsView)) {
@@ -3903,7 +3893,7 @@ void PEMainWindow::itemMovedSlot(ItemBase * itemBase) {
 }
 
 void PEMainWindow::resizedSlot(ItemBase * itemBase) {
-	if (itemBase == NULL) return;
+	if (itemBase == nullptr) return;
 	if (itemBase->viewID() != m_currentGraphicsView->viewID()) return;
 
 	foreach (PEGraphicsItem * pegi, getPegiList(m_currentGraphicsView)) {
@@ -3917,7 +3907,7 @@ void PEMainWindow::resizedSlot(ItemBase * itemBase) {
 
 void PEMainWindow::clickedItemCandidateSlot(QGraphicsItem * item, bool & ok) {
 	PEGraphicsItem * pegi = dynamic_cast<PEGraphicsItem *>(item);
-	if (pegi == NULL) {
+	if (pegi == nullptr) {
 		ok = true;
 		return;
 	}
@@ -3945,7 +3935,7 @@ void PEMainWindow::updateExportMenu() {
 }
 
 void PEMainWindow::convertToTenth() {
-	if (m_currentGraphicsView == NULL) return;
+	if (m_currentGraphicsView == nullptr) return;
 	if (m_currentGraphicsView->viewID() != ViewLayer::SchematicView) return;
 
 	QString originalFzpPath = saveFzp();
@@ -3974,5 +3964,5 @@ void PEMainWindow::s2sMessageSlot(const QString & message) {
 
 void PEMainWindow::updateEditMenu() {
 	MainWindow::updateEditMenu();
-	m_convertToTenthAct->setEnabled(m_currentGraphicsView != NULL && m_currentGraphicsView->viewID() == ViewLayer::SchematicView);
+	m_convertToTenthAct->setEnabled(m_currentGraphicsView != nullptr && m_currentGraphicsView->viewID() == ViewLayer::SchematicView);
 }

--- a/src/partseditor/pemainwindow.cpp
+++ b/src/partseditor/pemainwindow.cpp
@@ -290,16 +290,16 @@ void IconSketchWidget::addViewLayers() {
 
 PEMainWindow::PEMainWindow(ReferenceModel * referenceModel, QWidget * parent)
 	: MainWindow(referenceModel, parent),
-    m_useNextPick(false),
-    m_inPickMode(false),
-    m_gaveSaveWarning(false),
-    m_canSave(false),
-    m_guid(TextUtils::getRandText()),
-    m_prefix("prefix0000"),
-    m_fileIndex(0),
-    m_peToolView(nullptr),
-    m_peSvgView(nullptr),
-    m_connectorsView(nullptr)
+	m_useNextPick(false),
+	m_inPickMode(false),
+	m_gaveSaveWarning(false),
+	m_canSave(false),
+	m_guid(TextUtils::getRandText()),
+	m_prefix("prefix0000"),
+	m_fileIndex(0),
+	m_peToolView(nullptr),
+	m_peSvgView(nullptr),
+	m_connectorsView(nullptr)
 {
     m_settingsPrefix = "pe/";
 	m_viewThings.insert(ViewLayer::BreadboardView, new ViewThing);
@@ -729,7 +729,7 @@ bool PEMainWindow::setInitialItem(PaletteItem * paletteItem)
 	m_pcbGraphicsView->setLayerActive(ViewLayer::Silkscreen0, true);
 
 	ModelPart * originalModelPart = nullptr;
-	if (paletteItem == nullptr) {
+	if (!paletteItem) {
 		// this shouldn't happen
 		originalModelPart = m_referenceModel->retrieveModelPart("generic_ic_dip_8_300mil");
 	}

--- a/src/partseditor/pemainwindow.h
+++ b/src/partseditor/pemainwindow.h
@@ -235,23 +235,23 @@ protected:
 	QDomDocument m_schematicDocument;
 	QDomDocument m_pcbDocument;
 
-	QAction * m_showMetadataViewAct;
-	QAction * m_showConnectorsViewAct;
-	QAction * m_showIconAct;
-	QAction * m_showInOSAct;
-	WireAction * m_deleteBusConnectionAct;
-	QAction * m_reuseBreadboardAct;
-	QAction * m_reuseSchematicAct;
-	QAction * m_reusePCBAct;
-	QAction * m_hideOtherViewsAct;
-	QAction * m_convertToTenthAct;
+	QAction * m_showMetadataViewAct = nullptr;
+	QAction * m_showConnectorsViewAct = nullptr;
+	QAction * m_showIconAct = nullptr;
+	QAction * m_showInOSAct = nullptr;
+	WireAction * m_deleteBusConnectionAct = nullptr;
+	QAction * m_reuseBreadboardAct = nullptr;
+	QAction * m_reuseSchematicAct = nullptr;
+	QAction * m_reusePCBAct = nullptr;
+	QAction * m_hideOtherViewsAct = nullptr;
+	QAction * m_convertToTenthAct = nullptr;
 
 	QPointer<SketchAreaWidget> m_iconWidget;
 	QPointer<IconSketchWidget> m_iconGraphicsView;
-	PEMetadataView * m_metadataView;
-	PEConnectorsView * m_connectorsView;
-	PEToolView * m_peToolView;
-	PESvgView * m_peSvgView;
+	PEMetadataView * m_metadataView = nullptr;
+	PEConnectorsView * m_connectorsView = nullptr;
+	PEToolView * m_peToolView = nullptr;
+	PESvgView * m_peSvgView = nullptr;
 	QString m_guid;
 	QString m_prefix;
 	int m_fileIndex;

--- a/src/partseditor/pemainwindow.h
+++ b/src/partseditor/pemainwindow.h
@@ -39,28 +39,36 @@ public:
 };
 
 struct ViewThing {
-	ItemBase * itemBase;
-	QDomDocument * document;
-	int svgChangeCount;
-	bool everZoomed;
-	SketchWidget * sketchWidget;
+	ItemBase * itemBase = nullptr;
+	QDomDocument * document = nullptr;
+	int svgChangeCount = 0;
+	bool everZoomed = false;
+	SketchWidget * sketchWidget = nullptr;
 	QString referenceFile;
 	QString originalSvgPath;
-	bool firstTime;
-	bool busMode;
-
-	ViewThing();
+	bool firstTime = false;
+	bool busMode = false;
 };
 
+class ReferenceModel;
+class PaletteItem;
+class PEMetadataView;
+class PEConnectorsView;
+class PEToolView;
+class PESvgView;
+class PEGraphicsItem;
+class Wire;
+class WireAction;
+class IconSketchWidget;
 class PEMainWindow : public MainWindow
 {
 	Q_OBJECT
 
 public:
-	PEMainWindow(class ReferenceModel * referenceModel, QWidget * parent);
+	PEMainWindow(ReferenceModel * referenceModel, QWidget * parent);
 	~PEMainWindow();
 
-	bool setInitialItem(class PaletteItem *);
+	bool setInitialItem(PaletteItem *);
 	void changeTags(const QStringList &, bool updateDisplay);
 	void changeProperties(const QHash<QString, QString> &, bool updateDisplay);
 	void changeMetadata(const QString & name, const QString & value, bool updateDisplay);
@@ -85,11 +93,11 @@ public slots:
 	void tagsChanged(const QStringList &);
 	void connectorMetadataChanged(struct ConnectorMetadata *);
 	void removedConnectors(QList<ConnectorMetadata *> &);
-	void highlightSlot(class PEGraphicsItem *);
-	void pegiMousePressed(class PEGraphicsItem *, bool & ignore);
-	void pegiMouseReleased(class PEGraphicsItem *);
-	void pegiTerminalPointMoved(class PEGraphicsItem *, QPointF);
-	void pegiTerminalPointChanged(class PEGraphicsItem *, QPointF before, QPointF after);
+	void highlightSlot(PEGraphicsItem *);
+	void pegiMousePressed(PEGraphicsItem *, bool & ignore);
+	void pegiMouseReleased(PEGraphicsItem *);
+	void pegiTerminalPointMoved(PEGraphicsItem *, QPointF);
+	void pegiTerminalPointChanged(PEGraphicsItem *, QPointF before, QPointF after);
 	void switchedConnector(int);
 	void removedConnector(const QDomElement &);
 	void terminalPointChanged(const QString & how);
@@ -100,7 +108,7 @@ public slots:
 	void connectorCountChanged(int);
 	void deleteBusConnection();
 	void newWireSlot(Wire *);
-	void wireChangedSlot(class Wire*, const QLineF & oldLine, const QLineF & newLine, QPointF oldPos, QPointF newPos, ConnectorItem * from, ConnectorItem * to);
+	void wireChangedSlot(Wire*, const QLineF & oldLine, const QLineF & newLine, QPointF oldPos, QPointF newPos, ConnectorItem * from, ConnectorItem * to);
 	void connectorsTypeChanged(Connector::ConnectorType);
 	void smdChanged(const QString &);
 	void showing(SketchWidget *);
@@ -144,7 +152,7 @@ protected:
 	void reload(bool firstTime);
 	void createFileMenu();
 	void updateChangeCount(SketchWidget * sketchWidget, int changeDirection);
-	class PEGraphicsItem * findConnectorItem();
+	PEGraphicsItem * findConnectorItem();
 	void terminalPointChangedAux(PEGraphicsItem * pegi, QPointF before, QPointF after);
 	void showInOS(QWidget *parent, const QString &pathIn);
 	void switchedConnector(int, SketchWidget *);
@@ -231,7 +239,7 @@ protected:
 	QAction * m_showConnectorsViewAct;
 	QAction * m_showIconAct;
 	QAction * m_showInOSAct;
-	class WireAction * m_deleteBusConnectionAct;
+	WireAction * m_deleteBusConnectionAct;
 	QAction * m_reuseBreadboardAct;
 	QAction * m_reuseSchematicAct;
 	QAction * m_reusePCBAct;
@@ -239,11 +247,11 @@ protected:
 	QAction * m_convertToTenthAct;
 
 	QPointer<SketchAreaWidget> m_iconWidget;
-	QPointer<class IconSketchWidget> m_iconGraphicsView;
-	class PEMetadataView * m_metadataView;
-	class PEConnectorsView * m_connectorsView;
-	class PEToolView * m_peToolView;
-	class PESvgView * m_peSvgView;
+	QPointer<IconSketchWidget> m_iconGraphicsView;
+	PEMetadataView * m_metadataView;
+	PEConnectorsView * m_connectorsView;
+	PEToolView * m_peToolView;
+	PESvgView * m_peSvgView;
 	QString m_guid;
 	QString m_prefix;
 	int m_fileIndex;

--- a/src/sketch/welcomeview.cpp
+++ b/src/sketch/welcomeview.cpp
@@ -44,14 +44,14 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 ////////////////////////////////////////////////////////////
 
-static const int TitleRole = Qt::UserRole;
-static const int IntroRole = Qt::UserRole + 1;
-static const int DateRole = Qt::UserRole + 2;
-static const int AuthorRole = Qt::UserRole + 3;
-static const int IconRole = Qt::UserRole + 4;
-static const int RefRole = Qt::UserRole + 5;
-static const int ImageSpace = 65;
-static const int TopSpace = 5;
+constexpr auto TitleRole = Qt::UserRole;
+constexpr auto IntroRole = Qt::UserRole + 1;
+constexpr auto DateRole = Qt::UserRole + 2;
+constexpr auto AuthorRole = Qt::UserRole + 3;
+constexpr auto IconRole = Qt::UserRole + 4;
+constexpr auto RefRole = Qt::UserRole + 5;
+constexpr auto ImageSpace = 65;
+constexpr auto TopSpace = 5;
 
 QString WelcomeView::m_activeHeaderLabelColor = "#333";
 QString WelcomeView::m_inactiveHeaderLabelColor = "#b1b1b1";
@@ -239,11 +239,11 @@ BlogListDelegate::~BlogListDelegate()
 
 void BlogListDelegate::paint ( QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
 {
-	BlogListWidget * listWidget = qobject_cast<BlogListWidget *>(this->parent());
-	if (listWidget == NULL) return;
+	auto listWidget = qobject_cast<BlogListWidget *>(this->parent());
+	if (!listWidget) return;
 
-	QStyle * style = listWidget->style();
-	if (style == NULL) return;
+	auto style = listWidget->style();
+	if (!style) return;
 
 	painter->save();
 
@@ -311,7 +311,6 @@ WelcomeView::WelcomeView(QWidget * parent) : QFrame(parent)
 {
 	this->setObjectName("welcomeView");
 
-	m_tip = NULL;
 	setAcceptDrops(true);
 	initLayout();
 
@@ -330,9 +329,6 @@ WelcomeView::WelcomeView(QWidget * parent) : QFrame(parent)
 
 	TipsAndTricks::initTipSets();
 	nextTip();
-}
-
-WelcomeView::~WelcomeView() {
 }
 
 void WelcomeView::initLayout()
@@ -390,10 +386,10 @@ QWidget * WelcomeView::initRecent() {
 	names << "recentSpace" << "recentNewSketch" << "recentOpenSketch";
 
 	foreach (QString name, names) {
-		QWidget * widget = NULL;
+		QWidget * widget = nullptr;
 		QLayout * whichLayout = frameLayout;
-		QLabel * icon = NULL;
-		QLabel * text = NULL;
+		QLabel * icon = nullptr;
+		QLabel * text = nullptr;
 		if (name == "recentSpace") {
 			widget = new QLabel();
 		}
@@ -682,13 +678,13 @@ void WelcomeView::showEvent(QShowEvent * event) {
 }
 
 void WelcomeView::updateRecent() {
-	if (m_recentListWidget == NULL) return;
+	if (!m_recentListWidget) return;
 
 	QSettings settings;
-	QStringList files = settings.value("recentFileList").toStringList();
+	auto files = settings.value("recentFileList").toStringList();
 	m_recentListWidget->clear();
 
-	bool gotOne = false;
+	auto gotOne = false;
 
 	QIcon icon(":/resources/images/icons/WS-fzz-icon.png");
 	for (int i = 0; i < files.size(); ++i) {
@@ -696,7 +692,7 @@ void WelcomeView::updateRecent() {
 		if (!finfo.exists()) continue;
 
 		gotOne = true;
-		QListWidgetItem * item = new QListWidgetItem(icon, finfo.fileName());
+		auto item = new QListWidgetItem(icon, finfo.fileName());
 		item->setData(Qt::UserRole, finfo.absoluteFilePath());
 		item->setToolTip(finfo.absoluteFilePath());
 		m_recentListWidget->addItem(item);
@@ -704,7 +700,7 @@ void WelcomeView::updateRecent() {
 
 	if (!gotOne) {
 		// put in a placeholder if there are no recent files
-		QListWidgetItem * item = new QListWidgetItem(icon, tr("No recent sketches found"));
+		auto item = new QListWidgetItem(icon, tr("No recent sketches found"));
 		item->setData(Qt::UserRole, "");
 		m_recentListWidget->addItem(item);
 	}
@@ -722,16 +718,16 @@ void WelcomeView::clickRecent(const QString & url) {
 }
 
 void WelcomeView::gotBlogSnippet(QNetworkReply * networkReply) {
-	bool blog = networkReply->url().toString().contains("blog");
-	QString prefix = networkReply->url().scheme() + "://" + networkReply->url().authority();
-	QNetworkAccessManager * manager = networkReply->manager();
-	int responseCode = networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+	auto blog = networkReply->url().toString().contains("blog");
+	auto prefix = networkReply->url().scheme() + "://" + networkReply->url().authority();
+	auto manager = networkReply->manager();
+	auto responseCode = networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
-	bool goodBlog = false;
+	auto goodBlog = false;
 	QDomDocument doc;
 	QString errorStr;
-	int errorLine;
-	int errorColumn;
+	auto errorLine = 0;
+	auto errorColumn = 0;
 	if (responseCode == 200) {
 		QString data(networkReply->readAll());
 		//DebugDialog::debug("response data " + data);
@@ -840,7 +836,7 @@ void WelcomeView::clickBlog(const QString & url) {
 
 
 void WelcomeView::readBlog(const QDomDocument & doc, bool doEmit, bool blog, const QString & prefix) {
-	BlogListWidget * listWidget = (blog) ? m_blogListWidget : m_projectListWidget;
+	auto listWidget = (blog) ? m_blogListWidget : m_projectListWidget;
 	listWidget->clear();
 	listWidget->imageRequestList().clear();
 
@@ -879,7 +875,7 @@ void WelcomeView::readBlog(const QDomDocument & doc, bool doEmit, bool blog, con
 		if (stuff.value("title", "").isEmpty()) continue;
 		if (stuff.value("href", "").isEmpty()) continue;
 
-		QListWidgetItem * item = new QListWidgetItem();
+		auto item = new QListWidgetItem();
 		item->setData(TitleRole, stuff.value("title"));
 		item->setData(RefRole, stuff.value("href"));
 		QString text = stuff.value("intro", "");
@@ -907,7 +903,7 @@ void WelcomeView::readBlog(const QDomDocument & doc, bool doEmit, bool blog, con
 		getNextBlogImage(0, blog);
 		foreach (QWidget *widget, QApplication::topLevelWidgets()) {
 			WelcomeView * other = widget->findChild<WelcomeView *>();
-			if (other == NULL) continue;
+			if (!other) continue;
 			if (other == this) continue;
 
 			other->readBlog(doc, false, blog, prefix);
@@ -930,22 +926,22 @@ void WelcomeView::getNextBlogImage(int ix, bool blog) {
 }
 
 void WelcomeView::gotBlogImage(QNetworkReply * networkReply) {
-	QNetworkAccessManager * manager = networkReply->manager();
-	if (manager == NULL) return;
+	auto manager = networkReply->manager();
+	if (!manager) return;
 
-	int index = manager->property("index").toInt();
-	bool blog = manager->property("blog").toBool();
+	auto index = manager->property("index").toInt();
+	auto blog = manager->property("blog").toBool();
 
-	int responseCode = networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+	auto responseCode = networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 	if (responseCode == 200) {
 		QByteArray data(networkReply->readAll());
 		QPixmap pixmap;
 		if (pixmap.loadFromData(data)) {
-			QPixmap scaled = pixmap.scaled(QSize(ImageSpace, ImageSpace), Qt::KeepAspectRatio);
+			auto scaled = pixmap.scaled(QSize(ImageSpace, ImageSpace), Qt::KeepAspectRatio);
 			setBlogItemImage(scaled, index, blog);
 			foreach (QWidget *widget, QApplication::topLevelWidgets()) {
-				WelcomeView * other = widget->findChild<WelcomeView *>();
-				if (other == NULL) continue;
+				auto other = widget->findChild<WelcomeView *>();
+				if (!other) continue;
 				if (other == this) continue;
 
 				other->setBlogItemImage(scaled, index, blog);
@@ -959,16 +955,16 @@ void WelcomeView::gotBlogImage(QNetworkReply * networkReply) {
 }
 
 QWidget * WelcomeView::initTip() {
-	QFrame * tipFrame = new QFrame();
+	auto tipFrame = new QFrame();
 	tipFrame->setObjectName("tipFrame");
-	QVBoxLayout * tipLayout = new QVBoxLayout();
+	auto tipLayout = new QVBoxLayout();
 	zeroMargin(tipLayout);
 
-	QLabel * tipTitle = new QLabel(tr("Tip of the Day:"));
+	auto tipTitle = new QLabel(tr("Tip of the Day:"));
 	tipTitle->setObjectName("tipTitle");
 	tipLayout->addWidget(tipTitle);
 
-	QScrollArea * scrollArea = new QScrollArea;
+	auto scrollArea = new QScrollArea;
 	scrollArea->setObjectName("tipScrollArea");
 	scrollArea->setWidgetResizable(true);
 	// scrollArea->setAlignment(Qt::AlignTop | Qt::AlignLeft);
@@ -987,11 +983,11 @@ QWidget * WelcomeView::initTip() {
 	QFrame * footerFrame = new QFrame();
 	footerFrame->setObjectName("tipFooterFrame");
 
-	QHBoxLayout * footerFrameLayout = new QHBoxLayout;
+	auto footerFrameLayout = new QHBoxLayout;
 	zeroMargin(footerFrameLayout);
 
 
-	QLabel * footerLabel = new QLabel(QString("<a href='http://blog.fritzing.org'  style='font-family:Droid Sans; text-decoration:none; color:#2e94af;'>%1</a>").arg(tr("All Tips")));
+	auto footerLabel = new QLabel(QString("<a href='http://blog.fritzing.org'  style='font-family:Droid Sans; text-decoration:none; color:#2e94af;'>%1</a>").arg(tr("All Tips")));
 	footerLabel->setObjectName("allTips");
 	footerFrameLayout->addWidget(footerLabel);
 	connect(footerLabel, SIGNAL(linkActivated(const QString &)), this->window(), SLOT(tipsAndTricks()));
@@ -1021,7 +1017,7 @@ void WelcomeView::dragEnterEvent(QDragEnterEvent *event)
 }
 
 void WelcomeView::nextTip() {
-	if (m_tip == NULL) return;
+	if (!m_tip) return;
 
 	m_tip->setText(QString("<a href='tip' style='text-decoration:none; color:#2e94af;'>%1</a>").arg(TipsAndTricks::randomTip()));
 }
@@ -1044,8 +1040,8 @@ void WelcomeView::blogItemClicked(QListWidgetItem * item) {
 
 void WelcomeView::setBlogItemImage(QPixmap & pixmap, int index, bool blog) {
 	// TODO: this is not totally thread-safe if there are multiple sketch widgets opened within a very short time
-	BlogListWidget * listWidget = (blog) ? m_blogListWidget : m_projectListWidget;
-	QListWidgetItem * item = listWidget->item(index);
+	auto listWidget = (blog) ? m_blogListWidget : m_projectListWidget;
+	auto item = listWidget->item(index);
 	if (item) {
 		item->setData(IconRole, pixmap);
 	}

--- a/src/sketch/welcomeview.cpp
+++ b/src/sketch/welcomeview.cpp
@@ -718,10 +718,10 @@ void WelcomeView::clickRecent(const QString & url) {
 }
 
 void WelcomeView::gotBlogSnippet(QNetworkReply * networkReply) {
-	auto blog = networkReply->url().toString().contains("blog");
-	auto prefix = networkReply->url().scheme() + "://" + networkReply->url().authority();
-	auto manager = networkReply->manager();
-	auto responseCode = networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+	bool blog = networkReply->url().toString().contains("blog");
+	QString prefix = networkReply->url().scheme() + "://" + networkReply->url().authority();
+	QNetworkAccessManager * manager = networkReply->manager();
+	int responseCode = networkReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
 	auto goodBlog = false;
 	QDomDocument doc;
@@ -937,7 +937,7 @@ void WelcomeView::gotBlogImage(QNetworkReply * networkReply) {
 		QByteArray data(networkReply->readAll());
 		QPixmap pixmap;
 		if (pixmap.loadFromData(data)) {
-			auto scaled = pixmap.scaled(QSize(ImageSpace, ImageSpace), Qt::KeepAspectRatio);
+			QPixmap scaled = pixmap.scaled(QSize(ImageSpace, ImageSpace), Qt::KeepAspectRatio);
 			setBlogItemImage(scaled, index, blog);
 			foreach (QWidget *widget, QApplication::topLevelWidgets()) {
 				auto other = widget->findChild<WelcomeView *>();

--- a/src/sketch/welcomeview.h
+++ b/src/sketch/welcomeview.h
@@ -109,7 +109,7 @@ class WelcomeView : public QFrame
 
 public:
 	WelcomeView(QWidget * parent = 0);
-	~WelcomeView();
+	~WelcomeView() = default;
 
 	void showEvent(QShowEvent * event);
 	void dragEnterEvent(QDragEnterEvent *event);
@@ -147,20 +147,20 @@ protected slots:
 	void nextTip();
 
 protected:
-	BlogListWidget * m_blogListWidget;
-	BlogListWidget * m_projectListWidget;
-	QWidget * m_blogUberFrame;
-	QWidget * m_projectsUberFrame;
-	QLabel * m_tip;
-	QListWidget * m_recentListWidget;
-	QWidget * m_fabUberFrame;
-	QWidget * m_shopUberFrame;
-    QWidget * m_donateUberFrame;
-	QLabel * m_projectsLabel;
-	QLabel * m_blogLabel;
-	QLabel * m_fabLabel;
-	QLabel * m_shopLabel;
-    QLabel * m_donateLabel;
+	BlogListWidget * m_blogListWidget = nullptr;
+	BlogListWidget * m_projectListWidget = nullptr;
+	QWidget * m_blogUberFrame = nullptr;
+	QWidget * m_projectsUberFrame = nullptr;
+	QLabel * m_tip = nullptr;
+	QListWidget * m_recentListWidget = nullptr;
+	QWidget * m_fabUberFrame = nullptr;
+	QWidget * m_shopUberFrame = nullptr;
+    QWidget * m_donateUberFrame = nullptr;
+	QLabel * m_projectsLabel = nullptr;
+	QLabel * m_blogLabel = nullptr;
+	QLabel * m_fabLabel = nullptr;
+	QLabel * m_shopLabel = nullptr;
+    QLabel * m_donateLabel = nullptr;
 
 	static QString m_activeHeaderLabelColor;
 	static QString m_inactiveHeaderLabelColor;

--- a/src/svg/gedaelement2svg.h
+++ b/src/svg/gedaelement2svg.h
@@ -45,7 +45,7 @@ protected:
 	QString makeCopper(QStringList ids, QHash<QString, QString> &, const QString & filename);
 
 protected:
-	int m_nonConnectorNumber;
+	int m_nonConnectorNumber = 0;
 
 };
 

--- a/src/svg/svg2gerber.cpp
+++ b/src/svg/svg2gerber.cpp
@@ -25,7 +25,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QSet>
 #include <qmath.h>
 
-static const double MaskClearance = 0.005;  // 5 mils clearance
+constexpr double MaskClearance = 0.005;  // 5 mils clearance
 
 bool fillNotStroke(QDomElement & element, SVG2gerber::ForWhy forWhy) {
 	if (forWhy == SVG2gerber::ForOutline) return false;
@@ -46,10 +46,6 @@ bool fillNotStroke(QDomElement & element, SVG2gerber::ForWhy forWhy) {
 }
 
 //TODO: currently only supports one board per sketch (i.e. multiple board outlines will mess you up)
-
-SVG2gerber::SVG2gerber()
-{
-}
 
 int SVG2gerber::convert(const QString & svgStr, bool doubleSided, const QString & mainLayerName, ForWhy forWhy, QSizeF boardSize)
 {

--- a/src/svg/svg2gerber.h
+++ b/src/svg/svg2gerber.h
@@ -32,7 +32,7 @@ class SVG2gerber : public QObject
 	Q_OBJECT
 
 public:
-	SVG2gerber();
+	SVG2gerber() = default;
 
 public:
 	enum ForWhy {
@@ -56,8 +56,8 @@ protected:
 	QMultiHash<QString, QString> m_platedApertures;
 	QMultiHash<QString, QString> m_holeApertures;
 
-	double m_pathstart_x;
-	double m_pathstart_y;
+	double m_pathstart_x = 0.0;
+	double m_pathstart_y = 0.0;
 
 protected:
 

--- a/src/svg/x2svg.cpp
+++ b/src/svg/x2svg.cpp
@@ -32,13 +32,12 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QDateTime>
 #include <qmath.h>
 
-static const int MAX_INT = std::numeric_limits<int>::max();
-static const int MIN_INT = std::numeric_limits<int>::min();
+constexpr auto MAX_INT = std::numeric_limits<int>::max();
+constexpr auto MIN_INT = std::numeric_limits<int>::min();
 
-X2Svg::X2Svg() {
-	m_attribute = "<fz:attr name='%1'>%2</fz:attr>\n";
-	m_comment = "<fz:comment>%2</fz:comment>\n";
-
+X2Svg::X2Svg() : m_maxX(MIN_INT), m_maxY(MIN_INT), m_minX(MAX_INT), m_minY(MAX_INT), 
+    m_attribute("<fz:attr name='%1'>%2</fz:attr>\n"),
+    m_comment ("<fz:comment>%2</fz:comment>\n") {
 }
 
 void X2Svg::initLimits() {

--- a/src/utils/bezier.cpp
+++ b/src/utils/bezier.cpp
@@ -122,22 +122,11 @@ double Cvalues[25][24] = {
 
 /////////////////////////////////////////////
 
-Bezier::Bezier(QPointF cp0, QPointF cp1)
+Bezier::Bezier(QPointF cp0, QPointF cp1) : m_cp0(cp0), m_cp1(cp1), m_isEmpty(false)
 {
-	m_cp0 = cp0;
-	m_cp1 = cp1;
-	m_isEmpty = false;
 }
 
-Bezier::Bezier()
-{
-	m_isEmpty = true;
-}
-
-bool Bezier::isEmpty() const
-{
-	return m_isEmpty;
-}
+Bezier::Bezier() : m_isEmpty(true) { }
 
 void Bezier::clear()
 {
@@ -438,9 +427,4 @@ Bezier Bezier::join(const Bezier * other) const
 	}
 
 	return bezier;
-}
-
-bool Bezier::drag0()
-{
-	return m_drag_cp0;
 }

--- a/src/utils/bezier.h
+++ b/src/utils/bezier.h
@@ -40,7 +40,7 @@ public:
 	void set_cp0(QPointF);
 	void set_cp1(QPointF);
 	void set_endpoints(QPointF, QPointF);
-	bool isEmpty() const;
+	constexpr bool isEmpty() const noexcept { return m_isEmpty; }
 	void clear();
 	void write(QXmlStreamWriter &);
 	bool operator==(const Bezier &) const;
@@ -58,7 +58,7 @@ public:
 	void translateToZero();
 	void translate(QPointF);
 	Bezier join(const Bezier * other) const;
-	bool drag0();
+	constexpr bool drag0() const noexcept { return m_drag_cp0; }
 
 protected:
 	double cubicF(double t) const;
@@ -73,7 +73,7 @@ protected:
 	QPointF m_cp0;
 	QPointF m_cp1;
 	bool m_isEmpty;
-	bool m_drag_cp0;
+	bool m_drag_cp0 = false;
 };
 
 #endif

--- a/src/utils/fileprogressdialog.cpp
+++ b/src/utils/fileprogressdialog.cpp
@@ -37,11 +37,10 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 /////////////////////////////////////
 
-FileProgressDialog::FileProgressDialog(const QString & title, int initialMaximum, QWidget * parent) : QDialog(parent)
+FileProgressDialog::FileProgressDialog(const QString & title, int initialMaximum, QWidget * parent) : QDialog(parent),
+    m_incValueMod(2)
 {
-	m_incValueMod = 2;
-
-	QSplashScreen *splash = NULL;
+	QSplashScreen *splash = nullptr;
 	foreach (QWidget *widget, QApplication::topLevelWidgets()) {
 		splash = qobject_cast<QSplashScreen *>(widget);
 		if (splash) {
@@ -50,7 +49,7 @@ FileProgressDialog::FileProgressDialog(const QString & title, int initialMaximum
 	}
 
 	init(title, initialMaximum);
-	setModal(splash == NULL);			// OS X Lion doesn't seem to like modal dialogs during splash time
+	setModal(splash == nullptr);			// OS X Lion doesn't seem to like modal dialogs during splash time
 
 	show();
 	if (splash) {

--- a/src/utils/fileprogressdialog.h
+++ b/src/utils/fileprogressdialog.h
@@ -33,7 +33,7 @@ class FileProgressDialog : public QDialog
 	Q_OBJECT
 
 public:
-	FileProgressDialog(QWidget *parent = 0);
+	FileProgressDialog(QWidget *parent = nullptr);
 	FileProgressDialog(const QString & title, int initialMaximum, QWidget *parent);
 	~FileProgressDialog();
 
@@ -71,16 +71,16 @@ protected:
 	void init(const QString & title, int initialMaximum);
 
 protected:
-	QProgressBar * m_progressBar;
-	QLabel * m_message;
+	QProgressBar * m_progressBar = nullptr;
+	QLabel * m_message = nullptr;
 
-	int m_binLoadingCount;
-	int m_binLoadingIndex;
-	int m_binLoadingStart;
-	int m_binLoadingChunk;
-	int m_incValueMod;
-	double m_binLoadingInc;
-	double m_binLoadingValue;
+	int m_binLoadingCount = 0;
+	int m_binLoadingIndex = 0;
+	int m_binLoadingStart = 0;
+	int m_binLoadingChunk = 0;
+	int m_incValueMod = 0;
+	double m_binLoadingInc = 0.0;
+	double m_binLoadingValue = 0.0;
 	QTimer m_timer;
 };
 

--- a/src/utils/s2s.cpp
+++ b/src/utils/s2s.cpp
@@ -214,10 +214,10 @@ QString makeTerminal(const ConnectorLocation * connectorLocation, double x, doub
 ///////////////////////////////////////////////////////
 
 
-S2S::S2S(bool fzpzStyle) : QObject()
+S2S::S2S(bool fzpzStyle) : QObject(),
+	m_image(new QImage(50 * ImageFactor, 5 * ImageFactor, QImage::Format_Mono)),
+    m_fzpzStyle(fzpzStyle)
 {
-	m_image = new QImage(50 * ImageFactor, 5 * ImageFactor, QImage::Format_Mono);
-	m_fzpzStyle = fzpzStyle;
 }
 
 void S2S::message(const QString & msg) {

--- a/src/utils/s2s.h
+++ b/src/utils/s2s.h
@@ -55,15 +55,15 @@ protected:
 protected:
 	bool m_fzpzStyle;
 	QString m_andPath;
-	double m_minLeft;
-	double m_minTop;
-	double m_maxRight;
-	double m_maxBottom;
+	double m_minLeft = 0.0;
+	double m_minTop = 0.0;
+	double m_maxRight = 0.0;
+	double m_maxBottom = 0.0;
 	QList<ConnectorLocation *> m_lefts;
 	QList<ConnectorLocation *> m_tops;
 	QList<ConnectorLocation *> m_rights;
 	QList<ConnectorLocation *> m_bottoms;
-	double m_fudge;
+	double m_fudge = 0.0;
 	QDir m_oldSvgDir;
 	QDir m_newSvgDir;
 	QImage * m_image;

--- a/src/version/updatedialog.h
+++ b/src/version/updatedialog.h
@@ -67,17 +67,17 @@ protected:
 	void closeEvent(QCloseEvent *);
 
 protected:
-	class VersionChecker * m_versionChecker;
-	bool m_atUserRequest;
+	class VersionChecker * m_versionChecker = nullptr;
+	bool m_atUserRequest = false;
 	QString m_repoPath;
 	QString m_shaFromDataBase;
 	QString m_remoteSha;
-	QLabel * m_feedbackLabel;
-	QDialogButtonBox * m_buttonBox;
-	QProgressBar * m_progressBar;
+	QLabel * m_feedbackLabel = nullptr;
+	QDialogButtonBox * m_buttonBox = nullptr;
+	QProgressBar * m_progressBar = nullptr;
 	PartsCheckerResult m_partsCheckerResult;
-	bool m_doQuit;
-	bool m_doClose;
+	bool m_doQuit = false;
+	bool m_doClose = false;
 };
 
 

--- a/src/viewgeometry.cpp
+++ b/src/viewgeometry.cpp
@@ -22,11 +22,8 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "utils/graphicsutils.h"
 
 ViewGeometry::ViewGeometry(  ) 
-	: m_z(-1),
-	m_loc(-1, -1),
+	: m_loc(-1, -1),
 	m_line(-1, -1, -1, -1),
-	m_rect(),
-	m_selected(false),
 	m_wireFlags(WireFlag::NoFlag)
 {
 }
@@ -36,7 +33,6 @@ ViewGeometry::ViewGeometry(const ViewGeometry& that)
 	m_loc(that.m_loc),
 	m_line(that.m_line),
 	m_rect(that.m_rect),
-	m_selected(false),
 	m_wireFlags(that.m_wireFlags),
 	m_transform(that.m_transform) { }
 

--- a/src/viewgeometry.h
+++ b/src/viewgeometry.h
@@ -61,7 +61,7 @@ public:
 	void setLine(QLineF);
 	constexpr QLineF line() const noexcept { return m_line; }
 	void offset(double x, double y);
-	bool selected() const noexcept { return m_selected; }
+	constexpr bool selected() const noexcept { return m_selected; }
 	void setSelected(bool);
 	constexpr QRectF rect() const noexcept { return m_rect; }
 	void setRect(double x, double y, double width, double height);
@@ -89,11 +89,11 @@ public:
 	ViewGeometry::WireFlags wireFlags() const;
 
 protected:
-	double m_z;
+	double m_z = -1;
 	QPointF m_loc;
 	QLineF m_line;
 	QRectF m_rect;
-	bool m_selected;
+	bool m_selected = false;
 	WireFlags m_wireFlags;
 	QTransform m_transform;
 };


### PR DESCRIPTION
This is a continuation of my previous pull request. I have tended towards NSDMI in this pull request as it is more readable and easier to maintain as new constructors are added.

There is also a single use of std::unique_ptr in searchlineedit.cpp as it makes sense to use as a starting point. I am aware that Qt has a unique_ptr implementation which I believe is just an alias to std::unique_ptr these days. Over time, I want to replace raw pointers with unique and shared pointers as it makes memory management exponentially cleaner. We did the conversion over time at work and the program got smaller and easier to debug (this is a future plan so just view this single instance of what this will look like). 

Let me know what you think. 