### PR TITLE
replace != NULL/nullptr checks with implicit boolean conversion operations

### DIFF
--- a/src/autoroute/autorouter.cpp
+++ b/src/autoroute/autorouter.cpp
@@ -292,14 +292,14 @@ void Autorouter::clearTracesAndJumpers() {
 	foreach (QGraphicsItem * item, (m_board == NULL) ? m_sketchWidget->scene()->items() : m_sketchWidget->scene()->collidingItems(m_board)) {
 		if (m_pcbType) {
 			auto jumperItem = dynamic_cast<JumperItem *>(item);
-			if (jumperItem != NULL) {
+			if (jumperItem) {
 				if (jumperItem->getAutoroutable()) {
 					toDelete.append(jumperItem);
 				}
 				continue;
 			}
 			auto via = dynamic_cast<Via *>(item);
-			if (via != NULL) {
+			if (via) {
 				if (via->getAutoroutable()) {
 					toDelete.append(via);
 				}
@@ -308,7 +308,7 @@ void Autorouter::clearTracesAndJumpers() {
 		}
 		else {
 			auto netLabel = dynamic_cast<SymbolPaletteItem *>(item);
-			if (netLabel != NULL && netLabel->isOnlyNetLabel()) {
+			if (netLabel && netLabel->isOnlyNetLabel()) {
 				if (netLabel->getAutoroutable()) {
 					toDelete.append(netLabel);
 				}
@@ -317,7 +317,7 @@ void Autorouter::clearTracesAndJumpers() {
 		}
 
 		auto traceWire = dynamic_cast<TraceWire *>(item);
-		if (traceWire != NULL) {
+		if (traceWire) {
 			if (traceWire->isTraceType(m_sketchWidget->getTraceFlag()) && traceWire->getAutoroutable()) {
 				toDelete.append(traceWire);
 			}

--- a/src/autoroute/cmrouter/cmrouter.cpp
+++ b/src/autoroute/cmrouter/cmrouter.cpp
@@ -589,7 +589,7 @@ bool CMRouter::overlapsOnly(QGraphicsItem *, QList<Tile *> & alreadyTiled)
 	bool doClip = false;
 	for (int i = alreadyTiled.count() - 1;  i >= 0; i--) {
 		Tile * intersectingTile = alreadyTiled.at(i);
-		if (dynamic_cast<Wire *>(TiGetBody(intersectingTile)) != NULL || dynamic_cast<ConnectorItem *>(TiGetBody(intersectingTile)) != NULL) {
+		if (dynamic_cast<Wire *>(TiGetBody(intersectingTile)) || dynamic_cast<ConnectorItem *>(TiGetBody(intersectingTile))) {
 			doClip = true;
 			continue;
 		}
@@ -616,7 +616,7 @@ bool CMRouter::allowEquipotentialOverlaps(QGraphicsItem * item, QList<Tile *> & 
 	foreach (Tile * intersectingTile, alreadyTiled) {
 		QGraphicsItem * bodyItem = TiGetBody(intersectingTile);
 		ConnectorItem * ci = dynamic_cast<ConnectorItem *>(bodyItem);
-		if (ci != NULL) {
+		if (ci) {
 			if (!collected) {
 				ConnectorItem::collectEqualPotential(equipotential, false, ViewGeometry::NoFlag);
 				collected = true;

--- a/src/autoroute/eventeater.cpp
+++ b/src/autoroute/eventeater.cpp
@@ -50,7 +50,7 @@ bool EventEater::eventFilter(QObject *obj, QEvent *event)
 	{
 		bool gotOne = false;
 		foreach (QWidget * widget, m_allowedWidgets) {
-			for (QObject * parentObj = obj; parentObj != NULL; parentObj = parentObj->parent()) {
+			for (QObject * parentObj = obj; parentObj; parentObj = parentObj->parent()) {
 				if (parentObj == widget) {
 					gotOne = true;
 					break;

--- a/src/autoroute/panelizer.cpp
+++ b/src/autoroute/panelizer.cpp
@@ -890,7 +890,7 @@ bool Panelizer::openWindows(QDomElement & boardElement, QHash<QString, QString> 
 			/*
 			QSizeF boardSize = boardItem->size();
 			ResizableBoard * resizableBoard = qobject_cast<ResizableBoard *>(boardItem->layerKinChief());
-			if (resizableBoard != NULL) {
+			if (resizableBoard) {
 			    panelItem->boardSizeInches = resizableBoard->getSizeMM() / 25.4;
 			    DebugDialog::debug(QString("board size inches a %1, %2, %3")
 				    .arg(panelItem->boardSizeInches.width())
@@ -1743,7 +1743,7 @@ int Panelizer::checkDonuts(MainWindow * mainWindow, bool displayMessage) {
 		if (connectorItem == NULL) continue;
 		if (!connectorItem->attachedTo()->isEverVisible()) continue;
 
-		if (connectorItem->isPath() && connectorItem->getCrossLayerConnectorItem() != NULL) {  // && connectorItem->radius() == 0
+		if (connectorItem->isPath() && connectorItem->getCrossLayerConnectorItem()) {  // && connectorItem->radius() == 0
 			connectorItem->debugInfo("possible donut");
 			connectorItem->attachedTo()->debugInfo("\t");
 			donuts << connectorItem;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -116,7 +116,7 @@ const BaseCommand * BaseCommand::subCommand(int ix) const {
 void BaseCommand::addSubCommand(BaseCommand * subCommand) {
 	m_commands.append(subCommand);
 #ifndef QT_NO_DEBUG
-	if (m_sketchWidget != NULL) {
+	if (m_sketchWidget) {
 		m_sketchWidget->undoStack()->writeUndo(subCommand, 4, this);
 	}
 #endif
@@ -797,15 +797,15 @@ ChangeLegBendpointCommand::ChangeLegBendpointCommand(SketchWidget* sketchWidget,
 {
 	m_fromID = fromID;
 	m_bezier0 = m_bezier1 = m_bezier2 = NULL;
-	if (bezier0 != NULL) {
+	if (bezier0) {
 		m_bezier0 = new Bezier;
 		m_bezier0->copy(bezier0);
 	}
-	if (bezier1 != NULL) {
+	if (bezier1) {
 		m_bezier1 = new Bezier;
 		m_bezier1->copy(bezier1);
 	}
-	if (bezier2 != NULL) {
+	if (bezier2) {
 		m_bezier2 = new Bezier;
 		m_bezier2->copy(bezier2);
 	}

--- a/src/connectors/connector.cpp
+++ b/src/connectors/connector.cpp
@@ -75,7 +75,7 @@ const QString & Connector::connectorNameFromType(ConnectorType type) {
 }
 
 Connector::ConnectorType Connector::connectorType() const {
-	if (m_connectorShared != NULL) {
+	if (m_connectorShared) {
 		return m_connectorShared->connectorType();
 	}
 
@@ -240,7 +240,7 @@ void Connector::setBus(Bus * bus) {
 
 void Connector::unprocess(ViewLayer::ViewID viewID, ViewLayer::ViewLayerID viewLayerID) {
 	SvgIdLayer * svgIdLayer = m_connectorShared->fullPinInfo(viewID, viewLayerID);
-	if (svgIdLayer != NULL) {
+	if (svgIdLayer) {
 		svgIdLayer->unprocess();
 	}
 }
@@ -252,7 +252,7 @@ SvgIdLayer * Connector::fullPinInfo(ViewLayer::ViewID viewID, ViewLayer::ViewLay
 }
 
 long Connector::modelIndex() {
-	if (m_modelPart != NULL) return m_modelPart->modelIndex();
+	if (m_modelPart) return m_modelPart->modelIndex();
 
 	DebugDialog::debug(QString("saving bus connector item: how is this supposed to work?"));
 	return 0;
@@ -278,7 +278,7 @@ const QString & Connector::legID(ViewLayer::ViewID viewID, ViewLayer::ViewLayerI
 }
 
 void Connector::setConnectorLocalName(const QString & name) {
-	if (m_connectorShared != NULL && name.compare(m_connectorShared->sharedName()) == 0) {
+	if (m_connectorShared && name.compare(m_connectorShared->sharedName()) == 0) {
 		m_connectorLocalName.clear();
 		return;
 	}

--- a/src/debugdialog.cpp
+++ b/src/debugdialog.cpp
@@ -155,7 +155,7 @@ void DebugDialog::debug(QString message, DebugLevel debugLevel, QObject * ancest
 }
 
 void DebugDialog::hideDebug() {
-	if (singleton != NULL) {
+	if (singleton) {
 		singleton->hide();
 	}
 }
@@ -169,7 +169,7 @@ void DebugDialog::showDebug() {
 }
 
 void DebugDialog::closeDebug() {
-	if (singleton != NULL) {
+	if (singleton) {
 		singleton->close();
 	}
 }

--- a/src/fapplication.cpp
+++ b/src/fapplication.cpp
@@ -1488,12 +1488,12 @@ void FApplication::updateActivation() {
 	//DebugDialog::debug(QString("last:%1, new:%2").arg((long) prior, 0, 16).arg((long) m_lastTopmostWindow.data(), 0, 16));
 
 	MainWindow * priorMainWindow = qobject_cast<MainWindow *>(prior);
-	if (priorMainWindow != NULL) {
+	if (priorMainWindow) {
 		priorMainWindow->saveDocks();
 	}
 
 	MainWindow * lastTopmostMainWindow = qobject_cast<MainWindow *>(m_lastTopmostWindow);
-	if (lastTopmostMainWindow != NULL) {
+	if (lastTopmostMainWindow) {
 		lastTopmostMainWindow->restoreDocks();
 		//DebugDialog::debug("restoring active window");
 	}

--- a/src/fsvgrenderer.cpp
+++ b/src/fsvgrenderer.cpp
@@ -673,7 +673,7 @@ bool FSvgRenderer::setUpConnector(SvgIdLayer * svgIdLayer, bool ignoreTerminalPo
 	QMatrix elementMatrix = this->matrixForElement(connectorID);
 	QRectF r1 = elementMatrix.mapRect(bounds);
 
-	if (connectorInfo != NULL) {
+	if (connectorInfo) {
 		if (connectorInfo->gotCircle) {
 			QLineF l(0,0,connectorInfo->radius, 0);
 			QLineF lm = elementMatrix.map(l);

--- a/src/help/aboutbox.cpp
+++ b/src/help/aboutbox.cpp
@@ -235,7 +235,7 @@ void AboutBox::initBuildType(const QString & buildType) {
 
 void AboutBox::hideAbout() {
 	//DebugDialog::debug("the AboutBox gets a hide action triggered");
-	if (Singleton != NULL) {
+	if (Singleton) {
 		Singleton->hide();
 	}
 }
@@ -255,7 +255,7 @@ void AboutBox::showAbout() {
 void AboutBox::closeAbout() {
 	//DebugDialog::debug("the AboutBox gets a close action triggered");
 	// Note: not every close triggers this function. we better listen to closeEvent
-	if (Singleton != NULL) {
+	if (Singleton) {
 		Singleton->close();
 	}
 }

--- a/src/help/tipsandtricks.cpp
+++ b/src/help/tipsandtricks.cpp
@@ -182,7 +182,7 @@ TipsAndTricks::~TipsAndTricks()
 }
 
 void TipsAndTricks::hideTipsAndTricks() {
-	if (Singleton != NULL) {
+	if (Singleton) {
 		Singleton->hide();
 	}
 }

--- a/src/infoview/htmlinfoview.cpp
+++ b/src/infoview/htmlinfoview.cpp
@@ -633,7 +633,7 @@ void HtmlInfoView::setUpTitle(ItemBase * itemBase)
 
 	m_lastTitleItemBase = itemBase;
 	bool titleEnabled = true;
-	if (itemBase != NULL) {
+	if (itemBase) {
 		QString title = itemBase->getInspectorTitle();
 		if (title.isEmpty()) {
 			// assumes a part with an empty title only comes from the parts bin palette
@@ -680,9 +680,9 @@ void HtmlInfoView::setUpIcons(ItemBase * itemBase, bool swappingEnabled) {
 	m_icon2->setPixmap(*use2);
 	m_icon3->setPixmap(*use3);
 
-	if (pixmap1 != NULL) delete pixmap1;
-	if (pixmap2 != NULL) delete pixmap2;
-	if (pixmap3 != NULL) delete pixmap3;
+	if (pixmap1) delete pixmap1;
+	if (pixmap2) delete pixmap2;
+	if (pixmap3) delete pixmap3;
 }
 
 void HtmlInfoView::addTags(ModelPart * modelPart) {
@@ -798,7 +798,7 @@ void HtmlInfoView::displayProps(ModelPart * modelPart, ItemBase * itemBase, bool
 		QWidget * resultWidget = oldPlugin;
 		bool result = false;
 		bool hide = false;
-		if (itemBase != NULL) {
+		if (itemBase) {
 			result = itemBase->collectExtraInfo(propThing->m_name->parentWidget(), family, key, value, swappingEnabled, resultKey, resultValue, resultWidget, hide);
 		}
 
@@ -891,7 +891,7 @@ QHash<QString, QString> HtmlInfoView::getPartProperties(ModelPart * modelPart, I
 	QHash<QString, QString> properties;
 	QString family;
 	QString partNumber;
-	if (modelPart != NULL && itemBase != NULL) {
+	if (modelPart && itemBase) {
 		properties = itemBase->prepareProps(modelPart, wantDebug, keys);
 	}
 
@@ -939,7 +939,7 @@ void HtmlInfoView::showLayers(bool show, ItemBase * itemBase, const QString & fa
 	QString resultKey, resultValue;
 	bool hide;
 	bool result = itemBase->collectExtraInfo(m_layerLabel->parentWidget(), family, "layer", value, swappingEnabled, resultKey, resultValue, m_layerWidget, hide);
-	if (result && m_layerWidget != NULL) {
+	if (result && m_layerWidget) {
 		m_layerLayout->addWidget(m_layerWidget);
 	}
 }
@@ -1185,13 +1185,13 @@ void HtmlInfoView::xyEntry() {
 	DebugDialog::debug(QString("xedit %1 %2 %3").arg(m_xEdit->text()).arg(m_yEdit->text()).arg(sender() == m_xEdit));
 	double x = TextUtils::convertToInches(m_xEdit->text() + m_unitsLabel->text());
 	double y = TextUtils::convertToInches(m_yEdit->text() + m_unitsLabel->text());
-	if (infoGraphicsView != NULL && m_lastItemBase != NULL) {
+	if (infoGraphicsView && m_lastItemBase) {
 		infoGraphicsView->moveItem(m_lastItemBase, x * 90, y * 90);
 	}
 }
 
 void HtmlInfoView::rotEntry() {
-	if (m_lastItemBase != NULL) {
+	if (m_lastItemBase) {
 		InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(m_lastItemBase);
 		if (infoGraphicsView == NULL) return;
 

--- a/src/items/capacitor.cpp
+++ b/src/items/capacitor.cpp
@@ -142,7 +142,7 @@ void Capacitor::propertyEntry(const QString & text) {
 			}
 
 			InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-			if (infoGraphicsView != NULL) {
+			if (infoGraphicsView) {
 				infoGraphicsView->setProp(this, propertyDef->name, "", m_propertyDefs.value(propertyDef, ""), utext, true);
 			}
 			break;
@@ -171,7 +171,7 @@ void Capacitor::simplePropertyEntry(const QString & text) {
 	foreach (PropertyDef * propertyDef, m_comboBoxes.keys()) {
 		if (m_comboBoxes.value(propertyDef) == focusOutComboBox) {
 			InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-			if (infoGraphicsView != NULL) {
+			if (infoGraphicsView) {
 				infoGraphicsView->setProp(this, propertyDef->name, "", m_propertyDefs.value(propertyDef, ""), text, true);
 			}
 			break;

--- a/src/items/hole.cpp
+++ b/src/items/hole.cpp
@@ -110,7 +110,7 @@ void Hole::setBoth(const QString & holeDiameter, const QString & ringThickness) 
 		if (svgIdLayer == NULL) continue;
 
 		setBothNonConnectors(this, svgIdLayer);
-		if (otherLayer != NULL) {
+		if (otherLayer) {
 			setBothNonConnectors(otherLayer, svgIdLayer);
 		}
 
@@ -277,7 +277,7 @@ bool Hole::collectExtraInfo(QWidget * parent, const QString & family, const QStr
 
 void Hole::changeHoleSize(const QString & newSize) {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		QRectF holeRect = getRect(holeSize());
 		QRectF newHoleRect = getRect(newSize);
 		infoGraphicsView->setHoleSize(this, "hole size", tr("hole size"), holeSize(), newSize, holeRect, newHoleRect, true);

--- a/src/items/jumperitem.cpp
+++ b/src/items/jumperitem.cpp
@@ -202,7 +202,7 @@ bool JumperItem::mousePressEventK(PaletteItemBase * originalItem, QGraphicsScene
 {
 	m_originalClickItem = originalItem;
 	mousePressEvent(event);
-	return (m_dragItem != NULL);
+	return (m_dragItem);
 }
 
 void JumperItem::mouseMoveEventK(PaletteItemBase * originalItem, QGraphicsSceneMouseEvent *event)
@@ -222,7 +222,7 @@ void JumperItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 	PaletteItemBase * originalItem = m_originalClickItem;
 	m_originalClickItem = NULL;
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL && infographics->spaceBarIsPressed()) {
+	if (infographics && infographics->spaceBarIsPressed()) {
 		event->ignore();
 		return;
 	}
@@ -417,11 +417,11 @@ void JumperItem::resizeAux(double r0x, double r0y, double r1x, double r1y) {
 	m_connector0->setRect(r0);
 	m_connector1->setRect(r1);
 	ConnectorItem * cc0 = m_connector0->getCrossLayerConnectorItem();
-	if (cc0 != NULL) {
+	if (cc0) {
 		cc0->setRect(r0);
 	}
 	ConnectorItem * cc1 = m_connector1->getCrossLayerConnectorItem();
-	if (cc1 != NULL) {
+	if (cc1) {
 		cc1->setRect(r1);
 	}
 	resize();
@@ -479,7 +479,7 @@ bool JumperItem::hasCustomSVG() {
 }
 
 bool JumperItem::inDrag() {
-	return m_dragItem != NULL;
+	return m_dragItem;
 }
 
 void JumperItem::loadLayerKin( const LayerHash & viewLayers, ViewLayer::ViewLayerPlacement viewLayerPlacement) {
@@ -497,11 +497,11 @@ void JumperItem::addedToScene(bool temporary) {
 	if (m_connector1 == NULL) return;
 
 	ConnectorItem * cc0 = m_connector0->getCrossLayerConnectorItem();
-	if (cc0 != NULL) {
+	if (cc0) {
 		cc0->setRect(m_connector0->rect());
 	}
 	ConnectorItem * cc1 = m_connector1->getCrossLayerConnectorItem();
-	if (cc1 != NULL) {
+	if (cc1) {
 		cc1->setRect(m_connector1->rect());
 	}
 

--- a/src/items/layerkinpaletteitem.cpp
+++ b/src/items/layerkinpaletteitem.cpp
@@ -49,7 +49,7 @@ void LayerKinPaletteItem::initLKPI(LayerAttributes & layerAttributes, const Laye
 QVariant LayerKinPaletteItem::itemChange(GraphicsItemChange change, const QVariant &value)
 {
 	//DebugDialog::debug(QString("lk item change %1 %2").arg(this->id()).arg(change));
-	if (m_layerKinChief != NULL) {
+	if (m_layerKinChief) {
 		if (change == ItemSelectedChange) {
 			bool selected = value.toBool();
 			if (m_blockItemSelectedChange && m_blockItemSelectedValue == selected) {

--- a/src/items/logoitem.cpp
+++ b/src/items/logoitem.cpp
@@ -280,7 +280,7 @@ bool LogoItem::checkImage(const QString & filename) {
 void LogoItem::prepLoadImageAux(const QString & fileName, bool addName)
 {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->loadLogoImage(this, prop("shape"), m_aspectRatio, prop("lastfilename"), fileName, addName);
 	}
 }
@@ -647,7 +647,7 @@ void LogoItem::logoEntryAux(const QString & text)
 	m_inLogoEntry = QTime::currentTime().addSecs(1);
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "logo", tr("text"), this->logo(), text, true);
 	}
 }
@@ -728,7 +728,7 @@ void LogoItem::widthEntry() {
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->resizeBoard(w, h, true);
 	}
 }
@@ -754,7 +754,7 @@ void LogoItem::setHeight(double h)
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->resizeBoard(w, h, true);
 	}
 }
@@ -783,7 +783,7 @@ QString LogoItem::layerName()
 double LogoItem::minWidth() {
 	double zoom = 1;
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		zoom = infoGraphicsView->currentZoom() / 100;
 		if (zoom == 0) zoom = 1;
 	}
@@ -794,7 +794,7 @@ double LogoItem::minWidth() {
 double LogoItem::minHeight() {
 	double zoom = 1;
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		zoom = infoGraphicsView->currentZoom() / 100;
 		if (zoom == 0) zoom = 1;
 	}
@@ -957,7 +957,7 @@ void BreadboardLogoItem::changeTextColor() {
 	if (newColor.name().compare(m_color, Qt::CaseInsensitive) == 0) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "color", tr("color"), m_color, newColor.name(), true);
 	}
 }

--- a/src/items/mysterypart.cpp
+++ b/src/items/mysterypart.cpp
@@ -273,7 +273,7 @@ void MysteryPart::chipLabelEntry() {
 	if (edit->text().compare(this->chipLabel()) == 0) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "chip label", tr("chip label"), this->chipLabel(), edit->text(), true);
 	}
 }

--- a/src/items/note.cpp
+++ b/src/items/note.cpp
@@ -127,7 +127,7 @@ NoteGraphicsTextItem::NoteGraphicsTextItem(QGraphicsItem * parent) : QGraphicsTe
 
 void NoteGraphicsTextItem::focusInEvent(QFocusEvent * event) {
 	InfoGraphicsView * igv = InfoGraphicsView::getInfoGraphicsView(this);
-	if (igv != NULL) {
+	if (igv) {
 		igv->setNoteFocus(this, true);
 	}
 	QApplication::instance()->installEventFilter((Note *) this->parentItem());
@@ -137,7 +137,7 @@ void NoteGraphicsTextItem::focusInEvent(QFocusEvent * event) {
 
 void NoteGraphicsTextItem::focusOutEvent(QFocusEvent * event) {
 	InfoGraphicsView * igv = InfoGraphicsView::getInfoGraphicsView(this);
-	if (igv != NULL) {
+	if (igv) {
 		igv->setNoteFocus(this, false);
 	}
 	QApplication::instance()->removeEventFilter((Note *) this->parentItem());
@@ -351,7 +351,7 @@ void Note::positionGrip() {
 
 void Note::mousePressEvent(QGraphicsSceneMouseEvent * event) {
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL && infographics->spaceBarIsPressed()) {
+	if (infographics && infographics->spaceBarIsPressed()) {
 		m_spaceBarWasPressed = true;
 		event->ignore();
 		return;
@@ -437,7 +437,7 @@ void Note::contentsChangedSlot() {
 	}
 
 	InfoGraphicsView *infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		QString oldText;
 		if (m_modelPart) {
 			oldText = m_modelPart->instanceText();
@@ -725,7 +725,7 @@ void Note::handleMouseReleaseSlot(QGraphicsSceneMouseEvent * event, ResizeHandle
 
 	m_inResize = NULL;
 	InfoGraphicsView *infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->noteSizeChanged(this, m_viewGeometry.rect().size(), m_rect.size());
 	}
 }

--- a/src/items/pad.cpp
+++ b/src/items/pad.cpp
@@ -237,7 +237,7 @@ bool Pad::collectExtraInfo(QWidget * parent, const QString & family, const QStri
 
 	bool result = PaletteItem::collectExtraInfo(parent, family, prop, value, swappingEnabled, returnProp, returnValue, returnWidget, hide);
 
-	if (prop.compare("layer") == 0 && returnWidget != NULL) {
+	if (prop.compare("layer") == 0 && returnWidget) {
 		bool disabled = true;
 		InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
 		if (infoGraphicsView && infoGraphicsView->boardLayers() == 2) disabled = false;
@@ -332,7 +332,7 @@ void Pad::terminalPointEntry(const QString &) {
 	if (connectAt.compare(value) == 0) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "connect to", tr("connect to"), connectAt, value, true);
 	}
 }

--- a/src/items/paletteitem.cpp
+++ b/src/items/paletteitem.cpp
@@ -375,7 +375,7 @@ bool PaletteItem::mousePressEventK(PaletteItemBase * originalItem, QGraphicsScen
 void PaletteItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL && infographics->spaceBarIsPressed()) {
+	if (infographics && infographics->spaceBarIsPressed()) {
 		event->ignore();
 		return;
 	}
@@ -531,7 +531,7 @@ bool PaletteItem::collectExtraInfo(QWidget * parent, const QString & family, con
 
 	bool result = PaletteItemBase::collectExtraInfo(parent, family, prop, value, swappingEnabled, returnProp, returnValue, returnWidget, hide);
 
-	if (prop.compare("layer") == 0 && modelPart()->flippedSMD() && returnWidget != NULL) {
+	if (prop.compare("layer") == 0 && modelPart()->flippedSMD() && returnWidget) {
 		bool disabled = true;
 		InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
 		if (infoGraphicsView && infoGraphicsView->boardLayers() == 2) disabled = false;
@@ -1159,7 +1159,7 @@ void PaletteItem::changeHoleSize(const QString & newSize) {
 	m_propsMap.insert("moduleID", newModuleID);
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->swap(family(), newModuleID, m_propsMap, this);
 	}
 }

--- a/src/items/paletteitembase.cpp
+++ b/src/items/paletteitembase.cpp
@@ -205,7 +205,7 @@ void PaletteItemBase::paintSelected(QPainter *painter, const QStyleOptionGraphic
 
 void PaletteItemBase::mousePressConnectorEvent(ConnectorItem * connectorItem, QGraphicsSceneMouseEvent * event) {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->mousePressConnectorEvent(connectorItem, event);
 	}
 }
@@ -698,7 +698,7 @@ void PaletteItemBase::partPropertyEntry() {
 	if (lineEdit == NULL) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, ModelPartShared::PartNumberPropertyName, "", m_modelPart->localProp(ModelPartShared::PartNumberPropertyName).toString(), lineEdit->text(), true);
 	}
 }

--- a/src/items/partfactory.cpp
+++ b/src/items/partfactory.cpp
@@ -530,7 +530,7 @@ ModelPart * PartFactory::fixObsoleteModuleID(QDomDocument & domDocument, QDomEle
 	// TODO: less hard-coding
 	if (moduleIDRef.startsWith("generic_male")) {
 		ModelPart * modelPart = referenceModel->retrieveModelPart(moduleIDRef);
-		if (modelPart != NULL) {
+		if (modelPart) {
 			instance.setAttribute("moduleIdRef", moduleIDRef);
 			QDomElement prop = domDocument.createElement("property");
 			instance.appendChild(prop);
@@ -542,7 +542,7 @@ ModelPart * PartFactory::fixObsoleteModuleID(QDomDocument & domDocument, QDomEle
 
 	if (moduleIDRef.startsWith("generic_rounded_female")) {
 		ModelPart * modelPart = referenceModel->retrieveModelPart(moduleIDRef);
-		if (modelPart != NULL) {
+		if (modelPart) {
 			instance.setAttribute("moduleIdRef", moduleIDRef);
 			QDomElement prop = domDocument.createElement("property");
 			instance.appendChild(prop);

--- a/src/items/partlabel.cpp
+++ b/src/items/partlabel.cpp
@@ -188,7 +188,7 @@ void PartLabel::mousePressEvent(QGraphicsSceneMouseEvent *event)
 	}
 
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL && infographics->spaceBarIsPressed()) {
+	if (infographics && infographics->spaceBarIsPressed()) {
 		m_spaceBarWasPressed = true;
 		event->ignore();
 		return;
@@ -381,7 +381,7 @@ void PartLabel::restoreLabel(QDomElement & labelGeometry, ViewLayer::ViewLayerID
 	double fs = labelGeometry.attribute("fontSize").toDouble(&ok);
 	if (!ok) {
 		InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-		if (infographics != NULL) {
+		if (infographics) {
 			fs = infographics->getLabelFontSizeMedium();
 			ok = true;
 		}
@@ -438,7 +438,7 @@ void PartLabel::initMenu()
 	QMenu * rlmenu = m_menu.addMenu(tr("Flip/Rotate"));
 	QMenu * fsmenu = m_menu.addMenu(tr("Font Size"));
 
-	bool include45 = (m_owner != NULL) && (m_owner->viewID() == ViewLayer::PCBView);
+	bool include45 = (m_owner) && (m_owner->viewID() == ViewLayer::PCBView);
 
 	if (include45) {
 		QAction *rotate45cwAct = rlmenu->addAction(tr("Rotate 45° Clockwise"));
@@ -559,7 +559,7 @@ void PartLabel::transformLabel(QTransform currTransf)
 
 void PartLabel::setUpText() {
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL) {
+	if (infographics) {
 		infographics->getLabelFont(m_font, m_color, m_owner);
 	}
 }
@@ -610,7 +610,7 @@ void PartLabel::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 	m_mediumAct->setChecked(false);
 	m_largeAct->setChecked(false);
 	InfoGraphicsView *infographics = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infographics != NULL) {
+	if (infographics) {
 		int fs = m_font.pointSize();
 		if (fs == infographics->getLabelFontSizeTiny()) {
 			m_tinyAct->setChecked(true);

--- a/src/items/perfboard.cpp
+++ b/src/items/perfboard.cpp
@@ -240,7 +240,7 @@ bool Perfboard::collectExtraInfo(QWidget * parent, const QString & family, const
 		subframe1->setLayout(hboxLayout1);
 		subframe2->setLayout(hboxLayout2);
 
-		if (returnWidget != NULL) vboxLayout->addWidget(qobject_cast<QWidget *>(returnWidget));
+		if (returnWidget) vboxLayout->addWidget(qobject_cast<QWidget *>(returnWidget));
 		vboxLayout->addWidget(subframe1);
 		vboxLayout->addWidget(subframe2);
 
@@ -316,7 +316,7 @@ void Perfboard::changeBoardSize()
 	// }
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->swap(family(), "size", m_propsMap, this);
 	}
 }

--- a/src/items/resistor.cpp
+++ b/src/items/resistor.cpp
@@ -369,7 +369,7 @@ void Resistor::resistanceEntry(const QString & text) {
 	//DebugDialog::debug(QString("resistance entry %1").arg(text));
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setResistance(text, "");
 	}
 }

--- a/src/items/resizableboard.cpp
+++ b/src/items/resizableboard.cpp
@@ -533,7 +533,7 @@ bool Board::canLoad(const QString & fileName, const QString & reason) {
 void Board::prepLoadImageAux(const QString & fileName, bool addName)
 {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->loadLogoImage(this, "", QSizeF(0,0), "", fileName, addName);
 	}
 }
@@ -1051,7 +1051,7 @@ void ResizableBoard::paperSizeChanged(int index) {
 	QModelIndex modelIndex = comboBox->model()->index(index,0);
 	QSizeF size = comboBox->model()->data(modelIndex, Qt::UserRole).toSizeF();
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->resizeBoard(size.width(), size.height(), true);
 	}
 }
@@ -1067,7 +1067,7 @@ void ResizableBoard::widthEntry() {
 	double h =  m_modelPart->localProp("height").toDouble();
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->resizeBoard(w, h, true);
 	}
 }
@@ -1083,7 +1083,7 @@ void ResizableBoard::heightEntry() {
 	double w =  m_modelPart->localProp("width").toDouble();
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->resizeBoard(w, h, true);
 	}
 }
@@ -1308,7 +1308,7 @@ QFrame * ResizableBoard::setUpDimEntry(bool includeAspectRatio, bool includeReve
 
 	subframe1->setLayout(hboxLayout1);
 	subframe2->setLayout(hboxLayout2);
-	if (returnWidget != NULL) vboxLayout->addWidget(returnWidget);
+	if (returnWidget) vboxLayout->addWidget(returnWidget);
 
 	connect(e1, SIGNAL(editingFinished()), this, SLOT(widthEntry()));
 	connect(e2, SIGNAL(editingFinished()), this, SLOT(heightEntry()));
@@ -1457,7 +1457,7 @@ void ResizableBoard::revertSize(bool) {
 	double oh = modelPart()->localProp("originalHeight").toDouble();
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->resizeBoard(ow, oh, true);
 		m_revertButton->setEnabled(false);
 	}

--- a/src/items/ruler.cpp
+++ b/src/items/ruler.cpp
@@ -338,7 +338,7 @@ void Ruler::widthEntry() {
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		// get current object units
 		int units = (m_unitsEditor->objectName() == "cm") ? IndexCm : IndexIn;
 		DefaultWidth = edit->text() + m_unitsEditor->objectName();

--- a/src/items/schematicframe.cpp
+++ b/src/items/schematicframe.cpp
@@ -266,7 +266,7 @@ void SchematicFrame::addedToScene(bool temporary)
 {
 	if (prop("filename").isEmpty()) {
 		InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-		if (infoGraphicsView != NULL) {
+		if (infoGraphicsView) {
 			modelPart()->setLocalProp("filename", infoGraphicsView->filenameIf());
 		}
 	}
@@ -447,14 +447,14 @@ void SchematicFrame::propEntry() {
 	if (edit->text().compare(current) == 0) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, propp, ItemBase::TranslatedPropertyNames.value(propp), current, edit->text(), true);
 	}
 }
 
 void SchematicFrame::dateTimeEntry(QDateTime dateTime) {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "date", tr("date"), prop("date"), QString::number(dateTime.toTime_t()), true);
 	}
 }
@@ -476,7 +476,7 @@ void SchematicFrame::sheetEntry(int value) {
 	else return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "sheet", tr("sheet"), prop("sheet"), strings.at(0) + "/" + strings[1], true);
 	}
 }

--- a/src/items/stripboard.cpp
+++ b/src/items/stripboard.cpp
@@ -119,7 +119,7 @@ void Stripbit::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, 
 void Stripbit::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL && infoGraphicsView->spaceBarIsPressed()) {
+	if (infoGraphicsView && infoGraphicsView->spaceBarIsPressed()) {
 		event->ignore();
 		return;
 	}
@@ -222,7 +222,7 @@ void Stripbit::hoverEnterEvent( QGraphicsSceneHoverEvent * event )
 	if (dynamic_cast<ItemBase *>(this->parentItem())->moveLock()) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL && infoGraphicsView->spaceBarIsPressed()) {
+	if (infoGraphicsView && infoGraphicsView->spaceBarIsPressed()) {
 		SpaceBarWasPressed = true;
 		return;
 	}
@@ -468,10 +468,10 @@ void Stripboard::addedToScene(bool temporary)
 			StripConnector * sc = getStripConnector(cx, cy);
 			bool vertical = name.contains("v");
 			if (vertical) {
-				if (sc->down != NULL) sc->down->setRemoved(true);
+				if (sc->down) sc->down->setRemoved(true);
 			}
 			else {
-				if (sc->right != NULL) sc->right->setRemoved(true);
+				if (sc->right) sc->right->setRemoved(true);
 			}
 		}
 	}
@@ -526,7 +526,7 @@ void Stripboard::reinitBuses(bool triggerUndo)
 		collectTo(affectedConnectors);
 
 		InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-		if (infoGraphicsView != NULL) {
+		if (infoGraphicsView) {
 			QString changeType = (connect) ? tr("Restored") : tr("Cut") ;
 			QString changeText = tr("%1 %n strip(s)", "", changeCount).arg(changeType);
 			QList<ConnectorItem *> affected = affectedConnectors.toList();
@@ -596,21 +596,21 @@ void Stripboard::collectConnected(int ix, int iy, QList<ConnectorItem *> & conne
 
 	connected << sc->connectorItem;
 
-	if (sc->right != NULL && !sc->right->removed()) {
+	if (sc->right && !sc->right->removed()) {
 		collectConnected(ix + 1, iy, connected);
 
 	}
-	if (sc->down != NULL && !sc->down->removed()) {
+	if (sc->down && !sc->down->removed()) {
 		collectConnected(ix, iy + 1, connected);
 	}
 
 	StripConnector * left = ix > 0 ? getStripConnector(ix - 1, iy) : NULL;
-	if (left != NULL && left->right != NULL && !left->right->removed()) {
+	if (left && left->right && !left->right->removed()) {
 		collectConnected(ix - 1, iy, connected);
 	}
 
 	StripConnector * up = iy > 0 ? getStripConnector(ix, iy - 1) : NULL;
-	if (up != NULL && up->down != NULL && !up->down->removed()) {
+	if (up && up->down && !up->down->removed()) {
 		collectConnected(ix, iy - 1, connected);
 	}
 }
@@ -783,7 +783,7 @@ void Stripboard::swapEntry(const QString & text) {
 					propsMap.insert("buses", stripLayout.buses);
 					propsMap.insert("layout", text);
 					InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-					if (infoGraphicsView != NULL) {
+					if (infoGraphicsView) {
 						infoGraphicsView->swap(family(), "size", propsMap, this);
 					}
 					return;

--- a/src/items/symbolpaletteitem.cpp
+++ b/src/items/symbolpaletteitem.cpp
@@ -427,7 +427,7 @@ bool SymbolPaletteItem::collectExtraInfo(QWidget * parent, const QString & famil
 
 void SymbolPaletteItem::voltageEntry(const QString & text) {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setVoltage(text.toDouble(), true);
 	}
 }
@@ -445,7 +445,7 @@ void SymbolPaletteItem::labelEntry() {
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "label", ItemBase::TranslatedPropertyNames.value("label"), current, edit->text(), true);
 	}
 }

--- a/src/items/tracewire.cpp
+++ b/src/items/tracewire.cpp
@@ -94,7 +94,7 @@ bool TraceWire::collectExtraInfo(QWidget * parent, const QString & family, const
 	}
 
 	bool result =  ClipableWire::collectExtraInfo(parent, family, prop, value, swappingEnabled, returnProp, returnValue, returnWidget, hide);
-	if (prop.compare("layer") == 0 && returnWidget != NULL) {
+	if (prop.compare("layer") == 0 && returnWidget) {
 		bool disabled = !canSwitchLayers();
 		if (!disabled) {
 			InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
@@ -113,7 +113,7 @@ void TraceWire::widthEntry(const QString & text) {
 	if (w == 0) return;
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->changeWireWidthMils(QString::number(w));
 	}
 }

--- a/src/items/wire.cpp
+++ b/src/items/wire.cpp
@@ -182,7 +182,7 @@ Wire::~Wire() {
 FSvgRenderer * Wire::setUp(ViewLayer::ViewLayerID viewLayerID, const LayerHash &  viewLayers, InfoGraphicsView * infoGraphicsView) {
 	ItemBase::setViewLayerID(viewLayerID, viewLayers);
 	FSvgRenderer * svgRenderer = setUpConnectors(m_modelPart, m_viewID);
-	if (svgRenderer != NULL) {
+	if (svgRenderer) {
 		initEnds(m_viewGeometry, svgRenderer->viewBox(), infoGraphicsView);
 		//debugCompare(this);
 	}
@@ -249,7 +249,7 @@ void Wire::initEnds(const ViewGeometry & vg, QRectF defaultRect, InfoGraphicsVie
 
 	m_pen.setCapStyle(Qt::RoundCap);
 	m_shadowPen.setCapStyle(Qt::RoundCap);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->initWire(this, penWidth);
 	}
 
@@ -418,7 +418,7 @@ void Wire::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
 void Wire::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setActiveWire(this);
 	}
 
@@ -919,7 +919,7 @@ void Wire::mousePressConnectorEvent(ConnectorItem * connectorItem, QGraphicsScen
 	if (m_canChainMultiple && event->modifiers() & altOrMetaModifier()) {
 		// dragging a wire out of a bendpoint
 		InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-		if (infoGraphicsView != NULL) {
+		if (infoGraphicsView) {
 			infoGraphicsView->mousePressConnectorEvent(connectorItem, event);
 		}
 
@@ -1671,7 +1671,7 @@ void Wire::colorEntry(const QString & text) {
 	QString color = comboBox->itemData(comboBox->currentIndex()).toString();
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->changeWireColor(color);
 	}
 }
@@ -1841,7 +1841,7 @@ void Wire::changeCurve(const Bezier * bezier)
 }
 
 bool Wire::isCurved() {
-	return (m_bezier != NULL) && !m_bezier->isEmpty();
+	return (m_bezier) && !m_bezier->isEmpty();
 }
 
 const Bezier * Wire::curve() {
@@ -1919,7 +1919,7 @@ void Wire::updateCursor(Qt::KeyboardModifiers modifiers)
 		// only in breadboard view
 		CursorMaster::instance()->addCursor(this, *CursorMaster::MoveCursor);
 	}
-	else if (infoGraphicsView != NULL && infoGraphicsView->curvyWiresIndicated(modifiers)) {
+	else if (infoGraphicsView && infoGraphicsView->curvyWiresIndicated(modifiers)) {
 		CursorMaster::instance()->addCursor(this, *CursorMaster::MakeCurveCursor);
 	}
 	else if (m_displayBendpointCursor) {
@@ -1962,7 +1962,7 @@ void Wire::setBanded(bool banded) {
 
 void Wire::setBandedProp(bool banded) {
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL) {
+	if (infoGraphicsView) {
 		infoGraphicsView->setProp(this, "banded", ItemBase::TranslatedPropertyNames.value("banded"), m_banded ? "Yes" : "No", banded  ? "Yes" : "No", true);
 	}
 }

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1256,7 +1256,7 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 	/*
 	foreach (QWidget * widget, QApplication::topLevelWidgets()) {
 		QMenu * menu = qobject_cast<QMenu *>(widget);
-		if (menu != NULL) {
+		if (menu) {
 			continue;				// QMenus are always top level widgets, even if they have parents...
 		}
 		DebugDialog::debug(QString("top level widget %1 %2 %3")
@@ -1837,7 +1837,7 @@ QList<ModelPart*> MainWindow::moveToPartsFolder(QDir &unzipDir, MainWindow* mw, 
 
 	if (importingSinglePart && partEntryInfoList.count() > 0) {
 		QString moduleID = TextUtils::parseFileForModuleID(partEntryInfoList[0].absoluteFilePath());
-		if (!moduleID.isEmpty() && m_referenceModel->retrieveModelPart(moduleID) != NULL) {
+		if (!moduleID.isEmpty() && m_referenceModel->retrieveModelPart(moduleID)) {
 			throw tr("There is already a part with id '%1' loaded into Fritzing.").arg(moduleID);
 		}
 	}
@@ -1901,7 +1901,7 @@ ModelPart* MainWindow::copyToPartsFolder(const QFileInfo& file, bool addToAlien,
 		}
 	}
 	ModelPart *mp = m_referenceModel->loadPart(destFilePath, true);
-	if (mp != NULL) {
+	if (mp) {
 		mp->setAlien(true);
 	} else {
 		// Part load failed, remove modified files before proceeding.
@@ -2072,7 +2072,7 @@ void MainWindow::resizeEvent(QResizeEvent * event) {
 
 void MainWindow::enableCheckUpdates(bool enabled)
 {
-	if (m_checkForUpdatesAct != NULL) {
+	if (m_checkForUpdatesAct) {
 		m_checkForUpdatesAct->setEnabled(enabled);
 	}
 }
@@ -2249,7 +2249,7 @@ bool MainWindow::swapSpecial(const QString & theProp, QMap<QString, QString> & c
 		}
 
 		Resistor * resistor = qobject_cast<Resistor *>(itemBase);
-		if (resistor != NULL) {
+		if (resistor) {
 			m_currentGraphicsView->setResistance(resistance, pinSpacing);
 			return true;
 		}
@@ -2436,7 +2436,7 @@ void MainWindow::redrawSketch() {
 	foreach (QGraphicsItem * item, m_currentGraphicsView->scene()->items()) {
 		item->update();
 		ConnectorItem * c = dynamic_cast<ConnectorItem *>(item);
-		if (c != NULL) {
+		if (c) {
 			c->restoreColor(visited);
 		}
 	}
@@ -2444,7 +2444,7 @@ void MainWindow::redrawSketch() {
 
 void MainWindow::statusMessage(QString message, int timeout) {
 	QStatusBar * sb = realStatusBar();
-	if (sb != NULL) {
+	if (sb) {
 		sb->showMessage(message, timeout);
 	}
 }
@@ -2469,7 +2469,7 @@ bool MainWindow::save() {
 
 bool MainWindow::saveAs() {
 	bool convertSchematic = false;
-	if (m_schematicGraphicsView != NULL && m_schematicGraphicsView->isOldSchematic()) {
+	if (m_schematicGraphicsView && m_schematicGraphicsView->isOldSchematic()) {
 		QMessageBox::StandardButton reply = QMessageBox::question(this, tr("Schematic conversion"),
 		                                    tr("Saving this sketch will convert it to the new schematic graphics standard. Go ahead and convert?"),
 		                                    QMessageBox::Yes | QMessageBox::No);
@@ -2505,7 +2505,7 @@ void MainWindow::changeBoardLayers(int layers, bool doEmit) {
 }
 
 void MainWindow::updateActiveLayerButtons() {
-	if (m_activeLayerButtonWidget != NULL) {
+	if (m_activeLayerButtonWidget) {
 		int index = activeLayerIndex();
 		bool enabled = index >= 0;
 
@@ -2521,7 +2521,7 @@ void MainWindow::updateActiveLayerButtons() {
 		setActionsIcons(index, actions);
 	}
 
-	if (m_viewFromButtonWidget != NULL) {
+	if (m_viewFromButtonWidget) {
 		if (m_pcbGraphicsView) {
 			bool viewFromBelow = m_pcbGraphicsView->viewFromBelow();
 			int index = (viewFromBelow ? 1 : 0);
@@ -3000,7 +3000,7 @@ bool MainWindow::usesPart(const QString & moduleID) {
 
 	foreach (QGraphicsItem * item, m_currentGraphicsView->scene()->items()) {
 		ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
-		if (itemBase != NULL && itemBase->moduleID().compare(moduleID) == 0) {
+		if (itemBase && itemBase->moduleID().compare(moduleID) == 0) {
 			return true;
 		}
 	}

--- a/src/mainwindow/mainwindow_export.cpp
+++ b/src/mainwindow/mainwindow_export.cpp
@@ -1269,7 +1269,7 @@ void MainWindow::exportBOM() {
 	}
 
 	QClipboard *clipboard = QApplication::clipboard();
-	if (clipboard != NULL) {
+	if (clipboard) {
 		clipboard->setText(bom);
 	}
 	delete fileProgressDialog;
@@ -1469,7 +1469,7 @@ void MainWindow::exportSpiceNetlist() {
 	netList.clear();
 
 	QClipboard *clipboard = QApplication::clipboard();
-	if (clipboard != NULL) {
+	if (clipboard) {
 		clipboard->setText(output);
 	}
 
@@ -1537,7 +1537,7 @@ void MainWindow::exportNetlist() {
 			part.setAttribute("label", itemBase->instanceTitle());
 			part.setAttribute("title", itemBase->title());
 			ErcData * ercData = connectorItem->connectorSharedErcData();
-			if (ercData != NULL) {
+			if (ercData) {
 				QDomElement erc = doc.createElement("erc");
 				if (ercData->writeToElement(erc, doc)) {
 					connector.appendChild(erc);
@@ -1581,7 +1581,7 @@ void MainWindow::exportNetlist() {
 	fp.close();
 
 	QClipboard *clipboard = QApplication::clipboard();
-	if (clipboard != NULL) {
+	if (clipboard) {
 		clipboard->setText(doc.toByteArray());
 	}
 	delete fileProgressDialog;

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -543,25 +543,25 @@ void MainWindow::duplicate() {
 void MainWindow::doDelete() {
 	//DebugDialog::debug(QString("invoking do delete") );
 
-	if (m_currentGraphicsView != NULL) {
+	if (m_currentGraphicsView) {
 		m_currentGraphicsView->deleteSelected(retrieveWire(), false);
 	}
 }
 
 void MainWindow::doDeleteMinus() {
-	if (m_currentGraphicsView != NULL) {
+	if (m_currentGraphicsView) {
 		m_currentGraphicsView->deleteSelected(retrieveWire(), true);
 	}
 }
 
 void MainWindow::selectAll() {
-	if (m_currentGraphicsView != NULL) {
+	if (m_currentGraphicsView) {
 		m_currentGraphicsView->selectDeselectAllCommand(true);
 	}
 }
 
 void MainWindow::deselect() {
-	if (m_currentGraphicsView != NULL) {
+	if (m_currentGraphicsView) {
 		m_currentGraphicsView->selectDeselectAllCommand(false);
 	}
 }
@@ -797,7 +797,7 @@ void MainWindow::createOpenRecentMenu() {
 }
 
 void MainWindow::updateFileMenu() {
-	m_printAct->setEnabled(m_currentGraphicsView != NULL || m_currentWidget->contentView() == m_programView);
+	m_printAct->setEnabled(m_currentGraphicsView || m_currentWidget->contentView() == m_programView);
 
 	updateRecentFileActions();
 	m_orderFabAct->setEnabled(true);
@@ -1609,7 +1609,7 @@ void MainWindow::updateLayerMenu(bool resetLayout) {
 	        m_100PercentSizeAct << m_alignToGridAct << m_showGridAct << m_setGridSizeAct << m_setBackgroundColorAct <<
 	        m_colorWiresByLengthAct;
 
-	bool enabled = (m_currentGraphicsView != NULL);
+	bool enabled = (m_currentGraphicsView);
 	foreach (QAction * action, actions) action->setEnabled(enabled);
 
 	actions.clear();
@@ -1652,7 +1652,7 @@ void MainWindow::updateLayerMenu(bool resetLayout) {
 	foreach (ViewLayer::ViewLayerID key, keys) {
 		ViewLayer * viewLayer = viewLayers.value(key);
 		//DebugDialog::debug(QString("Layer: %1 is %2").arg(viewLayer->action()->text()).arg(viewLayer->action()->isEnabled()));
-		if (viewLayer != NULL) {
+		if (viewLayer) {
 			if (viewLayer->parentLayer()) continue;
 			m_viewMenu->addAction(viewLayer->action());
 			disconnect(viewLayer->action(), SIGNAL(triggered()), this, SLOT(updateLayerMenu()));
@@ -1679,8 +1679,8 @@ void MainWindow::updateLayerMenu(bool resetLayout) {
 	for (int i = 1; i < keys.count(); i++) {
 		ViewLayer *viewLayer = viewLayers.value(keys[i]);
 		//DebugDialog::debug(QString("Layer: %1 is %2").arg(viewLayer->action()->text()).arg(viewLayer->action()->isChecked()));
-		if (viewLayer != NULL) {
-			if (prev != NULL && prev->action()->isChecked() != viewLayer->action()->isChecked() ) {
+		if (viewLayer) {
+			if (prev && prev->action()->isChecked() != viewLayer->action()->isChecked() ) {
 				// if the actions aren't all checked or unchecked I don't bother about the "checked" variable
 				sameState = false;
 				break;
@@ -1733,7 +1733,7 @@ void MainWindow::updateWireMenu() {
 	bool gotRat = false;
 	bool ctlOK = false;
 
-	if (wire != NULL) {
+	if (wire) {
 
 		if (wire->getRatsnest()) {
 			QList<ConnectorItem *> ends;
@@ -1944,7 +1944,7 @@ void MainWindow::updatePartMenu() {
 	m_selectAllObsoleteAct->setEnabled(true);
 	m_swapObsoleteAct->setEnabled(itemCount.obsoleteCount > 0);
 
-	m_findPartInSketchAct->setEnabled(m_currentGraphicsView != NULL);
+	m_findPartInSketchAct->setEnabled(m_currentGraphicsView);
 	m_regeneratePartsDatabaseAct->setEnabled(true);
 	m_openProgramWindowAct->setEnabled(true);
 }
@@ -1999,15 +1999,15 @@ void MainWindow::updateItemMenu() {
 	}
 
 	PaletteItem *selected = qobject_cast<PaletteItem *>(itemBase);
-	bool enabled = (selCount == 1) && (selected != NULL);
+	bool enabled = (selCount == 1) && (selected);
 
 	m_saveBundledPart->setEnabled(enabled && !selected->modelPart()->isCore());
 
 
 	// can't open wire in parts editor
-	enabled &= selected != NULL && itemBase != NULL && itemBase->canEditPart();
+	enabled &= selected && itemBase && itemBase->canEditPart();
 
-	m_disconnectAllAct->setEnabled(enabled && m_currentGraphicsView->canDisconnectAll() && (itemBase->rightClickedConnector() != NULL));
+	m_disconnectAllAct->setEnabled(enabled && m_currentGraphicsView->canDisconnectAll() && (itemBase->rightClickedConnector()));
 
 	bool gfsEnabled = false;
 	if (activeConnectorItem) {
@@ -2035,9 +2035,9 @@ void MainWindow::updateEditMenu() {
 	QClipboard *clipboard = QApplication::clipboard();
 	m_pasteAct->setEnabled(false);
 	m_pasteInPlaceAct->setEnabled(false);
-	if (clipboard != NULL) {
+	if (clipboard) {
 		const QMimeData *mimeData = clipboard->mimeData(QClipboard::Clipboard);
-		if (mimeData != NULL) {
+		if (mimeData) {
 			if (mimeData->hasFormat("application/x-dnditemsdata")) {
 				m_pasteAct->setEnabled(true);
 				m_pasteInPlaceAct->setEnabled(true);
@@ -2077,7 +2077,7 @@ void MainWindow::updateTraceMenu() {
 
 	TraceMenuThing traceMenuThing;
 
-	if (m_currentGraphicsView != NULL) {
+	if (m_currentGraphicsView) {
 		QList<QGraphicsItem *> items = m_currentGraphicsView->scene()->items();
 		foreach (QGraphicsItem * item, items) {
 			Wire * wire = dynamic_cast<Wire *>(item);
@@ -2115,7 +2115,7 @@ void MainWindow::updateTraceMenu() {
 	}
 
 	if (!arEnabled) {
-		if (m_currentGraphicsView != NULL) {
+		if (m_currentGraphicsView) {
 			arEnabled = m_currentGraphicsView->hasAnyNets();
 		}
 	}
@@ -2440,7 +2440,7 @@ void MainWindow::updateWindowMenu() {
 		if (mainWindow == NULL) continue;
 
 		QAction *action = mainWindow->raiseWindowAction();
-		if (action != NULL) {
+		if (action) {
 			action->setChecked(action == m_raiseWindowAct);
 			m_windowMenu->addAction(action);
 		}
@@ -2907,7 +2907,7 @@ void MainWindow::toggleActiveLayer()
 
 
 void MainWindow::createOrderFabAct() {
-	if (m_orderFabAct != NULL) return;
+	if (m_orderFabAct) return;
 
 	m_orderFabAct = new QAction(tr("Order a PCB..."), this);
 	m_orderFabAct->setStatusTip(tr("Order a PCB created from your sketch--from fabulous Fritzing Fab"));
@@ -3100,7 +3100,7 @@ void MainWindow::enableAddBendpointAct(QGraphicsItem * graphicsItem) {
 	BendpointAction * bendpointAction = qobject_cast<BendpointAction *>(m_addBendpointAct);
 	BendpointAction * convertToViaAction = qobject_cast<BendpointAction *>(m_convertToViaAct);
 	FGraphicsScene * scene = qobject_cast<FGraphicsScene *>(graphicsItem->scene());
-	if (scene != NULL) {
+	if (scene) {
 		bendpointAction->setLastLocation(scene->lastContextMenuPos());
 		convertToViaAction->setLastLocation(scene->lastContextMenuPos());
 	}
@@ -4480,32 +4480,32 @@ void MainWindow::findPartInSketch() {
 }
 
 void MainWindow::setGroundFillKeepout() {
-	if (m_pcbGraphicsView != NULL) m_pcbGraphicsView->setGroundFillKeepout();
+	if (m_pcbGraphicsView) m_pcbGraphicsView->setGroundFillKeepout();
 }
 
 void MainWindow::setViewFromBelowToggle() {
-	if (m_pcbGraphicsView != NULL) {
+	if (m_pcbGraphicsView) {
 		m_pcbGraphicsView->setViewFromBelow(m_viewFromBelowToggleAct->isChecked());
 		updateActiveLayerButtons();
 	}
 }
 
 void MainWindow::setViewFromBelow() {
-	if (m_pcbGraphicsView != NULL) {
+	if (m_pcbGraphicsView) {
 		m_pcbGraphicsView->setViewFromBelow(true);
 		updateActiveLayerButtons();
 	}
 }
 
 void MainWindow::setViewFromAbove() {
-	if (m_pcbGraphicsView != NULL) {
+	if (m_pcbGraphicsView) {
 		m_pcbGraphicsView->setViewFromBelow(false);
 		updateActiveLayerButtons();
 	}
 }
 
 void MainWindow::updateExportMenu() {
-	bool enabled = m_currentGraphicsView != NULL;
+	bool enabled = m_currentGraphicsView;
 	foreach (QAction * action, m_exportMenu->actions()) {
 		action->setEnabled(enabled);
 	}

--- a/src/model/modelbase.cpp
+++ b/src/model/modelbase.cpp
@@ -168,7 +168,7 @@ bool ModelBase::loadFromFile(const QString & fileName, ModelBase * referenceMode
 	}
 
 	QString searchTerm = root.attribute("search");
-	if (!searchTerm.isEmpty() && modelPartSharedRoot != NULL) {
+	if (!searchTerm.isEmpty() && modelPartSharedRoot) {
 		modelPartSharedRoot->setSearchTerm(searchTerm);
 	}
 
@@ -294,7 +294,7 @@ bool ModelBase::loadInstances(QDomDocument & domDocument, QDomElement & instance
 			modelPart = fixObsoleteModuleID(domDocument, instance, moduleIDRef);
 			if (modelPart == NULL) {
 				modelPart = genFZP(moduleIDRef, m_referenceModel);
-				if (modelPart != NULL) {
+				if (modelPart) {
 					instance.setAttribute("moduleIdRef", modelPart->moduleID());
 					moduleIDRef = modelPart->moduleID();
 					generated = true;

--- a/src/model/palettemodel.cpp
+++ b/src/model/palettemodel.cpp
@@ -93,9 +93,9 @@ void PaletteModel::initNames() {
 
 ModelPart * PaletteModel::retrieveModelPart(const QString & moduleID) {
 	ModelPart * modelPart = m_partHash.value(moduleID, NULL);
-	if (modelPart != NULL) return modelPart;
+	if (modelPart) return modelPart;
 
-	if (m_referenceModel != NULL) {
+	if (m_referenceModel) {
 		return m_referenceModel->retrieveModelPart(moduleID);
 	}
 
@@ -379,9 +379,9 @@ QString PaletteModel::loadedFrom() {
 
 ModelPart * PaletteModel::addPart(QString newPartPath, bool addToReference, bool updateIdAlreadyExists) {
 	/*ModelPart * modelPart = loadPart(newPartPath, updateIdAlreadyExists);;
-	if (m_referenceModel != NULL && addToReference) {
+	if (m_referenceModel && addToReference) {
 		modelPart = m_referenceModel->addPart(newPartPath, addToReference);
-		if (modelPart != NULL) {
+		if (modelPart) {
 			return addModelPart( m_root, modelPart);
 		}
 	}*/

--- a/src/model/sketchmodel.cpp
+++ b/src/model/sketchmodel.cpp
@@ -62,7 +62,7 @@ ModelPart * SketchModel::findModelPartAux(ModelPart * modelPart, const QString &
 		if (mp == NULL) continue;
 
 		mp = findModelPartAux(mp, moduleID, id);
-		if (mp != NULL) {
+		if (mp) {
 			return mp;
 		}
 	}

--- a/src/partsbinpalette/binmanager/binmanager.cpp
+++ b/src/partsbinpalette/binmanager/binmanager.cpp
@@ -269,7 +269,7 @@ PartsBinPaletteWidget* BinManager::getOrOpenBin(const QString & binLocation, con
 		QString fileToOpen = QFileInfo(binLocation).exists() ? binLocation : createIfBinNotExists(binLocation, binTemplateLocation);
 		partsBin = openBinIn(fileToOpen, false);
 	}
-	if (partsBin != NULL && partsBin->fastLoaded()) {
+	if (partsBin && partsBin->fastLoaded()) {
 		partsBin->load(partsBin->fileName(), partsBin, false);
 	}
 
@@ -361,7 +361,7 @@ void BinManager::setDirtyTab(PartsBinPaletteWidget* w, bool dirty) {
 	}
 	*/
 	w->setWindowModified(dirty);
-	if(m_stackTabWidget != NULL) {
+	if(m_stackTabWidget) {
 		int tabIdx = m_stackTabWidget->indexOf(w);
 		m_stackTabWidget->setTabText(tabIdx, w->title()+(dirty? " *": ""));
 	} else {
@@ -370,7 +370,7 @@ void BinManager::setDirtyTab(PartsBinPaletteWidget* w, bool dirty) {
 }
 
 void BinManager::updateTitle(PartsBinPaletteWidget* w, const QString& newTitle) {
-	if(m_stackTabWidget != NULL) {
+	if(m_stackTabWidget) {
 		m_stackTabWidget->setTabText(m_stackTabWidget->indexOf(w), newTitle+" *");
 		setDirtyTab(w);
 	}
@@ -434,7 +434,7 @@ PartsBinPaletteWidget* BinManager::openBinIn(QString fileName, bool fastLoad) {
 
 PartsBinPaletteWidget* BinManager::openCoreBinIn() {
 	PartsBinPaletteWidget* bin = findBin(CorePartsBinLocation);
-	if (bin != NULL) {
+	if (bin) {
 		setAsCurrentTab(bin);
 	}
 	else {
@@ -965,7 +965,7 @@ void BinManager::updateBinCombinedMenu(PartsBinPaletteWidget * bin) {
 	m_closeBinAction->setEnabled(bin->canClose());
 	m_deleteBinAction->setEnabled(bin->canClose());
 	ItemBase *itemBase = bin->selectedItemBase();
-	bool enabled = (itemBase != NULL);
+	bool enabled = (itemBase);
 	m_editPartNewAction->setEnabled(enabled && itemBase->canEditPart());
 
 	bool enableAnyway = false;
@@ -1276,7 +1276,7 @@ void BinManager::saveBundledBin() {
 
 void BinManager::setTabIcon(PartsBinPaletteWidget* w, QIcon * icon)
 {
-	if (m_stackTabWidget != NULL) {
+	if (m_stackTabWidget) {
 		int tabIdx = m_stackTabWidget->indexOf(w);
 		m_stackTabWidget->setTabIcon(tabIdx, *icon);
 	}

--- a/src/partsbinpalette/partsbinlistview.cpp
+++ b/src/partsbinpalette/partsbinlistview.cpp
@@ -108,7 +108,7 @@ int PartsBinListView::setItemAux(ModelPart * modelPart, int position) {
 void PartsBinListView::mouseMoveEvent(QMouseEvent *event) {
 	if(m_infoViewOnHover) {
 		QListWidgetItem * item = itemAt(event->pos());
-		if (item != NULL) {
+		if (item) {
 			showInfo(item);
 		}
 		else {
@@ -125,9 +125,9 @@ void PartsBinListView::showInfo(QListWidgetItem * item) {
 		return;
 	}
 
-	if (m_hoverItem != NULL && m_infoView != NULL) {
+	if (m_hoverItem && m_infoView) {
 		ItemBase * itemBase = itemItemBase(m_hoverItem);
-		if (itemBase != NULL) {
+		if (itemBase) {
 			m_infoView->hoverLeaveItem(NULL, NULL, itemBase);
 		}
 	}
@@ -137,9 +137,9 @@ void PartsBinListView::showInfo(QListWidgetItem * item) {
 	}
 
 	m_hoverItem = item;
-	if (m_infoView != NULL) {
+	if (m_infoView) {
 		ItemBase * itemBase = itemItemBase(item);
-		if (itemBase != NULL) {
+		if (itemBase) {
 			m_infoView->hoverEnterItem(NULL, NULL, itemBase, swappingEnabled());
 		}
 	}
@@ -153,12 +153,12 @@ void PartsBinListView::mousePressEvent(QMouseEvent *event) {
 	QListWidgetItem * current = currentItem();
 	if (current == NULL) {
 		m_hoverItem = NULL;
-		if (m_infoView != NULL) m_infoView->viewItemInfo(NULL, NULL, false);
+		if (m_infoView) m_infoView->viewItemInfo(NULL, NULL, false);
 		return;
 	}
 
 	showInfo(current);
-	if (m_infoView != NULL) m_infoView->viewItemInfo(NULL, itemItemBase(current), false);
+	if (m_infoView) m_infoView->viewItemInfo(NULL, itemItemBase(current), false);
 }
 
 void PartsBinListView::setInfoView(HtmlInfoView * infoView) {
@@ -380,7 +380,7 @@ void PartsBinListView::loadImage(ModelPart * modelPart, QListWidgetItem * lwi, c
 		LayerAttributes layerAttributes;
 		itemBase->initLayerAttributes(layerAttributes, ViewLayer::IconView, ViewLayer::Icon, itemBase->viewLayerPlacement(), false, false);
 		FSvgRenderer * renderer = itemBase->setUpImage(modelPart, layerAttributes);
-		if (renderer != NULL) {
+		if (renderer) {
 			if (itemBase) {
 				itemBase->setFilename(renderer->filename());
 			}

--- a/src/partsbinpalette/partsbinpalettewidget.cpp
+++ b/src/partsbinpalette/partsbinpalettewidget.cpp
@@ -139,7 +139,7 @@ PartsBinPaletteWidget::PartsBinPaletteWidget(ReferenceModel *referenceModel, Htm
 }
 
 PartsBinPaletteWidget::~PartsBinPaletteWidget() {
-	if (m_canDeleteModel && m_model != NULL) {
+	if (m_canDeleteModel && m_model) {
 		delete m_model;
 		m_model = NULL;
 	}
@@ -504,7 +504,7 @@ void PartsBinPaletteWidget::load(const QString &filename, QWidget * progressTarg
 		if (name.isEmpty()) name = QFileInfo(filename).completeBaseName();
 
 		bool deleteWhenDone = false;
-		if (progressTarget != NULL) {
+		if (progressTarget) {
 			//DebugDialog::debug("open progress " + filename);
 			deleteWhenDone = true;
 			progressTarget = m_loadingProgressDialog = new FileProgressDialog(tr("Loading..."), 200, progressTarget);
@@ -840,7 +840,7 @@ QIcon PartsBinPaletteWidget::icon() {
 }
 
 bool PartsBinPaletteWidget::hasMonoIcon() {
-	return m_monoIcon != NULL;
+	return m_monoIcon;
 }
 
 QIcon PartsBinPaletteWidget::monoIcon() {

--- a/src/partsbinpalette/partsbinview.cpp
+++ b/src/partsbinpalette/partsbinview.cpp
@@ -150,7 +150,7 @@ void PartsBinView::mousePressOnItem(const QPoint &dragStartPos, const QString &m
 
 	// can set the pixmap, but can't hide it
 	//QPixmap * pixmap = pitem->pixmap();
-	//if (pixmap != NULL) {
+	//if (pixmap) {
 	//drag.setPixmap(*pixmap);
 	//drag.setHotSpot(mts.toPoint() - pitem->pos().toPoint());
 	//

--- a/src/partseditor/obsolete/addremovelistwidget.cpp
+++ b/src/partseditor/obsolete/addremovelistwidget.cpp
@@ -74,7 +74,7 @@ void AddRemoveListWidget::removeSelectedItems() {
 }
 
 int AddRemoveListWidget::count() {
-	if(m_list != NULL) {
+	if(m_list) {
 		return m_list->count();
 	} else {
 		return 0;
@@ -82,7 +82,7 @@ int AddRemoveListWidget::count() {
 }
 
 QListWidgetItem* AddRemoveListWidget::itemAt(int rowIdx) {
-	if(m_list != NULL) {
+	if(m_list) {
 		return m_list->item(rowIdx);
 	} else {
 		return NULL;

--- a/src/partseditor/obsolete/connectorsinfowidget.cpp
+++ b/src/partseditor/obsolete/connectorsinfowidget.cpp
@@ -444,7 +444,7 @@ void ConnectorsInfoWidget::syncNewConnectors(ViewLayer::ViewIdentifier viewId, c
 }
 
 bool ConnectorsInfoWidget::existingConnId(const QString &id) {
-	return findConnector(id) != NULL;
+	return findConnector(id);
 }
 
 MismatchingConnectorWidget* ConnectorsInfoWidget::existingMismatchingConnector(const QString &id) {

--- a/src/partseditor/obsolete/partseditorview.cpp
+++ b/src/partseditor/obsolete/partseditorview.cpp
@@ -194,7 +194,7 @@ ItemBase * PartsEditorView::addItemAux(ModelPart * modelPart, ViewLayer::ViewLay
 					viewLayerID = getViewLayerID(modelPart, m_viewIdentifier, viewLayerSpec);
 				}
 				addDefaultLayers(NULL);
-				if (m_viewItem != NULL) {
+				if (m_viewItem) {
 					QHash<QString, QString> svgHash;
 					QString svg = "";
 					foreach (ViewLayer * vl, m_viewLayers.values()) {
@@ -485,7 +485,7 @@ bool PartsEditorView::terminalIdForConnectorIdAux(QString &result, const QString
 
 void PartsEditorView::findConnectorsLayerId() {
 	if(m_connsLayerID == ViewLayer::UnknownLayer) {
-		if (m_item != NULL) {
+		if (m_item) {
 			m_connsLayerID = ViewLayer::viewLayerIDFromXmlString(
 			                     findConnectorsLayerId(m_item->svgDom())
 			                 );
@@ -1217,7 +1217,7 @@ void PartsEditorView::aboutToSave(bool fakeDefaultIfNone) {
 				somethingChanged |= updateTerminalPoints(svgDom, sceneViewBox, svgViewBox, connectorsLayerId);
 				somethingChanged |= addConnectorsIfNeeded(svgDom, sceneViewBox, svgViewBox, connectorsLayerId);
 			}
-			somethingChanged |= (m_viewItem != NULL);
+			somethingChanged |= (m_viewItem);
 
 			if(somethingChanged) {
 				QString viewFolder = getOrCreateViewFolderInTemp();
@@ -1597,7 +1597,7 @@ void PartsEditorView::addFixedToBottomRight(QWidget *widget) {
 }
 
 bool PartsEditorView::imageLoaded() {
-	return m_item != NULL;
+	return m_item;
 }
 
 void PartsEditorView::drawBackground(QPainter *painter, const QRectF &rect) {
@@ -1736,7 +1736,7 @@ void PartsEditorView::updatePinsInfo(QList< QPointer<ConnectorShared> > connsSha
 		foreach(ConnectorShared* cs, notFound) {
 			QString connId = cs->id();
 			SvgIdLayer* pinInfo = cs->fullPinInfo(m_viewIdentifier, vlid);
-			if (pinInfo != NULL && !m_svgIds[connId].connectorId.isEmpty()) {
+			if (pinInfo && !m_svgIds[connId].connectorId.isEmpty()) {
 				pinInfo->m_svgId = m_svgIds[connId].connectorId;
 				pinInfo->m_svgViewLayerID = layerID;
 				found << cs;

--- a/src/partseditor/peconnectorsview.cpp
+++ b/src/partseditor/peconnectorsview.cpp
@@ -172,7 +172,7 @@ void PEConnectorsView::initConnectors(QList<QDomElement> * connectorList)
 
 void PEConnectorsView::nameEntry() {
 	QLineEdit * lineEdit = qobject_cast<QLineEdit *>(sender());
-	if (lineEdit != NULL && lineEdit->isModified()) {
+	if (lineEdit && lineEdit->isModified()) {
 		changeConnector();
 		lineEdit->setModified(false);
 	}
@@ -184,7 +184,7 @@ void PEConnectorsView::typeEntry() {
 
 void PEConnectorsView::descriptionEntry() {
 	QLineEdit * lineEdit = qobject_cast<QLineEdit *>(sender());
-	if (lineEdit != NULL && lineEdit->isModified()) {
+	if (lineEdit && lineEdit->isModified()) {
 		changeConnector();
 		lineEdit->setModified(false);
 	}
@@ -194,7 +194,7 @@ void PEConnectorsView::connectorCountEntry() {
 	if (!m_mutex.tryLock(1)) return;            // need the mutex because multiple editingFinished() signals can be triggered more-or-less at once
 
 	QLineEdit * lineEdit = qobject_cast<QLineEdit *>(sender());
-	if (lineEdit != NULL && lineEdit->isModified()) {
+	if (lineEdit && lineEdit->isModified()) {
 		int newCount = lineEdit->text().toInt();
 		if (newCount != m_connectorCount) {
 			m_connectorCount = newCount;

--- a/src/partseditor/pegraphicsitem.cpp
+++ b/src/partseditor/pegraphicsitem.cpp
@@ -298,7 +298,7 @@ void PEGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent * event) {
 	}
 
 	InfoGraphicsView * infoGraphicsView = InfoGraphicsView::getInfoGraphicsView(this);
-	if (infoGraphicsView != NULL && infoGraphicsView->spaceBarIsPressed()) {
+	if (infoGraphicsView && infoGraphicsView->spaceBarIsPressed()) {
 		event->ignore();
 		return;
 	}

--- a/src/program/highlighter.cpp
+++ b/src/program/highlighter.cpp
@@ -132,7 +132,7 @@ void Highlighter::highlightBlock(const QString &text)
 		}
 		noComment.replace(startCommentIndex, commentLength, QString(commentLength, ' '));
 		QTextCharFormat * cf = m_styleFormats.value("Comment", NULL);
-		if (cf != NULL) {
+		if (cf) {
 			setFormat(startCommentIndex, commentLength, *cf);
 		}
 		m_syntaxer->matchCommentStart(text, startCommentIndex + commentLength, startCommentIndex, currentCommentInfo);
@@ -178,7 +178,7 @@ void Highlighter::highlightStrings(int startStringIndex, QString & text) {
 		}
 		text.replace(startStringIndex, stringLength, QString(stringLength, ' '));
 		QTextCharFormat * sf = m_styleFormats.value("String", NULL);
-		if (sf != NULL) {
+		if (sf) {
 			setFormat(startStringIndex, stringLength, *sf);
 		}
 		startStringIndex = m_syntaxer->matchStringStart(text, startStringIndex + stringLength);
@@ -198,10 +198,10 @@ void Highlighter::highlightTerms(const QString & text) {
 			TrieLeaf * leaf = NULL;
 			if (m_syntaxer->matches(text.mid(lastWordBreak, b - lastWordBreak), leaf)) {
 				SyntaxerTrieLeaf * stl = dynamic_cast<SyntaxerTrieLeaf *>(leaf);
-				if (stl != NULL) {
+				if (stl) {
 					QString format = Syntaxer::formatFromList(stl->name());
 					QTextCharFormat * tcf = m_styleFormats.value(format, NULL);
-					if (tcf != NULL) {
+					if (tcf) {
 						setFormat(lastWordBreak, b - lastWordBreak, *tcf);
 					}
 				}

--- a/src/program/programtab.cpp
+++ b/src/program/programtab.cpp
@@ -120,7 +120,7 @@ ProgramTab::ProgramTab(QString & filename, QWidget *parent) : QFrame(parent)
 	}
 
 	m_tabWidget = NULL;
-	while (parent != NULL) {
+	while (parent) {
 		QTabWidget * tabWidget = qobject_cast<QTabWidget *>(parent);
 		if (tabWidget) {
 			m_tabWidget = tabWidget;
@@ -393,7 +393,7 @@ void ProgramTab::setPlatform(Platform * newPlatform, bool updateLink) {
 		m_programWindow->updateLink(m_filename, newPlatform, false, false);
 	}
 
-	if (m_platform != NULL) m_platform->disconnect(SIGNAL(commandLocationChanged()));
+	if (m_platform) m_platform->disconnect(SIGNAL(commandLocationChanged()));
 	connect(newPlatform, SIGNAL(commandLocationChanged()), this, SLOT(enableProgramButton()));
 
 	m_platform = newPlatform;
@@ -405,7 +405,7 @@ void ProgramTab::setPlatform(Platform * newPlatform, bool updateLink) {
 	QSettings settings;
 	settings.setValue("programwindow/platform", newPlatform->getName());
 
-	//bool canProgram = (syntaxer != NULL && syntaxer->canProgram());
+	//bool canProgram = (syntaxer && syntaxer->canProgram());
 	//m_unableToProgramLabel->setVisible(!canProgram);
 	//m_unableToProgramLabel->setText(UnableToProgramMessage.arg(newPlatform.getName()));
 
@@ -736,7 +736,7 @@ void ProgramTab::sendProgram() {
 		//return;
 		save();
 	}
-	if (m_monitorWindow != NULL) {
+	if (m_monitorWindow) {
 		m_monitorWindow->closeSerialPort(m_portComboBox->currentText());
 	}
 

--- a/src/program/programwindow.cpp
+++ b/src/program/programwindow.cpp
@@ -716,7 +716,7 @@ Platform * ProgramWindow::getPlatformByName(const QString & platformName) {
 }
 
 bool ProgramWindow::hasPlatform(const QString & platformName) {
-	return getPlatformByName(platformName) != NULL;
+	return getPlatformByName(platformName);
 }
 
 const QMap<QString, QString> ProgramWindow::getBoards() {

--- a/src/referencemodel/sqlitereferencemodel.cpp
+++ b/src/referencemodel/sqlitereferencemodel.cpp
@@ -246,7 +246,7 @@ bool SqliteReferenceModel::loadFromDB(QSqlDatabase & keep_db, QSqlDatabase & db)
 		QString moduleID = query.value(ix++).toString();
 		qulonglong dbid = query.value(ix++).toULongLong();
 
-		if (m_partHash.value(moduleID, NULL) != NULL) {
+		if (m_partHash.value(moduleID, NULL)) {
 			// a part with this moduleID was already loaded--the file version overrides the db version
 			continue;
 		}

--- a/src/sketch/breadboardsketchwidget.cpp
+++ b/src/sketch/breadboardsketchwidget.cpp
@@ -222,7 +222,7 @@ void BreadboardSketchWidget::addDefaultParts() {
 
 void BreadboardSketchWidget::showEvent(QShowEvent * event) {
 	SketchWidget::showEvent(event);
-	if (m_addDefaultParts && (m_addedDefaultPart != NULL)) {
+	if (m_addDefaultParts && (m_addedDefaultPart)) {
 		m_addDefaultParts = false;
 		QSizeF partSize = m_addedDefaultPart->size();
 		QSizeF vpSize = this->viewport()->size();

--- a/src/sketch/pcbsketchwidget.cpp
+++ b/src/sketch/pcbsketchwidget.cpp
@@ -198,7 +198,7 @@ ViewLayer::ViewLayerID PCBSketchWidget::multiLayerGetViewLayerID(ModelPart * mod
 bool PCBSketchWidget::canDeleteItem(QGraphicsItem * item, int count)
 {
 	VirtualWire * wire = dynamic_cast<VirtualWire *>(item);
-	if (wire != NULL && count > 1) return false;
+	if (wire && count > 1) return false;
 
 	return SketchWidget::canDeleteItem(item, count);
 }
@@ -206,7 +206,7 @@ bool PCBSketchWidget::canDeleteItem(QGraphicsItem * item, int count)
 bool PCBSketchWidget::canCopyItem(QGraphicsItem * item, int count)
 {
 	VirtualWire * wire = dynamic_cast<VirtualWire *>(item);
-	if (wire != NULL) {
+	if (wire) {
 		if (wire->getRatsnest()) return false;
 	}
 
@@ -560,7 +560,7 @@ bool PCBSketchWidget::bothEndsConnectedAux(Wire * wire, ViewGeometry::WireFlags 
 bool PCBSketchWidget::canCreateWire(Wire * dragWire, ConnectorItem * from, ConnectorItem * to)
 {
 	Q_UNUSED(dragWire);
-	return ((from != NULL) && (to != NULL));
+	return ((from) && (to));
 }
 
 ConnectorItem * PCBSketchWidget::findNearestPartConnectorItem(ConnectorItem * fromConnectorItem) {
@@ -1037,7 +1037,7 @@ void PCBSketchWidget::changeTraceLayer(ItemBase * itemBase, bool force, QUndoCom
 	QSet<Wire *> changeWires;
 	TraceWire * sample = NULL;
 	QList<QGraphicsItem *> items;
-	if (itemBase != NULL) items << itemBase;
+	if (itemBase) items << itemBase;
 	else if (force) items = scene()->items();
 	else items =  scene()->selectedItems();
 	foreach (QGraphicsItem * item, items) {
@@ -1144,7 +1144,7 @@ void PCBSketchWidget::changeLayer(long id, double z, ViewLayer::ViewLayerID view
 	itemBase->saveGeometry();
 
 	TraceWire * tw = qobject_cast<TraceWire *>(itemBase);
-	if (tw != NULL) {
+	if (tw) {
 		ViewLayer::ViewLayerPlacement viewLayerPlacement = ViewLayer::specFromID(viewLayerID);
 		tw->setViewLayerPlacement(viewLayerPlacement);
 		tw->setColorString(traceColor(viewLayerPlacement), 1.0, true);
@@ -1336,7 +1336,7 @@ ItemBase * PCBSketchWidget::placePartDroppedInOtherView(ModelPart * modelPart, V
 			if (itemBase->layerKinChief() == newItem) continue;
 
 			Wire * wire = qobject_cast<Wire *>(itemBase);
-			if (wire != NULL) {
+			if (wire) {
 				if (!wire->getTrace()) continue;
 				if (!wire->isTraceType(getTraceFlag())) continue;
 			}
@@ -1355,7 +1355,7 @@ ItemBase * PCBSketchWidget::placePartDroppedInOtherView(ModelPart * modelPart, V
 		bestPlace.plane = plane;
 
 		TiSrArea(NULL, plane, &bestPlace.maxRect, Panelizer::placeBestFit, &bestPlace);
-		if (bestPlace.bestTile != NULL) {
+		if (bestPlace.bestTile) {
 			QRectF r;
 			tileToQRect(bestPlace.bestTile, r);
 			ItemBase * chief = newItem->layerKinChief();
@@ -1367,7 +1367,7 @@ ItemBase * PCBSketchWidget::placePartDroppedInOtherView(ModelPart * modelPart, V
 			alignOneToGrid(newItem);
 		}
 		router.drcClean();
-		if (bestPlace.bestTile != NULL) {
+		if (bestPlace.bestTile) {
 			break;
 		}
 	}
@@ -2203,7 +2203,7 @@ void PCBSketchWidget::shiftHoles() {
 
 bool PCBSketchWidget::canAlignToCenter(ItemBase * itemBase)
 {
-	return qobject_cast<Hole *>(itemBase) != NULL;
+	return qobject_cast<Hole *>(itemBase);
 }
 
 int PCBSketchWidget::selectAllItemType(ModelPart::ItemType itemType, const QString & typeName)
@@ -2316,7 +2316,7 @@ void PCBSketchWidget::convertToVia(ConnectorItem * lastHoverEnterConnectorItem) 
 		ConnectorItem * from = connectorItems.at(i);
 		foreach (ConnectorItem * to, from->connectedToItems()) {
 			Wire * w = qobject_cast<Wire *>(to->attachedTo());
-			if (w != NULL && w->isTraceType(getTraceFlag())) {
+			if (w && w->isTraceType(getTraceFlag())) {
 				if (!connectorItems.contains(to)) {
 					connectorItems.append(to);
 				}
@@ -2328,7 +2328,7 @@ void PCBSketchWidget::convertToVia(ConnectorItem * lastHoverEnterConnectorItem) 
 	foreach (ConnectorItem * from, connectorItems) {
 		foreach (ConnectorItem * to, from->connectedToItems()) {
 			Wire * w = qobject_cast<Wire *>(to->attachedTo());
-			if (w != NULL && w->isTraceType(getTraceFlag())) {
+			if (w && w->isTraceType(getTraceFlag())) {
 				new ChangeConnectionCommand(this, BaseCommand::CrossView, from->attachedToID(), from->connectorSharedID(),
 				                            to->attachedToID(), to->connectorSharedID(),
 				                            ViewLayer::specFromID(w->viewLayerID()),
@@ -2817,7 +2817,7 @@ void PCBSketchWidget::requestQuoteNow() {
 
 ItemBase * PCBSketchWidget::resizeBoard(long itemID, double mmW, double mmH) {
 	ItemBase * itemBase = SketchWidget::resizeBoard(itemID, mmW, mmH);
-	if (itemBase != NULL && Board::isBoard(itemBase)) requestQuoteSoon();
+	if (itemBase && Board::isBoard(itemBase)) requestQuoteSoon();
 	return itemBase;
 }
 

--- a/src/sketch/schematicsketchwidget.cpp
+++ b/src/sketch/schematicsketchwidget.cpp
@@ -252,7 +252,7 @@ void SchematicSketchWidget::setProp(ItemBase * itemBase, const QString & prop, c
 {
 	if (prop =="label") {
 		SymbolPaletteItem * sitem = qobject_cast<SymbolPaletteItem *>(itemBase);
-		if (sitem != NULL && sitem->isOnlyNetLabel()) {
+		if (sitem && sitem->isOnlyNetLabel()) {
 			if (sitem->getLabel() == newValue) {
 				return;
 			}
@@ -566,7 +566,7 @@ void SchematicSketchWidget::resizeLabels() {
 		ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
 		if (itemBase == NULL) continue;
 
-		if (itemBase->hasPartLabel() && itemBase->partLabel() != NULL) {
+		if (itemBase->hasPartLabel() && itemBase->partLabel()) {
 			itemBase->partLabel()->setFontPointSize(fontSize);
 		}
 	}

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -334,7 +334,7 @@ void SketchWidget::loadFromModelParts(QList<ModelPart *> & modelParts, BaseComma
 		if (parentCommand == NULL) {
 			viewGeometryConversionHack(viewGeometry, mp);
 			ItemBase * itemBase = addItemAux(mp, viewLayerPlacement, viewGeometry, newID, true, m_viewID, false);
-			if (itemBase != NULL) {
+			if (itemBase) {
 				if (locked) {
 					itemBase->setMoveLock(true);
 				}
@@ -360,7 +360,7 @@ void SketchWidget::loadFromModelParts(QList<ModelPart *> & modelParts, BaseComma
 				bool gotOne = false;
 				if (!gotOne) {
 					PaletteItem * paletteItem = qobject_cast<PaletteItem *>(itemBase);
-					if (paletteItem != NULL) {
+					if (paletteItem) {
 						// wires don't have transforms
 
 						//paletteItem->setTransforms();     // jrc 14 july 2013: this call seems redundant--transforms have already been set up by now
@@ -369,7 +369,7 @@ void SketchWidget::loadFromModelParts(QList<ModelPart *> & modelParts, BaseComma
 				}
 				if (!gotOne) {
 					Wire * wire = qobject_cast<Wire *>(itemBase);
-					if (wire != NULL) {
+					if (wire) {
 						QDomElement extras = view.firstChildElement("wireExtras");
 						wire->setExtras(extras, this);
 						gotOne = true;
@@ -377,7 +377,7 @@ void SketchWidget::loadFromModelParts(QList<ModelPart *> & modelParts, BaseComma
 				}
 				if (!gotOne) {
 					Note * note = qobject_cast<Note *>(itemBase);
-					if (note != NULL) {
+					if (note) {
 						note->setText(mp->instanceText(), true);
 						gotOne = true;
 					}
@@ -508,7 +508,7 @@ void SketchWidget::loadFromModelParts(QList<ModelPart *> & modelParts, BaseComma
 			z += ViewLayer::getZIncrement();
 		}
 		foreach (ViewLayer * viewLayer, m_viewLayers) {
-			if (viewLayer != NULL) viewLayer->resetNextZ(z);
+			if (viewLayer) viewLayer->resetNextZ(z);
 		}
 	}
 
@@ -723,7 +723,7 @@ ItemBase * SketchWidget::addItem(const QString & moduleID, ViewLayer::ViewLayerP
 	ItemBase * itemBase = NULL;
 	ModelPart * modelPart = m_referenceModel->retrieveModelPart(moduleID);
 
-	if (modelPart != NULL) {
+	if (modelPart) {
 		if (!m_blockUI) {
 			QApplication::setOverrideCursor(Qt::WaitCursor);
 			statusMessage(tr("loading part"));
@@ -745,7 +745,7 @@ ItemBase * SketchWidget::addItem(ModelPart * modelPart, ViewLayer::ViewLayerPlac
 	ItemBase * newItem = NULL;
 	//if (checkAlreadyExists) {
 	//	newItem = findItem(id);
-	//	if (newItem != NULL) {
+	//	if (newItem) {
 	//		newItem->debugInfo("already exists");
 	//	}
 	//}
@@ -860,14 +860,14 @@ void SketchWidget::checkSticky(long id, bool doEmit, bool checkCurrent, CheckSti
 		ItemBase * stickyOne = overSticky(itemBase);
 		ItemBase * wasStickyOne = itemBase->stickingTo();
 		if (stickyOne != wasStickyOne) {
-			if (wasStickyOne != NULL) {
+			if (wasStickyOne) {
 				wasStickyOne->addSticky(itemBase, false);
 				itemBase->addSticky(wasStickyOne, false);
 				if (checkStickyCommand) {
 					checkStickyCommand->stick(this, wasStickyOne->id(), itemBase->id(), false);
 				}
 			}
-			if (stickyOne != NULL) {
+			if (stickyOne) {
 				stickyOne->addSticky(itemBase, true);
 				itemBase->addSticky(stickyOne, true);
 				if (checkStickyCommand) {
@@ -994,7 +994,7 @@ ItemBase * SketchWidget::findItem(long id) {
 void SketchWidget::deleteItem(long id, bool deleteModelPart, bool doEmit, bool later) {
 	ItemBase * pitem = findItem(id);
 	DebugDialog::debug(QString("delete item (1) %1 %2 %3 %4").arg(id).arg(doEmit).arg(m_viewID).arg((long) pitem, 0, 16) );
-	if (pitem != NULL) {
+	if (pitem) {
 		deleteItem(pitem, deleteModelPart, doEmit, later);
 	}
 	else {
@@ -1022,7 +1022,7 @@ void SketchWidget::deleteItem(ItemBase * itemBase, bool deleteModelPart, bool do
 		itemBase->killRubberBandLeg();
 	}
 
-	if (m_infoView != NULL) {
+	if (m_infoView) {
 		m_infoView->unregisterCurrentItemIf(itemBase->id());
 	}
 	if (itemBase == this->m_lastPaletteItemSelected) {
@@ -1032,7 +1032,7 @@ void SketchWidget::deleteItem(ItemBase * itemBase, bool deleteModelPart, bool do
 
 	if (deleteModelPart) {
 		ModelPart * modelPart = itemBase->modelPart();
-		if (modelPart != NULL) {
+		if (modelPart) {
 			m_sketchModel->removeModelPart(modelPart);
 			delete modelPart;
 		}
@@ -1109,7 +1109,7 @@ void SketchWidget::cutDeleteAux(QString undoStackMessage, bool minus, Wire * wir
 	const QList<QGraphicsItem *> sitems = scene()->selectedItems();
 
 	QSet<ItemBase *> deletedItems;
-	if (minus && wire != NULL) {
+	if (minus && wire) {
 		// called from wire context menu "delete to bendpoint"
 		deletedItems.insert(wire);
 	}
@@ -1199,7 +1199,7 @@ void SketchWidget::deleteAux(QSet<ItemBase *> & deletedItems, QUndoCommand * par
 	new CleanUpWiresCommand(this, CleanUpWiresCommand::RedoOnly, parentCommand);
 
 	foreach (ItemBase * itemBase, deletedItems) {
-		if (itemBase->superpart() != NULL) {
+		if (itemBase->superpart()) {
 			AddSubpartCommand * asc = new AddSubpartCommand(this, BaseCommand::CrossView, itemBase->superpart()->id(), itemBase->id(), parentCommand);
 			asc->setUndoOnly();
 		}
@@ -1215,7 +1215,7 @@ void SketchWidget::deleteAux(QSet<ItemBase *> & deletedItems, QUndoCommand * par
 }
 
 bool isVirtualWireConnector(ConnectorItem * toConnectorItem) {
-	return (qobject_cast<VirtualWire *>(toConnectorItem->attachedTo()) != NULL);
+	return (qobject_cast<VirtualWire *>(toConnectorItem->attachedTo()));
 }
 
 void SketchWidget::deleteMiddle(QSet<ItemBase *> & deletedItems, QUndoCommand * parentCommand) {
@@ -1395,7 +1395,7 @@ ViewLayer::ViewLayerPlacement SketchWidget::createWireViewLayerPlacement(Connect
 
 void SketchWidget::moveItem(long id, ViewGeometry & viewGeometry, bool updateRatsnest) {
 	ItemBase * itemBase = findItem(id);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		if (updateRatsnest) {
 			ratsnestConnect(itemBase, true);
 		}
@@ -1406,7 +1406,7 @@ void SketchWidget::moveItem(long id, ViewGeometry & viewGeometry, bool updateRat
 
 void SketchWidget::simpleMoveItem(long id, QPointF p) {
 	ItemBase * itemBase = findItem(id);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		itemBase->setItemPos(p);
 		if (m_infoView) m_infoView->updateLocation(itemBase);
 	}
@@ -1414,7 +1414,7 @@ void SketchWidget::simpleMoveItem(long id, QPointF p) {
 
 void SketchWidget::moveItem(long id, const QPointF & p, bool updateRatsnest) {
 	ItemBase * itemBase = findItem(id);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		itemBase->setPos(p);
 		if (updateRatsnest) {
 			ratsnestConnect(itemBase, true);
@@ -1447,7 +1447,7 @@ void SketchWidget::rotateItem(long id, double degrees) {
 	if (!isVisible()) return;
 
 	ItemBase * itemBase = findItem(id);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		itemBase->rotateItem(degrees, false);
 		if (m_infoView) m_infoView->updateRotation(itemBase);
 	}
@@ -1455,7 +1455,7 @@ void SketchWidget::rotateItem(long id, double degrees) {
 }
 void SketchWidget::transformItem(long id, const QMatrix & matrix) {
 	ItemBase * itemBase = findItem(id);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		itemBase->transformItem2(matrix);
 		if (m_infoView) m_infoView->updateRotation(itemBase);
 	}
@@ -1467,7 +1467,7 @@ void SketchWidget::flipItem(long id, Qt::Orientations orientation) {
 	if (!isVisible()) return;
 
 	ItemBase * itemBase = findItem(id);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		itemBase->flipItem(orientation);
 		if (m_infoView) m_infoView->updateRotation(itemBase);
 		ratsnestConnect(itemBase, true);
@@ -1563,7 +1563,7 @@ void SketchWidget::changeLegAux(long fromID, const QString & fromConnectorID, co
 void SketchWidget::selectItem(long id, bool state, bool updateInfoView, bool doEmit) {
 	this->clearHoldingSelectItem();
 	ItemBase * item = findItem(id);
-	if (item != NULL) {
+	if (item) {
 		item->setSelected(state);
 		if(updateInfoView) {
 			// show something in the info view, even if it's not selected
@@ -1923,7 +1923,7 @@ void SketchWidget::dragLeaveEvent(QDragLeaveEvent * event) {
 	Q_UNUSED(event);
 	turnOffAutoscroll();
 
-	if (m_droppingItem != NULL) {
+	if (m_droppingItem) {
 		if (m_clearSceneRect) {
 			m_clearSceneRect = false;
 			scene()->setSceneRect(QRectF());
@@ -1983,7 +1983,7 @@ void SketchWidget::dragMoveHighlightConnector(QPoint eventPos) {
 	checkAutoscroll(m_globalPos);
 
 	QPointF loc = this->mapToScene(eventPos) - m_droppingOffset;
-	if (m_alignToGrid && (m_alignmentItem != NULL)) {
+	if (m_alignToGrid && (m_alignmentItem)) {
 		QPointF l =  m_alignmentItem->getViewGeometry().loc();
 		alignLoc(loc, m_alignmentStartPoint, loc, l);
 
@@ -2115,7 +2115,7 @@ void SketchWidget::dropItemEvent(QDropEvent *event) {
 		//connectorItem->setMarked(false);
 		//connectorItems.append(connectorItem);
 		ConnectorItem * to = connectorItem->overConnectorItem();
-		if (to != NULL) {
+		if (to) {
 			to->connectorHover(to->attachedTo(), false);
 			connectorItem->setOverConnectorItem(NULL);   // clean up
 			extendChangeConnectionCommand(BaseCommand::CrossView, connectorItem, to, ViewLayer::specFromID(connectorItem->attachedToViewLayerID()), true, parentCommand);
@@ -2195,7 +2195,7 @@ bool SketchWidget::moveByArrow(double dx, double dy, QKeyEvent * event) {
 		QPointF sp = this->mapToScene(wp);
 		Wire * wire = dynamic_cast<Wire *>(scene()->itemAt(sp, QTransform()));
 		bool draggingWire = false;
-		if (wire != NULL) {
+		if (wire) {
 			if (canChainWire(wire) && wire->hasConnections()) {
 				if (canDragWire(wire) && ((event->modifiers() & altOrMetaModifier()) != 0)) {
 					prepDragWire(wire);
@@ -2205,7 +2205,7 @@ bool SketchWidget::moveByArrow(double dx, double dy, QKeyEvent * event) {
 		}
 
 		if (!draggingWire) {
-			rubberBandLegEnabled = (event != NULL) && ((event->modifiers() & altOrMetaModifier()) != 0);
+			rubberBandLegEnabled = (event) && ((event->modifiers() & altOrMetaModifier()) != 0);
 			prepMove(NULL, rubberBandLegEnabled, true);
 		}
 		if (m_savedItems.count() == 0) return false;
@@ -2217,7 +2217,7 @@ bool SketchWidget::moveByArrow(double dx, double dy, QKeyEvent * event) {
 		//DebugDialog::debug("autorepeat");
 	}
 
-	if (event != NULL && (event->modifiers() & Qt::ShiftModifier)) {
+	if (event && (event->modifiers() & Qt::ShiftModifier)) {
 		dx *= 10;
 		dy *= 10;
 	}
@@ -2300,21 +2300,21 @@ void SketchWidget::mousePressEvent(QMouseEvent *event)
 		if (items.length() == 1) {
 			// if we unambiguously click on a partlabel whose owner is unselected, go ahead and activate it
 			PartLabel * partLabel =  dynamic_cast<PartLabel *>(items[0]);
-			if (partLabel != NULL) {
+			if (partLabel) {
 				partLabel->owner()->setSelected(true);
 				return;
 			}
 		}
 
 		clickBackground(event);
-		if (m_infoView != NULL) {
+		if (m_infoView) {
 			m_infoView->viewItemInfo(this, NULL, true);
 		}
 		return;
 	}
 
 	PartLabel * partLabel =  dynamic_cast<PartLabel *>(item);
-	if (partLabel != NULL) {
+	if (partLabel) {
 		viewItemInfo(partLabel->owner());
 		setLastPaletteItemSelectedIf(partLabel->owner());
 		return;
@@ -2322,7 +2322,7 @@ void SketchWidget::mousePressEvent(QMouseEvent *event)
 
 	// Note's child items (at the moment) are the resize grip and the text editor
 	Note * note = dynamic_cast<Note *>(item->parentItem());
-	if (note != NULL)  {
+	if (note)  {
 		return;
 	}
 
@@ -2340,12 +2340,12 @@ void SketchWidget::mousePressEvent(QMouseEvent *event)
 	}
 
 	ConnectorItem * connectorItem = dynamic_cast<ConnectorItem *>(wasItem);
-	if (connectorItem != NULL && connectorItem->isDraggingLeg()) {
+	if (connectorItem && connectorItem->isDraggingLeg()) {
 		return;
 	}
 
 	Wire * wire = dynamic_cast<Wire *>(item);
-	if ((event->button() == Qt::LeftButton) && (wire != NULL)) {
+	if ((event->button() == Qt::LeftButton) && (wire)) {
 		if (canChainWire(wire) && wire->hasConnections()) {
 			if (canDragWire(wire) && ((event->modifiers() & altOrMetaModifier()) != 0)) {
 				prepDragWire(wire);
@@ -2375,9 +2375,9 @@ void SketchWidget::mousePressEvent(QMouseEvent *event)
 		prepMove(itemBase ? itemBase : dynamic_cast<ItemBase *>(item->parentItem()), (event->modifiers() & altOrMetaModifier()) != 0, true);
 		if (m_alignToGrid && (itemBase == NULL) && (event->modifiers() == Qt::NoModifier)) {
 			Wire * wire = dynamic_cast<Wire *>(item->parentItem());
-			if (wire != NULL && wire->draggingEnd()) {
+			if (wire && wire->draggingEnd()) {
 				ConnectorItem * connectorItem = dynamic_cast<ConnectorItem *>(item);
-				if (connectorItem != NULL) {
+				if (connectorItem) {
 					m_draggingBendpoint = (connectorItem->connectionsCount() > 0);
 					this->m_alignmentStartPoint = mapToScene(event->pos()) - connectorItem->sceneAdjustedTerminalPoint(NULL);
 				}
@@ -2482,7 +2482,7 @@ void SketchWidget::prepMove(ItemBase * originatingItem, bool rubberBandLegEnable
 		foreach (ConnectorItem * connectorItem, itemBase->cachedConnectorItems()) {
 			bool gotOne = false;
 			foreach (ConnectorItem * toConnectorItem, connectorItem->connectedToItems()) {
-				if (m_savedItems.value(toConnectorItem->attachedToID(), NULL) != NULL) {
+				if (m_savedItems.value(toConnectorItem->attachedToID(), NULL)) {
 					m_checkUnder.removeAt(i);
 					gotOne = true;
 					break;
@@ -2743,7 +2743,7 @@ void SketchWidget::categorizeDragWires(QSet<Wire *> & wires, QList<ItemBase *> &
 			if (ct->status[i] != UNDETERMINED_) continue;
 
 			ItemBase * stickingTo = ct->wire->stickingTo();
-			if (stickingTo != NULL) {
+			if (stickingTo) {
 				QPointF p = from.at(i)->sceneAdjustedTerminalPoint(NULL);
 				if (stickingTo->contains(stickingTo->mapFromScene(p))) {
 					if (m_savedItems.keys().contains(stickingTo->layerKinChief()->id())) {
@@ -2973,7 +2973,7 @@ bool SketchWidget::checkUnder() {
 };
 
 bool SketchWidget::draggingWireEnd() {
-	if (m_connectorDragWire != NULL) return true;
+	if (m_connectorDragWire) return true;
 
 	QGraphicsItem * mouseGrabberItem = scene()->mouseGrabberItem();
 	Wire * wire = dynamic_cast<Wire *>(mouseGrabberItem);
@@ -3011,7 +3011,7 @@ void SketchWidget::mouseMoveEvent(QMouseEvent *event) {
 		//DebugDialog::debug(QString("pos= %1,%2").arg(posx).arg(posy));
 	}
 
-	if (m_dragBendpointWire != NULL) {
+	if (m_dragBendpointWire) {
 		Wire * tempWire = m_dragBendpointWire;
 		m_dragBendpointWire = NULL;
 		prepDragBendpoint(tempWire, m_dragBendpointPos, m_dragCurve);
@@ -3099,7 +3099,7 @@ QString SketchWidget::makeMoveSVG(double printerScale, double dpi, QPointF & off
 
 	foreach (ItemBase * itemBase, m_savedItems.values()) {
 		Wire * wire = qobject_cast<Wire *>(itemBase);
-		if (wire != NULL) {
+		if (wire) {
 			outputSVG.append(makeWireSVG(wire, offset, dpi, printerScale, true));
 		}
 		else {
@@ -3125,7 +3125,7 @@ void SketchWidget::moveItems(QPoint globalPos, bool checkAutoScrollFlag, bool ru
 	QPoint q = mapFromGlobal(globalPos);
 	QPointF scenePos = mapToScene(q);
 
-	if (m_alignToGrid && (m_alignmentItem != NULL)) {
+	if (m_alignToGrid && (m_alignmentItem)) {
 		QPointF currentParentPos = m_alignmentItem->mapToParent(m_alignmentItem->mapFromScene(scenePos));
 		QPointF buttonDownParentPos = m_alignmentItem->mapToParent(m_alignmentItem->mapFromScene(m_mousePressScenePos));
 		alignLoc(scenePos, m_alignmentStartPoint, currentParentPos, buttonDownParentPos);
@@ -3246,9 +3246,9 @@ void SketchWidget::mouseReleaseEvent(QMouseEvent *event) {
 
 	QGraphicsView::mouseReleaseEvent(event);
 
-	if (m_connectorDragWire != NULL) {
+	if (m_connectorDragWire) {
 		// remove again (may not have been removed earlier)
-		if (m_connectorDragWire->scene() != NULL) {
+		if (m_connectorDragWire->scene()) {
 			removeDragWire();
 			//m_infoView->unregisterCurrentItem();
 			updateInfoView();
@@ -3282,7 +3282,7 @@ void SketchWidget::mouseReleaseEvent(QMouseEvent *event) {
 	m_bendpointWire = NULL;
 
 	if (m_moveEventCount == 0) {
-		if (this->m_holdingSelectItemCommand != NULL) {
+		if (this->m_holdingSelectItemCommand) {
 			if (m_holdingSelectItemCommand->updated()) {
 				SelectItemCommand* tempCommand = m_holdingSelectItemCommand;
 				m_holdingSelectItemCommand = NULL;
@@ -3398,7 +3398,7 @@ bool SketchWidget::checkMoved(bool wait)
 			}
 
 			ConnectorItem * toConnectorItem = fromConnectorItem->overConnectorItem();
-			if (toConnectorItem != NULL) {
+			if (toConnectorItem) {
 				toConnectorItem->connectorHover(item, false);
 				fromConnectorItem->setOverConnectorItem(NULL);   // clean up
 				gotConnection = true;
@@ -3451,7 +3451,7 @@ void SketchWidget::setSketchModel(SketchModel * sketchModel) {
 }
 
 void SketchWidget::itemAddedSlot(ModelPart * modelPart, ItemBase *, ViewLayer::ViewLayerPlacement viewLayerPlacement, const ViewGeometry & viewGeometry, long id, SketchWidget * dropOrigin) {
-	if (dropOrigin != NULL && dropOrigin != this) {
+	if (dropOrigin && dropOrigin != this) {
 		placePartDroppedInOtherView(modelPart, viewLayerPlacement, viewGeometry, id, dropOrigin);
 	}
 	else {
@@ -3468,7 +3468,7 @@ ItemBase * SketchWidget::placePartDroppedInOtherView(ModelPart * modelPart, View
 	ViewGeometry vg(viewGeometry);
 	vg.setLoc(to + dp);
 	ItemBase * itemBase = addItemAux(modelPart, viewLayerPlacement, vg, id, true, m_viewID, false);
-	if (m_alignToGrid && (itemBase != NULL)) {
+	if (m_alignToGrid && (itemBase)) {
 		alignOneToGrid(itemBase);
 	}
 
@@ -3477,7 +3477,7 @@ ItemBase * SketchWidget::placePartDroppedInOtherView(ModelPart * modelPart, View
 
 void SketchWidget::itemDeletedSlot(long id) {
 	ItemBase * pitem = findItem(id);
-	if (pitem != NULL) {
+	if (pitem) {
 		deleteItem(pitem, false, false, false);
 	}
 }
@@ -3489,7 +3489,7 @@ void SketchWidget::selectionChangedSlot() {
 
 	emit selectionChangedSignal();
 
-	if (m_holdingSelectItemCommand != NULL) {
+	if (m_holdingSelectItemCommand) {
 		//DebugDialog::debug("update holding command");
 
 		int selCount = 0;
@@ -3518,7 +3518,7 @@ void SketchWidget::selectionChangedSlot() {
 
 void SketchWidget::clearHoldingSelectItem() {
 	// DebugDialog::debug("clear holding");
-	if (m_holdingSelectItemCommand != NULL) {
+	if (m_holdingSelectItemCommand) {
 		delete m_holdingSelectItemCommand;
 		m_holdingSelectItemCommand = NULL;
 	}
@@ -3535,8 +3535,8 @@ void SketchWidget::clearSelectionSlot() {
 
 void SketchWidget::itemSelectedSlot(long id, bool state) {
 	ItemBase * item = findItem(id);
-	//DebugDialog::debug(QString("got item selected signal %1 %2 %3 %4").arg(id).arg(state).arg(item != NULL).arg(m_viewID));
-	if (item != NULL) {
+	//DebugDialog::debug(QString("got item selected signal %1 %2 %3 %4").arg(id).arg(state).arg(item).arg(m_viewID));
+	if (item) {
 		item->setSelected(state);
 	}
 
@@ -3577,7 +3577,7 @@ void SketchWidget::prepLegBendpointMove(ConnectorItem * from, int index, QPointF
 
 	long toID = -1;
 	QString toConnectorID;
-	if (changeConnections && (to != NULL)) {
+	if (changeConnections && (to)) {
 		toID = to->attachedToID();
 		toConnectorID = to->connectorSharedID();
 	}
@@ -3632,7 +3632,7 @@ void SketchWidget::prepLegBendpointMove(ConnectorItem * from, int index, QPointF
 			}
 
 		}
-		if (to != NULL) {
+		if (to) {
 			ChangeConnectionCommand * ccc = extendChangeConnectionCommand(BaseCommand::CrossView, from, to, ViewLayer::specFromID(from->attachedToViewLayerID()), true, parentCommand);
 			ccc->setUpdateConnections(false);
 		}
@@ -3720,7 +3720,7 @@ void SketchWidget::wireChangedSlot(Wire* wire, const QLineF & oldLine, const QLi
 	}
 
 	clearDragWireTempCommand();
-	if ((to != NULL) && from->connectedToItems().contains(to)) {
+	if ((to) && from->connectedToItems().contains(to)) {
 		// there's no change: the wire was dragged back to its original connection
 		QList<ConnectorItem *> already;
 		from->attachedTo()->updateConnections(to, false, already);
@@ -3732,13 +3732,13 @@ void SketchWidget::wireChangedSlot(Wire* wire, const QLineF & oldLine, const QLi
 	long fromID = wire->id();
 
 	QString fromConnectorID;
-	if (from != NULL) {
+	if (from) {
 		fromConnectorID = from->connectorSharedID();
 	}
 
 	long toID = -1;
 	QString toConnectorID;
-	if (to != NULL) {
+	if (to) {
 		toID = to->attachedToID();
 		toConnectorID = to->connectorSharedID();
 	}
@@ -3809,7 +3809,7 @@ void SketchWidget::wireChangedSlot(Wire* wire, const QLineF & oldLine, const QLi
 			}
 
 		}
-		if (to != NULL) {
+		if (to) {
 			extendChangeConnectionCommand(BaseCommand::CrossView, from, to, ViewLayer::specFromID(wire->viewLayerID()), true, parentCommand);
 		}
 	}
@@ -3823,7 +3823,7 @@ void SketchWidget::wireChangedSlot(Wire* wire, const QLineF & oldLine, const QLi
 
 void SketchWidget::dragWireChanged(Wire* wire, ConnectorItem * fromOnWire, ConnectorItem * to)
 {
-	if (m_bendpointWire != NULL && wire->getRatsnest()) {
+	if (m_bendpointWire && wire->getRatsnest()) {
 		dragRatsnestChanged();
 		return;
 	}
@@ -3849,7 +3849,7 @@ void SketchWidget::dragWireChanged(Wire* wire, ConnectorItem * fromOnWire, Conne
 	parentCommand->setText(tr("Create and connect wire"));
 
 	SelectItemCommand * selectItemCommand = new SelectItemCommand(this, SelectItemCommand::NormalSelect, parentCommand);
-	if (m_tempDragWireCommand != NULL) {
+	if (m_tempDragWireCommand) {
 		selectItemCommand->copyUndo(m_tempDragWireCommand);
 		clearDragWireTempCommand();
 	}
@@ -3877,11 +3877,11 @@ void SketchWidget::dragWireChanged(Wire* wire, ConnectorItem * fromOnWire, Conne
 
 	if (m_bendpointWire == NULL) {
 		ConnectorItem * anchor = wire->otherConnector(fromOnWire);
-		if (anchor != NULL) {
+		if (anchor) {
 			extendChangeConnectionCommand(BaseCommand::CrossView, anchor, m_connectorDragConnector, ViewLayer::specFromID(wire->viewLayerID()), true, parentCommand);
 			doEmit = true;
 		}
-		if (to != NULL) {
+		if (to) {
 			extendChangeConnectionCommand(BaseCommand::CrossView, fromOnWire, to, ViewLayer::specFromID(wire->viewLayerID()), true, parentCommand);
 			doEmit = true;
 		}
@@ -4078,7 +4078,7 @@ void SketchWidget::setAllLayersVisible(bool visible) {
 
 	for (int i = 0; i < keys.count(); i++) {
 		ViewLayer * viewLayer = m_viewLayers.value(keys[i]);
-		if (viewLayer != NULL && viewLayer->action()->isEnabled()) {
+		if (viewLayer && viewLayer->action()->isEnabled()) {
 			setLayerVisible(viewLayer, visible, true);
 		}
 	}
@@ -4101,7 +4101,7 @@ ItemCount SketchWidget::calcItemCount() {
 
 	for (int i = 0; i < selItems.count(); i++) {
 		ItemBase * itemBase = ItemBase::extractTopLevelItemBase(selItems[i]);
-		if (itemBase != NULL) {
+		if (itemBase) {
 			itemCount.selCount++;
 
 			if (itemBase->moveLock()) {
@@ -4171,7 +4171,7 @@ ItemCount SketchWidget::calcItemCount() {
 	}
 	if (itemCount.selCount > 0) {
 		for (int i = 0; i < items.count(); i++) {
-			if (ItemBase::extractTopLevelItemBase(items[i]) != NULL) {
+			if (ItemBase::extractTopLevelItemBase(items[i])) {
 				itemCount.itemsCount++;
 			}
 		}
@@ -4265,7 +4265,7 @@ void SketchWidget::setLayerActive(ViewLayer * viewLayer, bool active) {
 	foreach (QGraphicsItem * item, scene()->items()) {
 		// want all items, not just topLevel
 		ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
-		if (itemBase != NULL) {
+		if (itemBase) {
 			//itemBase->debugInfo("setActive");
 			if (viewLayerIDs.contains(itemBase->viewLayerID())) {
 				itemBase->setInactive(!active);
@@ -4275,7 +4275,7 @@ void SketchWidget::setLayerActive(ViewLayer * viewLayer, bool active) {
 		}
 
 		PartLabel * partLabel = dynamic_cast<PartLabel *>(item);
-		if (partLabel != NULL) {
+		if (partLabel) {
 			if (viewLayerIDs.contains(partLabel->viewLayerID())) {
 				partLabel->setInactive(!active);
 			}
@@ -4401,7 +4401,7 @@ void SketchWidget::continueZChangeMax(QList<ItemBase *> & bases, int start, int 
 	for (int i = start; test(i, end); i += inc) {
 		ItemBase * base = bases[i];
 		if (!base->getViewGeometry().selected()) continue;
-		if (marked[base] != NULL) continue;
+		if (marked[base]) continue;
 
 		marked.insert(base, base);
 
@@ -4457,7 +4457,7 @@ void SketchWidget::continueZChangeAux(QList<ItemBase *> & bases, const QString &
 void SketchWidget::sortAnyByZ(const QList<QGraphicsItem *> & items, QList<ItemBase *> & bases) {
 	for (int i = 0; i < items.size(); i++) {
 		ItemBase * base = dynamic_cast<ItemBase *>(items[i]);
-		if (base != NULL) {
+		if (base) {
 			bases.append(base);
 			base->saveGeometry();
 		}
@@ -4544,7 +4544,7 @@ void SketchWidget::mousePressConnectorEvent(ConnectorItem * connectorItem, QGrap
 	// make sure wire layer is visible
 	ViewLayer::ViewLayerID viewLayerID = getDragWireViewLayerID(connectorItem);
 	ViewLayer * viewLayer = m_viewLayers.value(viewLayerID);
-	if (viewLayer != NULL && !viewLayer->visible()) {
+	if (viewLayer && !viewLayer->visible()) {
 		setLayerVisible(viewLayer, true, true);
 		emit updateLayerMenuSignal();
 	}
@@ -4848,7 +4848,7 @@ ConnectorItem * SketchWidget::findConnectorItem(ConnectorItem * foreignConnector
 ConnectorItem * SketchWidget::findConnectorItem(ItemBase * itemBase, const QString & connectorID, ViewLayer::ViewLayerPlacement viewLayerPlacement) {
 
 	ConnectorItem * connectorItem = itemBase->findConnectorItemWithSharedID(connectorID, viewLayerPlacement);
-	if (connectorItem != NULL) return connectorItem;
+	if (connectorItem) return connectorItem;
 
 	DebugDialog::debug("used to seek layer kin");
 	/*
@@ -4858,7 +4858,7 @@ ConnectorItem * SketchWidget::findConnectorItem(ItemBase * itemBase, const QStri
 
 		foreach (ItemBase * lkpi, pitem->layerKin()) {
 			connectorItem = lkpi->findConnectorItemWithSharedID(connectorID);
-			if (connectorItem != NULL) return connectorItem;
+			if (connectorItem) return connectorItem;
 		}
 
 	}
@@ -4876,7 +4876,7 @@ PaletteItem * SketchWidget::getSelectedPart() {
 		PaletteItem *temp = dynamic_cast<PaletteItem *>(items[i]);
 		if (temp == NULL) continue;
 
-		if (item != NULL) return NULL;  // there are multiple items selected
+		if (item) return NULL;  // there are multiple items selected
 		item = temp;
 	}
 
@@ -4986,7 +4986,7 @@ void SketchWidget::wireDisconnectedSlot(long fromID, QString fromConnectorID) {
 	}
 
 	ConnectorItem * toConnectorItem = fromConnectorItem->firstConnectedToIsh();
-	if (toConnectorItem != NULL) {
+	if (toConnectorItem) {
 		fromConnectorItem->removeConnection(toConnectorItem, true);
 		toConnectorItem->removeConnection(fromConnectorItem, true);
 	}
@@ -5164,7 +5164,7 @@ void SketchWidget::makeDeleteItemCommandPrepSlot(ItemBase * itemBase, bool forei
 	}
 
 	Note * note = qobject_cast<Note *>(itemBase);
-	if (note != NULL) {
+	if (note) {
 		ChangeNoteTextCommand * cntc = new ChangeNoteTextCommand(this, note->id(), note->text(), note->text(), QSizeF(), QSizeF(), parentCommand);
 		cntc->setSkipFirstRedo();
 	}
@@ -5237,7 +5237,7 @@ void SketchWidget::prepDeleteProps(ItemBase * itemBase, long id, const QString &
 
 	bool boardToCustomBoard = false;
 	ModelPart * mp = (newModuleID.isEmpty()) ? itemBase->modelPart() : referenceModel()->retrieveModelPart(newModuleID);
-	if (mp->itemType() == ModelPart::Logo && qobject_cast<Board *>(itemBase) != NULL) {
+	if (mp->itemType() == ModelPart::Logo && qobject_cast<Board *>(itemBase)) {
 		boardToCustomBoard = true;
 		mp = itemBase->modelPart();
 	}
@@ -5331,7 +5331,7 @@ void SketchWidget::prepDeleteProps(ItemBase * itemBase, long id, const QString &
 	}
 
 	Pad* pad = qobject_cast<Pad *>(itemBase);
-	if (pad != NULL) {
+	if (pad) {
 		pad->saveParams();
 		QPointF p;
 		QSizeF sz;
@@ -5342,14 +5342,14 @@ void SketchWidget::prepDeleteProps(ItemBase * itemBase, long id, const QString &
 	}
 
 	Resistor * resistor =  qobject_cast<Resistor *>(itemBase);
-	if (resistor != NULL) {
+	if (resistor) {
 		new SetResistanceCommand(this, id, resistor->resistance(), resistor->resistance(), resistor->pinSpacing(), resistor->pinSpacing(), parentCommand);
 		prepDeleteOtherProps(itemBase, id, newModuleID, propsMap, parentCommand);
 		return;
 	}
 
 	MysteryPart * mysteryPart = qobject_cast<MysteryPart *>(itemBase);
-	if (mysteryPart != NULL) {
+	if (mysteryPart) {
 		new SetPropCommand(this, id, "chip label", mysteryPart->chipLabel(), mysteryPart->chipLabel(), true, parentCommand);
 		prepDeleteOtherProps(itemBase, id, newModuleID, propsMap, parentCommand);
 		return;
@@ -5357,7 +5357,7 @@ void SketchWidget::prepDeleteProps(ItemBase * itemBase, long id, const QString &
 
 	/*
 	PinHeader * pinHeader = qobject_cast<PinHeader *>(itemBase);
-	if (pinHeader != NULL) {
+	if (pinHeader) {
 		// deal with old-style pin headers (pre 0.6.4)
 		new SetPropCommand(this, id, "form", pinHeader->form(), PinHeader::findForm(newModuleID), true, parentCommand);
 		prepDeleteOtherProps(itemBase, id, newModuleID, parentCommand);
@@ -5366,7 +5366,7 @@ void SketchWidget::prepDeleteProps(ItemBase * itemBase, long id, const QString &
 	*/
 
 	Hole * hole = qobject_cast<Hole *>(itemBase);
-	if (hole != NULL) {
+	if (hole) {
 		new SetPropCommand(this, id, "hole size", hole->holeSize(), hole->holeSize(), true, parentCommand);
 		prepDeleteOtherProps(itemBase, id, newModuleID, propsMap, parentCommand);
 		return;
@@ -5408,7 +5408,7 @@ void SketchWidget::prepDeleteOtherProps(ItemBase * itemBase, long id, const QStr
 		if (!newModuleID.isEmpty()) {
 			newValue = "";
 			ModelPart * newModelPart = m_referenceModel->retrieveModelPart(newModuleID);
-			if (newModelPart != NULL) {
+			if (newModelPart) {
 				newValue = newModelPart->properties().value(ModelPartShared::PartNumberPropertyName, "");
 			}
 		}
@@ -5434,7 +5434,7 @@ void SketchWidget::rememberSticky(ItemBase * itemBase, QUndoCommand * parentComm
 			checkStickyCommand->stick(this, itemBase->id(), sticking->id(), true);
 		}
 	}
-	else if (itemBase->stickingTo() != NULL) {
+	else if (itemBase->stickingTo()) {
 		checkStickyCommand->stick(this, itemBase->stickingTo()->id(), itemBase->id(), true);
 	}
 }
@@ -5469,7 +5469,7 @@ void SketchWidget::clearTemporaries() {
 
 void SketchWidget::killDroppingItem() {
 	m_alignmentItem = NULL;
-	if (m_droppingItem != NULL) {
+	if (m_droppingItem) {
 		m_droppingItem->removeLayerKin();
 		this->scene()->removeItem(m_droppingItem);
 		if (m_droppingItem->modelPart()) {
@@ -5740,7 +5740,7 @@ void SketchWidget::hoverEnterItem(QGraphicsSceneHoverEvent * event, ItemBase * i
 	}
 
 	Wire * wire = dynamic_cast<Wire *>(item);
-	if (wire != NULL) {
+	if (wire) {
 		if (canChainWire(wire)) {
 			bool segment = wire->connector0()->chained() && wire->connector1()->chained();
 			bool disconnected = wire->connector0()->connectionsCount() == 0 &&  wire->connector1()->connectionsCount() == 0;
@@ -5766,7 +5766,7 @@ void SketchWidget::statusMessage(QString message, int timeout)
 
 	if (m_statusConnectState == StatusConnectFailed) {
 		QStatusBar * sb = mainWindow->statusBar();
-		if (sb != NULL) {
+		if (sb) {
 			sb->showMessage(message, timeout);
 		}
 	}
@@ -6096,7 +6096,7 @@ void SketchWidget::setUpSwapReconnect(SwapThing & swapThing, ItemBase * itemBase
 
 
 			Wire * wire = qobject_cast<Wire *>(toConnectorItem->attachedTo());
-			if (wire != NULL) {
+			if (wire) {
 				if (wire->getRatsnest()) continue;
 
 				//if (newConnector == NULL && wire->getTrace() && wire->isTraceType(getTraceFlag())) {
@@ -6535,7 +6535,7 @@ void SketchWidget::resizeEvent(QResizeEvent * event) {
 //
 //	);
 
-	if (m_sizeItem != NULL) {
+	if (m_sizeItem) {
 		m_sizeItem->setLine(z.x(), z.y(), p.x(), p.y());
 	}
 
@@ -6683,7 +6683,7 @@ void SketchWidget::updateRoutingStatus(RoutingStatus & routingStatus, bool manua
 		//}
 
 		VirtualWire * vw = qobject_cast<VirtualWire *>(connectorItem->attachedTo());
-		if (vw != NULL) {
+		if (vw) {
 			if (vw->connector0()->connectionsCount() == 0 || vw->connector1()->connectionsCount() == 0) {
 				ratsToDelete.append(vw);
 			}
@@ -6759,7 +6759,7 @@ void SketchWidget::updateRoutingStatus(RoutingStatus & routingStatus, bool manua
 	}
 
 	foreach(QPointer<VirtualWire> vw, ratsToDelete) {
-		if (vw != NULL) {
+		if (vw) {
 			//vw->debugInfo("removing rat 2");
 			vw->scene()->removeItem(vw);
 			delete vw;
@@ -7093,7 +7093,7 @@ void SketchWidget::setInstanceTitle(long itemID, const QString & oldText, const 
 void SketchWidget::showPartLabel(long itemID, bool showIt) {
 
 	ItemBase * itemBase = findItem(itemID);
-	if (itemBase != NULL) {
+	if (itemBase) {
 		itemBase->showPartLabel(showIt, m_viewLayers.value(getLabelViewLayerID(itemBase)));
 	}
 }
@@ -7756,13 +7756,13 @@ void SketchWidget::resizeWithHandle(ItemBase * itemBase, double mmW, double mmH)
 void SketchWidget::addBendpoint(ItemBase * lastHoverEnterItem, ConnectorItem * lastHoverEnterConnectorItem, QPointF lastLocation) {
 	if (lastHoverEnterConnectorItem) {
 		Wire * wire = qobject_cast<Wire *>(lastHoverEnterConnectorItem->attachedTo());
-		if (wire != NULL) {
+		if (wire) {
 			wireJoinSlot(wire, lastHoverEnterConnectorItem);
 		}
 	}
 	else if (lastHoverEnterItem) {
 		Wire * wire = qobject_cast<Wire *>(lastHoverEnterItem);
-		if (wire != NULL) {
+		if (wire) {
 			wireSplitSlot(wire, lastLocation, wire->pos(), wire->line());
 		}
 	}
@@ -7779,7 +7779,7 @@ void SketchWidget::flattenCurve(ItemBase * lastHoverEnterItem, ConnectorItem * l
 		wire = qobject_cast<Wire *>(lastHoverEnterItem);
 	}
 
-	if (wire != NULL) {
+	if (wire) {
 		wireChangedCurveSlot(wire, wire->curve(), NULL, true);
 	}
 
@@ -7861,7 +7861,7 @@ bool SketchWidget::createOneTrace(Wire * wire, ViewGeometry::WireFlag flag, bool
 		return false;
 	}
 
-	if (trace != NULL) {
+	if (trace) {
 		removeWire(trace, ends, done, parentCommand);
 	}
 
@@ -7891,7 +7891,7 @@ void SketchWidget::selectAllWiresFrom(ViewGeometry::WireFlag flag, QList<QGraphi
 		if (wire == NULL) continue;
 
 		if (wire->hasFlag(flag)) {
-			if (wire->parentItem() != NULL) {
+			if (wire->parentItem()) {
 				// skip module wires
 				continue;
 			}
@@ -8037,11 +8037,11 @@ void SketchWidget::disconnectAllSlot(QList<ConnectorItem *> connectorItems, QHas
 		if (itemBase == NULL) continue;
 
 		ConnectorItem * fromConnectorItem = findConnectorItem(itemBase, ci->connectorSharedID(), ViewLayer::NewTop);
-		if (fromConnectorItem != NULL) {
+		if (fromConnectorItem) {
 			myConnectorItems.append(fromConnectorItem);
 		}
 		fromConnectorItem = findConnectorItem(itemBase, ci->connectorSharedID(), ViewLayer::NewBottom);
-		if (fromConnectorItem != NULL) {
+		if (fromConnectorItem) {
 			myConnectorItems.append(fromConnectorItem);
 		}
 	}
@@ -9129,7 +9129,7 @@ VirtualWire * SketchWidget::makeOneRatsnestWire(ConnectorItem * source, Connecto
 	if (source->attachedTo() == dest->attachedTo()) {
 		if (source == dest) return NULL;
 
-		if (source->bus() == dest->bus() && dest->bus() != NULL) {
+		if (source->bus() == dest->bus() && dest->bus()) {
 			if (!force) return NULL;				// don't draw a wire within the same part on the same bus
 		}
 	}
@@ -9279,7 +9279,7 @@ bool SketchWidget::canConnect(ItemBase * from, ItemBase * to) {
 	Wire * fromWire = qobject_cast<Wire *>(from);
 	Wire * toWire = qobject_cast<Wire *>(to);
 
-	if (fromWire != NULL && fromWire->getTrace()) {
+	if (fromWire && fromWire->getTrace()) {
 		if (fromWire->isTraceType(getTraceFlag())) {
 			return canConnect(fromWire, to);
 		}
@@ -9290,7 +9290,7 @@ bool SketchWidget::canConnect(ItemBase * from, ItemBase * to) {
 		}
 	}
 
-	if (toWire != NULL && toWire->getTrace()) {
+	if (toWire && toWire->getTrace()) {
 		if (toWire->isTraceType(getTraceFlag())) {
 			return canConnect(toWire, from);
 		}
@@ -9858,7 +9858,7 @@ void SketchWidget::squashShapes(QPointF scenePos)
 		}
 
 		wire = dynamic_cast<Wire *>(item);
-		if (wire != NULL && wire->acceptHoverEvents() && !wire->inactive() && !wire->hidden() && !wire->layerHidden()) break;
+		if (wire && wire->acceptHoverEvents() && !wire->inactive() && !wire->hidden() && !wire->layerHidden()) break;
 	}
 
 	if (ix == 0) {
@@ -9871,7 +9871,7 @@ void SketchWidget::squashShapes(QPointF scenePos)
 		for (ix = 0; ix < itms.count(); ix++) {
 			QGraphicsItem * item = itms.at(ix);
 			ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
-			if (itemBase != NULL) {
+			if (itemBase) {
 				if (itemBase->hidden() || itemBase->layerHidden() || itemBase->inactive()) continue;
 
 				QPainterPath painterPath = itemBase->mapToScene(itemBase->selectionShape());
@@ -9903,7 +9903,7 @@ void SketchWidget::squashShapes(QPointF scenePos)
 		ItemBase * itemBase = dynamic_cast<ItemBase *>(itms.at(i));
 		if (itemBase == NULL) continue;
 
-		if (connectorItem != NULL && connectorItem->parentItem() == itemBase) {
+		if (connectorItem && connectorItem->parentItem() == itemBase) {
 			if (firstTime) {
 				// topmost  contains connectorItem
 				return;
@@ -10133,9 +10133,9 @@ void SketchWidget::updateWires() {
 		if (!wire->isTraceType(traceFlag)) continue;
 
 		ConnectorItem * from = wire->connector0()->firstConnectedToIsh();
-		if (from != NULL) wire->connectedMoved(from, wire->connector0(), already);
+		if (from) wire->connectedMoved(from, wire->connector0(), already);
 		ConnectorItem * to = wire->connector1()->firstConnectedToIsh();
-		if (to != NULL) wire->connectedMoved(to, wire->connector1(), already);
+		if (to) wire->connectedMoved(to, wire->connector1(), already);
 	}
 }
 

--- a/src/utils/graphutils.cpp
+++ b/src/utils/graphutils.cpp
@@ -362,7 +362,7 @@ bool GraphUtils::chooseRatsnestGraph(const QList<ConnectorItem *> * partConnecto
 			edges[ix].first = i;
 			edges[ix].second = j;
 			ConnectorItem * c2 = temp.at(j);
-			if ((c1->attachedTo() == c2->attachedTo()) && (c1->bus() != NULL) && (c1->bus() == c2->bus())) {
+			if ((c1->attachedTo() == c2->attachedTo()) && (c1->bus()) && (c1->bus() == c2->bus())) {
 				weights[ix++] = 0;
 				continue;
 			}
@@ -488,7 +488,7 @@ bool GraphUtils::scoreOneNet(QList<ConnectorItem *> & partConnectorItems, ViewGe
 				continue;
 			}
 
-			if ((to->bus() != NULL) && (to->bus() == from->bus())) {
+			if ((to->bus()) && (to->bus() == from->bus())) {
 				add_edge_d(i, j, G);
 				add_edge_d(j, i, G);
 				continue;

--- a/src/utils/ratsnestcolors.cpp
+++ b/src/utils/ratsnestcolors.cpp
@@ -242,7 +242,7 @@ QString RatsnestColors::wireColor(ViewLayer::ViewID viewID, QString & string)
 	if (ratsnestColors == NULL) return ___emptyString___;
 
 	RatsnestColor * ratsnestColor = ratsnestColors->m_ratsnestColorHash.value(string.toLower(), NULL);
-	if (ratsnestColor != NULL) {
+	if (ratsnestColor) {
 		QString w = ratsnestColor->m_wire;
 		if (!w.isEmpty()) return w;
 	}

--- a/src/utils/resizehandle.cpp
+++ b/src/utils/resizehandle.cpp
@@ -97,12 +97,12 @@ void ResizeHandle::paint(QPainter *painter, const QStyleOptionGraphicsItem *opti
 {
 	if(scene()) {
 		FGraphicsScene * fscene = qobject_cast<FGraphicsScene *>(scene());
-		if (fscene != NULL && fscene->displayHandles()) {
+		if (fscene && fscene->displayHandles()) {
 			QGraphicsPixmapItem::paint(painter, option, widget);
 		}
 	}
 }
 
 bool ResizeHandle::scaling() {
-	return (this->flags() & QGraphicsItem::ItemIgnoresTransformations) && (scene() != NULL);
+	return (this->flags() & QGraphicsItem::ItemIgnoresTransformations) && (scene());
 }

--- a/src/version/updatedialog.cpp
+++ b/src/version/updatedialog.cpp
@@ -104,7 +104,7 @@ bool UpdateDialog::setAvailableReleases(const QList<AvailableRelease *> & availa
 			continue;
 		}
 
-		if (mainRelease != NULL && interimRelease != NULL) break;
+		if (mainRelease && interimRelease) break;
 	}
 
 	if (mainRelease == NULL && interimRelease == NULL) {
@@ -143,7 +143,7 @@ bool UpdateDialog::setAvailableReleases(const QList<AvailableRelease *> & availa
 
 void UpdateDialog::setVersionChecker(VersionChecker * versionChecker)
 {
-	if (m_versionChecker != NULL) {
+	if (m_versionChecker) {
 		m_versionChecker->stop();
 		delete m_versionChecker;
 		m_versionChecker = NULL;

--- a/src/waitpushundostack.cpp
+++ b/src/waitpushundostack.cpp
@@ -137,7 +137,7 @@ void WaitPushUndoStack::resolveTemporary() {
 }
 
 void WaitPushUndoStack::deleteTemporary() {
-	if (m_temporary != NULL) {
+	if (m_temporary) {
 		delete m_temporary;
 		m_temporary = NULL;
 	}


### PR DESCRIPTION
Okay, so my replacement of NULL with nullptr broke something badly. However, the replacement of != NULL/nullptr is successful. 