### PR TITLE
Reduce load times on part bins and any svg processing

### DIFF
--- a/src/fsvgrenderer.cpp
+++ b/src/fsvgrenderer.cpp
@@ -117,14 +117,6 @@ QByteArray FSvgRenderer::loadSvg(const QByteArray & contents, const LoadInfo & l
 QByteArray FSvgRenderer::loadAux(const QByteArray & theContents, const LoadInfo & loadInfo)
 {
 	QByteArray cleanContents(theContents);
-	bool cleaned = false;
-
-	QString string(cleanContents);
-    cleaned = TextUtils::fixMuchAndPixelDimensionsIn(string, false);
-	if (cleaned) {
-		cleanContents = string.toUtf8();
-	}
-
 	if (loadInfo.connectorIDs.count() > 0 || !loadInfo.setColor.isEmpty() || loadInfo.findNonConnectors) {
 		QString errorStr;
 		int errorLine;
@@ -133,6 +125,9 @@ QByteArray FSvgRenderer::loadAux(const QByteArray & theContents, const LoadInfo 
 		if (!doc.setContent(cleanContents, &errorStr, &errorLine, &errorColumn)) {
 			DebugDialog::debug(QString("renderer loadAux failed %1 %2 %3 %4").arg(loadInfo.filename).arg(errorStr).arg(errorLine).arg(errorColumn));
 		}
+
+        QString string(cleanContents);
+        TextUtils::fixMuchAndPixelDimensionsIn(string, doc, false);
 
 		bool resetContents = false;
 
@@ -158,22 +153,6 @@ QByteArray FSvgRenderer::loadAux(const QByteArray & theContents, const LoadInfo 
 			cleanContents = TextUtils::removeXMLEntities(doc.toString()).toUtf8();
 		}
 	}
-
-
-	/*
-	cleanContents = doc.toByteArray();
-
-	//QFile file("all.txt");
-	//if (file.open(QIODevice::Append)) {
-		//QTextStream t(&file);
-		//t << cleanContents;
-		//file.close();
-	//}
-
-	*/
-
-	//DebugDialog::debug(cleanContents.data());
-
 	return finalLoad(cleanContents, loadInfo.filename);
 }
 

--- a/src/fsvgrenderer.cpp
+++ b/src/fsvgrenderer.cpp
@@ -120,14 +120,6 @@ QByteArray FSvgRenderer::loadAux(const QByteArray & theContents, const LoadInfo 
 	bool cleaned = false;
 
 	QString string(cleanContents);
-#if 0
-	if (TextUtils::fixMuch(string, false)) {
-		cleaned = true;
-	}
-	if (TextUtils::fixPixelDimensionsIn(string)) {
-		cleaned = true;
-	}
-#endif
     cleaned = TextUtils::fixMuchAndPixelDimensionsIn(string, false);
 	if (cleaned) {
 		cleanContents = string.toUtf8();

--- a/src/fsvgrenderer.cpp
+++ b/src/fsvgrenderer.cpp
@@ -120,12 +120,15 @@ QByteArray FSvgRenderer::loadAux(const QByteArray & theContents, const LoadInfo 
 	bool cleaned = false;
 
 	QString string(cleanContents);
+#if 0
 	if (TextUtils::fixMuch(string, false)) {
 		cleaned = true;
 	}
 	if (TextUtils::fixPixelDimensionsIn(string)) {
 		cleaned = true;
 	}
+#endif
+    cleaned = TextUtils::fixMuchAndPixelDimensionsIn(string, false);
 	if (cleaned) {
 		cleanContents = string.toUtf8();
 	}

--- a/src/items/logoitem.cpp
+++ b/src/items/logoitem.cpp
@@ -363,8 +363,6 @@ void LogoItem::loadImage(const QString & fileName, bool addName)
 			return;
 		}
 
-		TextUtils::fixMuch(svg, true);
-		TextUtils::fixPixelDimensionsIn(svg);
 
 		QString errorStr;
 		int errorLine;
@@ -376,6 +374,9 @@ void LogoItem::loadImage(const QString & fileName, bool addName)
 			unableToLoad(fileName, tr("due to an xml problem: %1 line:%2 column:%3").arg(errorStr).arg(errorLine).arg(errorColumn));
 			return;
 		}
+        // if we can't even open the dom then there is no point in modifying it
+        // dump the svg output later on
+        TextUtils::fixMuchAndPixelDimensionsIn(svg, domDocument, true);
 
 		QDomElement root = domDocument.documentElement();
 		if (root.isNull()) {

--- a/src/model/modelpart.cpp
+++ b/src/model/modelpart.cpp
@@ -47,25 +47,18 @@ static const QList<ViewImage *> EmptyViewImages;
 ////////////////////////////////////////
 
 ModelPart::ModelPart(ItemType type)
-	: QObject()
+	: QObject(),
+    m_type(type),
+    m_index(m_nextIndex++)
 {
-	commonInit(type);
-	m_modelPartShared = nullptr;
-	m_index = m_nextIndex++;
 }
 
 ModelPart::ModelPart(QDomDocument & domDocument, const QString & path, ItemType type)
-	: QObject()
+	: QObject(),
+    m_type(type),
+    m_modelPartShared(new ModelPartShared(domDocument, path))
 {
-	commonInit(type);
-	m_modelPartShared = new ModelPartShared(domDocument, path);
 	m_modelPartShared->addOwner(this);
-}
-
-void ModelPart::commonInit(ItemType type) {
-	m_type = type;
-	m_locationFlags = 0;
-	m_indexSynched = false;
 }
 
 ModelPart::~ModelPart() {
@@ -91,37 +84,37 @@ ModelPart::~ModelPart() {
 }
 
 const QString & ModelPart::moduleID() const {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->moduleID();
+	if (m_modelPartShared) return m_modelPartShared->moduleID();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::label() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->label();
+	if (m_modelPartShared) return m_modelPartShared->label();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::author() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->author();
+	if (m_modelPartShared) return m_modelPartShared->author();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::taxonomy() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->taxonomy();
+	if (m_modelPartShared) return m_modelPartShared->taxonomy();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::uri() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->uri();
+	if (m_modelPartShared) return m_modelPartShared->uri();
 
 	return ___emptyString___;
 }
 
 const QDate & ModelPart::date() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->date();
+	if (m_modelPartShared) return m_modelPartShared->date();
 
 	static QDate tempDate;
 	tempDate = QDate::currentDate();
@@ -133,7 +126,7 @@ void ModelPart::setItemType(ItemType t) {
 }
 
 void ModelPart::copy(ModelPart * modelPart) {
-	if (modelPart == nullptr) return;
+	if (!modelPart) return;
 
 	m_type = modelPart->itemType();
 	m_modelPartShared = modelPart->modelPartShared();
@@ -214,7 +207,7 @@ void ModelPart::saveInstances(const QString & fileName, QXmlStreamWriter & strea
 		streamWriter.writeStartElement("instances");
 	}
 
-	if (parent() != nullptr) {  // m_viewItems.size() > 0
+	if (parent()) {  // m_viewItems.size() > 0
 		saveInstance(streamWriter);
 	}
 
@@ -226,7 +219,7 @@ void ModelPart::saveInstances(const QString & fileName, QXmlStreamWriter & strea
 	QList<QObject *>::const_iterator i;
 	for (i = children.constBegin(); i != children.constEnd(); ++i) {
 		ModelPart* mp = qobject_cast<ModelPart *>(*i);
-		if (mp == nullptr) continue;
+		if (!mp) continue;
 
 		mp->saveInstances(fileName, streamWriter, false);
 	}
@@ -246,7 +239,7 @@ void ModelPart::saveInstance(QXmlStreamWriter & streamWriter)
 	}
 
 	streamWriter.writeStartElement("instance");
-	if (m_modelPartShared != nullptr) {
+	if (m_modelPartShared) {
 		QString moduleIdRef = m_modelPartShared->moduleID();
 		moduleIdRef.remove(PartFactory::OldSchematicPrefix);
 		streamWriter.writeAttribute("moduleIdRef", moduleIdRef);
@@ -402,7 +395,7 @@ void ModelPart::saveAsPart(QXmlStreamWriter & streamWriter, bool startDocument) 
 	QList<QObject *>::const_iterator i;
 	for (i = children().constBegin(); i != children().constEnd(); ++i) {
 		ModelPart * mp = qobject_cast<ModelPart *>(*i);
-		if (mp == nullptr) continue;
+		if (!mp) continue;
 
 		mp->saveAsPart(streamWriter, false);
 	}
@@ -415,7 +408,7 @@ void ModelPart::saveAsPart(QXmlStreamWriter & streamWriter, bool startDocument) 
 }
 
 void ModelPart::initConnectors(bool force) {
-	if(m_modelPartShared == nullptr) return;
+	if(!m_modelPartShared) return;
 
 	if(force) {
 		foreach (Connector * connector, m_connectorHash.values()) {
@@ -446,9 +439,9 @@ void ModelPart::clearBuses() {
 void ModelPart::initBuses() {
 	foreach (Connector * connector, m_connectorHash.values()) {
 		BusShared * busShared = connector->connectorShared()->bus();
-		if (busShared != nullptr) {
+		if (busShared) {
 			Bus * bus = m_busHash.value(busShared->id());
-			if (bus == nullptr) {
+			if (!bus) {
 				bus = new Bus(busShared, this);
 				m_busHash.insert(busShared->id(), bus);
 			}
@@ -509,7 +502,7 @@ const QDomElement & ModelPart::instanceDomElement() {
 
 const QString & ModelPart::fritzingVersion() {
 
-	if (m_modelPartShared != nullptr) return m_modelPartShared->fritzingVersion();
+	if (m_modelPartShared) return m_modelPartShared->fritzingVersion();
 
 	return ___emptyString___;
 }
@@ -517,7 +510,7 @@ const QString & ModelPart::fritzingVersion() {
 const QString & ModelPart::title() {
 	if (!m_localTitle.isEmpty()) return m_localTitle;
 
-	if (m_modelPartShared != nullptr) return m_modelPartShared->title();
+	if (m_modelPartShared) return m_modelPartShared->title();
 
 	return m_localTitle;
 }
@@ -527,49 +520,49 @@ void ModelPart::setLocalTitle(const QString & localTitle) {
 }
 
 const QString & ModelPart::version() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->version();
+	if (m_modelPartShared) return m_modelPartShared->version();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::path() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->path();
+	if (m_modelPartShared) return m_modelPartShared->path();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::description() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->description();
+	if (m_modelPartShared) return m_modelPartShared->description();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::spice() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->spice();
+	if (m_modelPartShared) return m_modelPartShared->spice();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::spiceModel() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->spiceModel();
+	if (m_modelPartShared) return m_modelPartShared->spiceModel();
 
 	return ___emptyString___;
 }
 
 const QString & ModelPart::url() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->url();
+	if (m_modelPartShared) return m_modelPartShared->url();
 
 	return ___emptyString___;
 }
 
 const QStringList & ModelPart::tags() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->tags();
+	if (m_modelPartShared) return m_modelPartShared->tags();
 
 	return ___emptyStringList___;
 }
 
 const QHash<QString,QString> & ModelPart::properties() const {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->properties();
+	if (m_modelPartShared) return m_modelPartShared->properties();
 
 	return ___emptyStringHash___;
 }
@@ -587,7 +580,7 @@ Bus * ModelPart::bus(const QString & busID) {
 }
 
 bool ModelPart::ignoreTerminalPoints() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->ignoreTerminalPoints();
+	if (m_modelPartShared) return m_modelPartShared->ignoreTerminalPoints();
 
 	return true;
 }
@@ -690,7 +683,7 @@ QList<ModelPart*> ModelPart::getAllParts() {
 	QList<QObject *>::const_iterator i;
 	for (i = children().constBegin(); i != children().constEnd(); ++i) {
 		ModelPart* mp = qobject_cast<ModelPart *>(*i);
-		if (mp == nullptr) continue;
+		if (!mp) continue;
 		retval << mp;
 	}
 
@@ -702,7 +695,7 @@ QList<ModelPart*> ModelPart::getAllNonCoreParts() {
 	QList<QObject *>::const_iterator i;
 	for (i = children().constBegin(); i != children().constEnd(); ++i) {
 		ModelPart* mp = qobject_cast<ModelPart *>(*i);
-		if (mp == nullptr) continue;
+		if (!mp) continue;
 
 		if(!mp->isCore()) {
 			retval << mp;
@@ -735,14 +728,14 @@ void ModelPart::setInstanceText(QString text) {
 void ModelPart::clearOldInstanceTitle(const QString & title)
 {
 	InstanceTitleIncrementHash * itih = nullptr;
-	if (parent() == nullptr) {
+	if (!parent()) {
 		itih = &NullInstanceTitleIncrements;
 	}
 	else {
 		itih = AllInstanceTitleIncrements.value(parent(), nullptr);
 	}
 
-	if (itih == nullptr) return;
+	if (!itih) return;
 
 	//DebugDialog::debug(QString("clearing title:%1 ix:%2").arg(title).arg(modelPart->modelIndex()));
 	QString prefix = title;
@@ -760,20 +753,20 @@ void ModelPart::clearOldInstanceTitle(const QString & title)
 ModelPartList * ModelPart::ensureInstanceTitleIncrements(const QString & prefix)
 {
 	InstanceTitleIncrementHash * itih = nullptr;
-	if (parent() == nullptr) {
+	if (!parent()) {
 		itih = &NullInstanceTitleIncrements;
 	}
 	else {
 		itih = AllInstanceTitleIncrements.value(parent(), nullptr);
-		if (itih == nullptr) {
+		if (!itih) {
 			itih = new InstanceTitleIncrementHash;
 			AllInstanceTitleIncrements.insert(parent(), itih);
 		}
 	}
 
 	ModelPartList * modelParts = itih->value(prefix, nullptr);
-	if (modelParts == nullptr) {
-		modelParts =  new ModelPartList;
+	if (!modelParts) {
+		modelParts =  new ModelPartList();
 		itih->insert(prefix, modelParts);
 	}
 	return modelParts;
@@ -812,15 +805,15 @@ void ModelPart::setInstanceTitle(QString title, bool initial) {
 }
 
 bool ModelPart::setSubpartInstanceTitle() {
-	if (m_modelPartShared == nullptr) return false;
-	if (m_modelPartShared->superpart() == nullptr) return false;
+	if (!m_modelPartShared) return false;
+	if (!m_modelPartShared->superpart()) return false;
 	if (m_viewItems.count() <= 0) return false;
 
 	ItemBase * itemBase = m_viewItems.last();
-	if (itemBase == nullptr) return false;
+	if (!itemBase) return false;
 
 	itemBase = itemBase->superpart();
-	if (itemBase == nullptr) return false;
+	if (!itemBase) return false;
 
 	QString superTitle = itemBase->instanceTitle();
 	if (superTitle.isEmpty()) return false;
@@ -856,7 +849,7 @@ QString ModelPart::getNextTitle(const QString & title) {
 	int highestSoFar = 0;
 	bool gotNull = false;
 	foreach (ModelPart * modelPart, *modelParts) {
-		if (modelPart == nullptr) {
+		if (!modelPart) {
 			gotNull = true;
 			continue;
 		}
@@ -909,19 +902,19 @@ const QStringList & ModelPart::possibleFolders() {
 }
 
 const QString & ModelPart::replacedby() {
-	if (m_modelPartShared != nullptr) return m_modelPartShared->replacedby();
+	if (m_modelPartShared) return m_modelPartShared->replacedby();
 
 	return ___emptyString___;
 }
 
 bool ModelPart::isObsolete() {
-	if (m_modelPartShared != nullptr) return !m_modelPartShared->replacedby().isEmpty();
+	if (m_modelPartShared) return !m_modelPartShared->replacedby().isEmpty();
 
 	return false;
 }
 
 bool ModelPart::flippedSMD() {
-	if (m_modelPartShared != nullptr) {
+	if (m_modelPartShared) {
 		return m_modelPartShared->flippedSMD();
 	}
 
@@ -929,7 +922,7 @@ bool ModelPart::flippedSMD() {
 }
 
 bool ModelPart::needsCopper1() {
-	if (m_modelPartShared != nullptr) {
+	if (m_modelPartShared) {
 		return m_modelPartShared->needsCopper1();
 	}
 
@@ -937,25 +930,25 @@ bool ModelPart::needsCopper1() {
 }
 
 bool ModelPart::hasViewFor(ViewLayer::ViewID viewID) {
-	if (m_modelPartShared == nullptr) return false;
+	if (!m_modelPartShared) return false;
 
 	return m_modelPartShared->hasViewFor(viewID);
 }
 
 bool ModelPart::hasViewFor(ViewLayer::ViewID viewID, ViewLayer::ViewLayerID viewLayerID) {
-	if (m_modelPartShared == nullptr) return false;
+	if (!m_modelPartShared) return false;
 
 	return m_modelPartShared->hasViewFor(viewID, viewLayerID);
 }
 
 QString ModelPart::hasBaseNameFor(ViewLayer::ViewID viewID) {
-	if (m_modelPartShared == nullptr) return ___emptyString___;
+	if (!m_modelPartShared) return ___emptyString___;
 
 	return m_modelPartShared->hasBaseNameFor(viewID);
 }
 
 const QStringList & ModelPart::displayKeys() {
-	if (m_modelPartShared == nullptr) return ___emptyStringList___;
+	if (!m_modelPartShared) return ___emptyStringList___;
 
 	return m_modelPartShared->displayKeys();
 }

--- a/src/model/modelpart.h
+++ b/src/model/modelpart.h
@@ -37,7 +37,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "modelpartshared.h"
 #include "../connectors/connector.h"
 #include "../connectors/bus.h"
-
+class ItemBase;
 class ModelPart : public QObject
 {
 	Q_OBJECT
@@ -88,11 +88,11 @@ public:
 	void setModelPartShared(ModelPartShared *modelPartShared);
 	void saveInstances(const QString & fileName, QXmlStreamWriter & streamWriter, bool startDocument);
 	void saveAsPart(QXmlStreamWriter & streamWriter, bool startDocument);
-	void addViewItem(class ItemBase *);
-	void removeViewItem(class ItemBase *);
+	void addViewItem(ItemBase *);
+	void removeViewItem(ItemBase *);
 	void killViewItems();
-	class ItemBase * viewItem(QGraphicsScene * scene);
-	class ItemBase * viewItem(ViewLayer::ViewID);
+	ItemBase * viewItem(QGraphicsScene * scene);
+	ItemBase * viewItem(ViewLayer::ViewID);
 	bool hasViewItems();
 	void initConnectors(bool force=false);
 	const QHash<QString, QPointer<Connector> > & connectors();
@@ -205,24 +205,23 @@ protected:
 	void writeNestedTag(QXmlStreamWriter & streamWriter, QString tagName, const QStringList &values, QString childTag);
 	void writeNestedTag(QXmlStreamWriter & streamWriter, QString tagName, const QHash<QString,QString> &values, QString childTag, QString attrName);
 
-	void commonInit(ItemType type);
 	void saveInstance(QXmlStreamWriter & streamWriter);
 	QList< QPointer<ModelPart> > * ensureInstanceTitleIncrements(const QString & prefix);
 	void clearOldInstanceTitle(const QString & title);
 	bool setSubpartInstanceTitle();
 
 protected:
-	QList< QPointer<class ItemBase> > m_viewItems;
+	QList< QPointer<ItemBase> > m_viewItems;
 
 	ItemType m_type;
 	QPointer<ModelPartShared> m_modelPartShared;
 	QHash<QString, QPointer<Connector> > m_connectorHash;
 	QHash<QString, QPointer<Bus> > m_busHash;
-	long m_index;						// only used at save time to identify model parts in the xml
+	long m_index = 0;					// only used at save time to identify model parts in the xml
 	QDomElement m_instanceDomElement;	// only used at load time (so far)
 
-	LocationFlags m_locationFlags;
-	bool m_indexSynched;
+	LocationFlags m_locationFlags = 0;
+	bool m_indexSynched = false;
 
 	QString m_instanceTitle;
 	QString m_instanceText;

--- a/src/model/palettemodel.cpp
+++ b/src/model/palettemodel.cpp
@@ -157,10 +157,10 @@ int PaletteModel::countParts(const QDir & currentDir, const QStringList & nameFi
     return partCount;
 }
 
-int PaletteModel::loadPartsAux(const QDir & currentDirectory, QStringList & nameFilters, int partsLoadedSoFar, int totalPartCount) {
+int PaletteModel::loadPartsAux(const QDir & currentDirectory, const QStringList & nameFilters, int partsLoadedSoFar, int totalPartCount) {
 	//QString temp = dir.absolutePath();
     int loadingPart = partsLoadedSoFar;
-	QFileInfoList list = dir.entryInfoList(nameFilters, QDir::Files | QDir::NoSymLinks);
+	QFileInfoList list = currentDirectory.entryInfoList(nameFilters, QDir::Files | QDir::NoSymLinks);
     for (auto& fileInfo : list) {
 		auto path = fileInfo.absoluteFilePath();
 		//DebugDialog::debug(QString("part path:%1 core? %2").arg(path).arg(m_loadingCore? "true" : "false"));
@@ -172,7 +172,7 @@ int PaletteModel::loadPartsAux(const QDir & currentDirectory, QStringList & name
 		//DebugDialog::debug("loadedok");
 	}
 
-	QStringList dirs = dir.entryList(QDir::AllDirs | QDir::NoSymLinks | QDir::NoDotAndDotDot);
+	QStringList dirs = currentDirectory.entryList(QDir::AllDirs | QDir::NoSymLinks | QDir::NoDotAndDotDot);
     for (const auto& dir : dirs) {
         QDir childDirectory(currentDirectory);
         childDirectory.cd(dir);
@@ -223,13 +223,13 @@ ModelPart * PaletteModel::loadPart(const QString & path, bool update) {
 
 	if (root.tagName() != "module") {
 		//QMessageBox::information(NULL, QObject::tr("Fritzing"), QObject::tr("The file is not a Fritzing file (9)."));
-		return NULL;
+		return nullptr;
 	}
 
 	moduleID = root.attribute("moduleId");
 	if (moduleID.isNull() || moduleID.isEmpty()) {
 		//QMessageBox::information(NULL, QObject::tr("Fritzing"), QObject::tr("The file is not a Fritzing file (10)."));
-		return NULL;
+		return nullptr;
 	}
 
 	// check if it's a wire

--- a/src/model/palettemodel.cpp
+++ b/src/model/palettemodel.cpp
@@ -241,22 +241,22 @@ ModelPart * PaletteModel::loadPart(const QString & path, bool update) {
 	TextUtils::findText(t, title);
 
 	//DebugDialog::debug("module ID " + moduleID);
-    static QHash<QString, ModelPart> pureEqualityChecks = {
+    static QHash<QString, ModelPart::ItemType> pureEqualityChecks = {
         { ModuleIDNames::WireModuleIDName, ModelPart::Wire },
         { ModuleIDNames::JumperModuleIDName, ModelPart::Jumper },
         { ModuleIDNames::GroundPlaneModuleIDName, ModelPart::CopperFill },
         { ModuleIDNames::NoteModuleIDName, ModelPart::Note },
         { ModuleIDNames::GroundModuleIDName, ModelPart::Symbol },
         { ModuleIDNames::PowerLabelModuleIDName, ModelPart::Symbol },
-        { ModuleIDNames::RuleModuleIDName, ModelPart::Ruler },
+        { ModuleIDNames::RulerModuleIDName, ModelPart::Ruler },
         { ModuleIDNames::ViaModuleIDName, ModelPart::Via },
         { ModuleIDNames::HoleModuleIDName, ModelPart::Hole },
     };
-    auto isLogo = [](const QString& moduleId) noexcept {
+    auto isLogo = [](const QString& moduleID) noexcept {
         return moduleID.endsWith(ModuleIDNames::LogoImageModuleIDName) ||
                moduleID.endsWith(ModuleIDNames::LogoTextModuleIDName);
     };
-    auto isBreadboard = [&propertiesText](const QString& moduleId) noexcept {
+    auto isBreadboard = [&propertiesText](const QString& moduleID) noexcept {
         return moduleID.endsWith(ModuleIDNames::PerfboardModuleIDName) || 
             moduleID.endsWith(ModuleIDNames::StripboardModuleIDName) ||
             moduleID.endsWith(ModuleIDNames::Stripboard2ModuleIDName) ||
@@ -269,19 +269,19 @@ ModelPart * PaletteModel::loadPart(const QString & path, bool update) {
             return moduleId.endsWith(ModuleIDNames::PowerModuleIDName) ||
                    moduleId.endsWith(ModuleIDNames::NetLabelModuleIDName);
     };
-    if (pureEqualityChecks.contains(moduleId)) {
-        type = pureEqualityChecks.value(moduleId);
+    if (pureEqualityChecks.contains(moduleID)) {
+        type = pureEqualityChecks.value(moduleID);
     }
-    else if (isLogo(moduleId)) {
+    else if (isLogo(moduleID)) {
 		type = ModelPart::Logo;
 	}
-    else if (isPart(moduleId)) {
+    else if (isPart(moduleID)) {
 		type = ModelPart::Part;
 	}
-    else if (isSymbol(moduleId)) {
+    else if (isSymbol(moduleID)) {
 		type = ModelPart::Symbol;
 	}
-    else if (isBreadboard(moduleId) {
+    else if (isBreadboard(moduleID)) {
 		type = ModelPart::Breadboard;
 	}
 	else if (propertiesText.contains("plain vanilla pcb", Qt::CaseInsensitive)) {

--- a/src/model/palettemodel.h
+++ b/src/model/palettemodel.h
@@ -57,11 +57,11 @@ public:
 
 protected:
 	QHash<QString, ModelPart *> m_partHash;
-	bool m_loadedFromFile;
+	bool m_loadedFromFile = false;
 	QString m_loadedFrom; // The file this was loaded from, only if m_loadedFromFile == true
 
-	bool m_loadingContrib;
-	bool m_fullLoad;
+	bool m_loadingContrib = false;
+	bool m_fullLoad = false;
 
 signals:
 	void loadedPart(int i, int total);
@@ -73,7 +73,7 @@ protected:
 	virtual void initParts(bool dbExists);
 	void loadParts(bool dbExists);
 	void loadPartsAux(QDir & dir, QStringList & nameFilters, int & loadedPart, int totalParts);
-	void countParts(QDir & dir, QStringList & nameFilters, int & partCount);
+	int countParts(const QDir & dir, const QStringList & nameFilters) const;
 	ModelPart * makeSubpart(ModelPart * originalModelPart, const QDomElement & originalSubparth);
 
 public:

--- a/src/model/palettemodel.h
+++ b/src/model/palettemodel.h
@@ -72,7 +72,7 @@ signals:
 protected:
 	virtual void initParts(bool dbExists);
 	void loadParts(bool dbExists);
-	void loadPartsAux(QDir & dir, QStringList & nameFilters, int & loadedPart, int totalParts);
+	int loadPartsAux(const QDir & dir, const QStringList & nameFilters, int partsLoadedSoFar, int totalParts);
 	int countParts(const QDir & dir, const QStringList & nameFilters) const;
 	ModelPart * makeSubpart(ModelPart * originalModelPart, const QDomElement & originalSubparth);
 

--- a/src/partsbinpalette/partsbinpalettewidget.cpp
+++ b/src/partsbinpalette/partsbinpalettewidget.cpp
@@ -57,28 +57,13 @@ static QIcon EmptyIcon;
 
 //////////////////////////////////////////////
 
-PartsBinPaletteWidget::PartsBinPaletteWidget(ReferenceModel *referenceModel, HtmlInfoView *infoView, WaitPushUndoStack *undoStack, BinManager* manager) :
-	QFrame(manager)
+PartsBinPaletteWidget::PartsBinPaletteWidget(ReferenceModel *referenceModel, HtmlInfoView *infoView, WaitPushUndoStack * /* undoStack */, BinManager* manager) :
+	QFrame(manager),
+    m_referenceModel(referenceModel),
+    m_manager(manager)
 {
-	m_binLabel = NULL;
-	m_monoIcon = m_icon = NULL;
-	m_searchLineEdit = NULL;
-	m_saveQuietly = false;
-	m_fastLoaded = false;
-	m_model = NULL;
-
-	m_loadingProgressDialog = NULL;
-
 	setAcceptDrops(true);
 	setAllowsChanges(true);
-
-	m_manager = manager;
-
-	m_referenceModel = referenceModel;
-	m_canDeleteModel = false;
-	m_orderHasChanged = false;
-
-	Q_UNUSED(undoStack);
 
 	m_undoStack = new WaitPushUndoStack(this);
 	connect(m_undoStack, SIGNAL(cleanChanged(bool)), this, SLOT(undoStackCleanChanged(bool)) );
@@ -97,7 +82,6 @@ PartsBinPaletteWidget::PartsBinPaletteWidget(ReferenceModel *referenceModel, Htm
 	vbl->setMargin(3);
 	vbl->setSpacing(0);
 
-	m_header = NULL;
 	setupHeader();
 	if (m_header) {
 		vbl->addWidget(m_header);
@@ -141,7 +125,7 @@ PartsBinPaletteWidget::PartsBinPaletteWidget(ReferenceModel *referenceModel, Htm
 PartsBinPaletteWidget::~PartsBinPaletteWidget() {
 	if (m_canDeleteModel && m_model) {
 		delete m_model;
-		m_model = NULL;
+		m_model = nullptr;
 	}
 
 	if (m_icon) delete m_icon;
@@ -174,7 +158,7 @@ void PartsBinPaletteWidget::setTitle(const QString &title) {
 void PartsBinPaletteWidget::setupHeader()
 {
 	QMenu * combinedMenu = m_manager->combinedMenu();
-	if (combinedMenu == NULL) return;
+	if (!combinedMenu) return;
 
 	m_combinedBinMenuButton = newToolButton("partsBinCombinedMenuButton", ___emptyString___, ___emptyString___);
 	m_combinedBinMenuButton->setMenu(combinedMenu);
@@ -360,7 +344,7 @@ void PartsBinPaletteWidget::grabTitle(const QString & title, QString & iconFilen
 }
 
 void PartsBinPaletteWidget::addPart(ModelPart *modelPart, int position) {
-	if (m_model == NULL) {
+	if (!m_model) {
 		return;
 	}
 
@@ -450,14 +434,14 @@ bool PartsBinPaletteWidget::loadBundledAux(QDir &unzipDir, QList<ModelPart*> mps
 bool PartsBinPaletteWidget::open(QString fileName, QWidget * progressTarget, bool fastLoad) {
 	QFile file(fileName);
 	if (!file.exists()) {
-		QMessageBox::warning(NULL, tr("Fritzing"),
+		QMessageBox::warning(nullptr, tr("Fritzing"),
 		                     tr("Cannot find file %1.")
 		                     .arg(fileName));
 		return false;
 	}
 
 	if (!file.open(QFile::ReadOnly | QFile::Text)) {
-		QMessageBox::warning(NULL, tr("Fritzing"),
+		QMessageBox::warning(nullptr, tr("Fritzing"),
 		                     tr("Cannot read file %1:\n%2.")
 		                     .arg(fileName)
 		                     .arg(file.errorString()));
@@ -496,7 +480,7 @@ void PartsBinPaletteWidget::load(const QString &filename, QWidget * progressTarg
 
 	m_fastLoaded = false;
 	PaletteModel * paletteBinModel = PaletteBinModels.value(filename);
-	if (paletteBinModel == NULL) {
+	if (!paletteBinModel) {
 		paletteBinModel = new PaletteModel(true, false);
 		//DebugDialog::debug("after palette model");
 
@@ -525,7 +509,7 @@ void PartsBinPaletteWidget::load(const QString &filename, QWidget * progressTarg
 		//DebugDialog::debug(QString("done loading bin '%1'").arg(name));
 
 		if (!result) {
-			QMessageBox::warning(NULL, QObject::tr("Fritzing"), QObject::tr("Fritzing cannot load the parts bin"));
+			QMessageBox::warning(nullptr, QObject::tr("Fritzing"), QObject::tr("Fritzing cannot load the parts bin"));
 		}
 		else {
 			m_fileName = filename;
@@ -543,7 +527,7 @@ void PartsBinPaletteWidget::load(const QString &filename, QWidget * progressTarg
 				m_loadingProgressDialog->close();
 				delete m_loadingProgressDialog;
 			}
-			m_loadingProgressDialog = NULL;
+			m_loadingProgressDialog = nullptr;
 		}
 	}
 	else {
@@ -780,7 +764,7 @@ void PartsBinPaletteWidget::setFilename(const QString &filename) {
 
 void PartsBinPaletteWidget::search() {
 	SearchLineEdit * edit = qobject_cast<SearchLineEdit *>(sender());
-	if (edit == NULL) return;
+	if (!edit) return;
 
 	QString searchText = edit->text();
 	if (searchText.isEmpty()) return;
@@ -793,19 +777,11 @@ void PartsBinPaletteWidget::search() {
 	m_manager->search(searchText);
 }
 
-bool PartsBinPaletteWidget::allowsChanges() {
-	return m_allowsChanges;
-}
-
-bool PartsBinPaletteWidget::readOnly() {
-	return !allowsChanges();
-}
-
-void PartsBinPaletteWidget::setAllowsChanges(bool allowsChanges) {
+void PartsBinPaletteWidget::setAllowsChanges(bool allowsChanges) noexcept {
 	m_allowsChanges = allowsChanges;
 }
 
-void PartsBinPaletteWidget::setReadOnly(bool readOnly) {
+void PartsBinPaletteWidget::setReadOnly(bool readOnly) noexcept {
 	setAllowsChanges(!readOnly);
 }
 
@@ -828,7 +804,7 @@ void PartsBinPaletteWidget::setSaveQuietly(bool saveQuietly) {
 }
 
 bool PartsBinPaletteWidget::currentViewIsIconView() {
-	if (m_currentView == NULL) return true;
+	if (!m_currentView) return true;
 
 	return (m_currentView == m_iconView);
 }
@@ -862,7 +838,7 @@ QMenu * PartsBinPaletteWidget::partContextMenu()
 QMenu * PartsBinPaletteWidget::binContextMenu()
 {
 	QMenu * menu = m_manager->binContextMenu(this);
-	if (menu == NULL) return NULL;
+	if (!menu) return nullptr;
 
 	QMenu * newMenu = new QMenu();
 	foreach (QAction * action, menu->actions()) {
@@ -871,7 +847,7 @@ QMenu * PartsBinPaletteWidget::binContextMenu()
 
 	// TODO: need to enable/disable actions based on this bin
 
-	ModelPartSharedRoot * root = (m_model == NULL) ? NULL : m_model->rootModelPartShared();
+	ModelPartSharedRoot * root = (!m_model) ? nullptr : m_model->rootModelPartShared();
 	if (root) {
 		QString iconFilename = root->icon();
 		if (iconFilename.compare(CustomIconName) == 0 || isCustomSvg(iconFilename)) {
@@ -962,7 +938,7 @@ void PartsBinPaletteWidget::copyFilesToContrib(ModelPart * mp, QWidget * origina
 }
 
 ModelPart * PartsBinPaletteWidget::root() {
-	if (m_model == NULL) return NULL;
+	if (!m_model) return nullptr;
 
 	return m_model->root();
 }
@@ -978,9 +954,9 @@ void PartsBinPaletteWidget::reloadPart(const QString & moduleID) {
 
 QList<ModelPart *> PartsBinPaletteWidget::getAllParts() {
 	QList<ModelPart*> empty;
-	if (m_model == NULL) return empty;
+	if (!m_model) return empty;
 
-	if (m_model->root() == NULL) return empty;
+	if (!m_model->root()) return empty;
 
 	return m_model->root()->getAllParts();
 }

--- a/src/partsbinpalette/partsbinpalettewidget.cpp
+++ b/src/partsbinpalette/partsbinpalettewidget.cpp
@@ -496,9 +496,6 @@ void PartsBinPaletteWidget::load(const QString &filename, QWidget * progressTarg
 			m_loadingProgressDialog->setBinLoadingCount(1);
 			m_loadingProgressDialog->setMessage(tr("loading bin '%1'").arg(name));
 			m_loadingProgressDialog->show();
-		}
-
-		if (progressTarget) {
 			connect(paletteBinModel, SIGNAL(loadingInstances(ModelBase *, QDomElement &)), progressTarget, SLOT(loadingInstancesSlot(ModelBase *, QDomElement &)));
 			connect(paletteBinModel, SIGNAL(loadingInstance(ModelBase *, QDomElement &)), progressTarget, SLOT(loadingInstanceSlot(ModelBase *, QDomElement &)));
 			connect(m_iconView, SIGNAL(settingItem()), progressTarget, SLOT(settingItemSlot()));

--- a/src/partsbinpalette/partsbinpalettewidget.h
+++ b/src/partsbinpalette/partsbinpalettewidget.h
@@ -74,7 +74,7 @@ public:
 	void load(const QString& filename, QWidget * progressTarget, bool fastLoad);
 
 	bool contains(const QString &moduleID);
-	void setDirty(bool dirty=true);
+	void setDirty(bool dirty = true);
 
 	const QString &fileName();
 
@@ -160,7 +160,7 @@ protected:
 	QString m_untitledFileName;
 
 	QString m_title;
-	bool m_isDirty;
+	bool m_isDirty = false;
 
 	PartsBinView *m_currentView = nullptr;
 	PartsBinIconView *m_iconView = nullptr;

--- a/src/partsbinpalette/partsbinpalettewidget.h
+++ b/src/partsbinpalette/partsbinpalettewidget.h
@@ -34,11 +34,18 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../utils/bundler.h"
 #include "binmanager/binmanager.h"
 
+class ReferenceModel;
+class HtmlInfoView;
+class BinManager;
+class PartsBinView;
+class PartsBinIconView;
+class PartsBinListView;
+class SearchLineEdit;
 class PartsBinPaletteWidget : public QFrame, public Bundler {
 	Q_OBJECT
 
 public:
-	PartsBinPaletteWidget(class ReferenceModel *referenceModel, class HtmlInfoView *infoView, WaitPushUndoStack *undoStack, class BinManager* manager);
+	PartsBinPaletteWidget(ReferenceModel *referenceModel, HtmlInfoView *infoView, WaitPushUndoStack *undoStack, BinManager* manager);
 	~PartsBinPaletteWidget();
 
 	QSize sizeHint() const;
@@ -71,12 +78,12 @@ public:
 
 	const QString &fileName();
 
-	class PartsBinView *currentView();
+	PartsBinView *currentView();
 	QAction *addPartToMeAction();
-	bool allowsChanges();
-	bool readOnly();
-	void setAllowsChanges(bool);
-	void setReadOnly(bool);
+	constexpr bool allowsChanges() const noexcept { return m_allowsChanges; }
+	constexpr bool readOnly() const noexcept { return !m_allowsChanges; }
+	void setAllowsChanges(bool) noexcept;
+	void setReadOnly(bool) noexcept;
 	void focusSearch();
 	void setSaveQuietly(bool);
 	bool open(QString fileName, QWidget * progressTarget, bool fastLoad);
@@ -131,7 +138,7 @@ protected:
 	void grabTitle(PaletteModel *model);
 	void grabTitle(const QString & title, QString & iconFilename);
 
-	void setView(class PartsBinView *view);
+	void setView(PartsBinView *view);
 	bool saveAsAux(const QString &filename);
 
 	void afterModelSetted(PaletteModel *model);
@@ -143,10 +150,10 @@ protected:
 	void setFilename(const QString &filename);
 
 protected:
-	PaletteModel *m_model;
-	ReferenceModel *m_referenceModel;
-	bool m_canDeleteModel;
-	bool m_orderHasChanged;
+	PaletteModel *m_model = nullptr;
+	ReferenceModel *m_referenceModel = nullptr;
+	bool m_canDeleteModel = false;
+	bool m_orderHasChanged = false;
 
 	QString m_fileName;
 	QString m_defaultSaveFolder;
@@ -155,31 +162,31 @@ protected:
 	QString m_title;
 	bool m_isDirty;
 
-	PartsBinView *m_currentView;
-	class PartsBinIconView *m_iconView;
-	class PartsBinListView *m_listView;
+	PartsBinView *m_currentView = nullptr;
+	PartsBinIconView *m_iconView = nullptr;
+	PartsBinListView *m_listView = nullptr;
 
-	QFrame *m_header;
-	QLabel * m_binLabel;
+	QFrame * m_header = nullptr;
+	QLabel * m_binLabel = nullptr;
 
-	class SearchLineEdit * m_searchLineEdit;
+	SearchLineEdit * m_searchLineEdit = nullptr;
 
-	QToolButton * m_combinedBinMenuButton;
+	QToolButton * m_combinedBinMenuButton = nullptr;
 
-	WaitPushUndoStack *m_undoStack;
-	BinManager *m_manager;
+	WaitPushUndoStack *m_undoStack = nullptr;
+	BinManager *m_manager = nullptr;
 
 	QStringList m_alienParts;
-	bool m_allowsChanges;
-	bool m_saveQuietly;
+	bool m_allowsChanges = false;
+	bool m_saveQuietly = false;
 
-	FileProgressDialog * m_loadingProgressDialog;
-	QIcon * m_icon;
-	QIcon * m_monoIcon;
-	QAction *m_addPartToMeAction;
-	QStackedWidget * m_stackedWidget;
-	QStackedWidget * m_searchStackedWidget;
-	bool m_fastLoaded;
+	FileProgressDialog * m_loadingProgressDialog = nullptr;
+	QIcon * m_icon = nullptr;
+	QIcon * m_monoIcon = nullptr;
+	QAction *m_addPartToMeAction = nullptr;
+	QStackedWidget * m_stackedWidget = nullptr;
+	QStackedWidget * m_searchStackedWidget = nullptr;
+	bool m_fastLoaded = false;
 	BinLocation::Location m_location;
 	QStringList m_removed;
 

--- a/src/partseditor/pemainwindow.cpp
+++ b/src/partseditor/pemainwindow.cpp
@@ -1637,7 +1637,7 @@ void PEMainWindow::loadImage()
 			return;
 		}
 	}
-
+    /// @todo hmmm, we are making two copies of this svg's dom, how to fix this...
 	TextUtils::fixMuch(svg, true);
 	insertDesc(newReferenceFile, svg);
 	QString newPath = m_userPartsFolderSvgPath + makeSvgPath2(m_currentGraphicsView);

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -7315,13 +7315,12 @@ QString SketchWidget::renderToSVG(RenderThing & renderThing, QList<QGraphicsItem
 			QString itemSvg = itemBase->retrieveSvg(itemBase->viewLayerID(), svgHash, renderThing.blackOnly, renderThing.dpi, factor);
 			if (itemSvg.isEmpty()) continue;
 
-			TextUtils::fixMuch(itemSvg, false);
-
 			QDomDocument doc;
 			QString errorStr;
 			int errorLine;
 			int errorColumn;
 			if (doc.setContent(itemSvg, &errorStr, &errorLine, &errorColumn)) {
+                TextUtils::fixMuch(itemSvg, doc, false);
 				bool changed = false;
 				if (renderThing.renderBlocker) {
 					Pad * pad = qobject_cast<Pad *>(itemBase);

--- a/src/utils/textutils.cpp
+++ b/src/utils/textutils.cpp
@@ -1041,12 +1041,15 @@ bool TextUtils::fixMuch(QString &svg, bool fixStrokeWidthFlag)
 
 	QDomElement root = svgDom.documentElement();
 	result |= fixViewBox(root);
-
-	QStringList strings;
-	strings << "pattern" << "marker" << "clipPath";
-	foreach (QString string, strings) {
-		if (svg.contains("<" + string)) {
-			result |= noPatternAux(svgDom, string);
+    // only set this table up once 
+    static std::array<std::pair<QString, QString>, 3> lookupTable = {
+        std::make_pair("<pattern", "pattern" ),
+        std::make_pair("<marker", "marker" ),
+        std::make_pair("<clipPath", "clipPath" ),
+    };
+    for (const auto & lookup : lookupTable) {
+		if (svg.contains(lookup.first)) {
+			result |= noPatternAux(svgDom, lookup.second);
 		}
 	}
 

--- a/src/utils/textutils.cpp
+++ b/src/utils/textutils.cpp
@@ -1059,20 +1059,21 @@ bool TextUtils::fixMuchAndPixelDimensionsIn(QString& svg, bool fixStrokeWidth) {
     bool result = cleanSodipodi(svg);
     result |= fixInternalUnits(svg);
 	QDomDocument svgDom;
-	QString errorMsg;
-	int errorLine;
-	int errorCol;
-	if(!svgDom.setContent(svg, true, &errorMsg, &errorLine, &errorCol)) {
+	if(!svgDom.setContent(svg, true)) {
 		return result;
 	}
-
-    result |= fixMuch(svg, svgDom, fixStrokeWidth);
-	result |= fixPixelDimensionsIn(svgDom, isIllustratorFile(svg));
+    result |= fixMuchAndPixelDimensionsIn(svg, svgDom, fixStrokeWidth);
 
 	if (result) {
 		svg = removeXMLEntities(svgDom.toString());
 	}
 
+	return result;
+}
+
+bool TextUtils::fixMuchAndPixelDimensionsIn(const QString& svg, QDomDocument& svgDom, bool fixStrokeWidth) {
+    auto result = fixMuch(svg, svgDom, fixStrokeWidth);
+	result |= fixPixelDimensionsIn(svgDom, isIllustratorFile(svg));
 	return result;
 }
 

--- a/src/utils/textutils.h
+++ b/src/utils/textutils.h
@@ -110,6 +110,7 @@ public:
 	static bool fixMuch(QString &svg, bool fixStrokeWidth);
 	static bool fixMuch(const QString& svg, QDomDocument& svgDom, bool fixStrokeWidth);
     static bool fixMuchAndPixelDimensionsIn(QString& svg, bool fixStrokeWidth);
+    static bool fixMuchAndPixelDimensionsIn(const QString& svg, QDomDocument& svgDom, bool fixStrokeWidth);
 	static bool fixInternalUnits(QString & svg);
 	static bool fixFonts(QString & svg, const QString & destFont, bool & reallyFixed);
 	static void fixStyleAttribute(QDomElement & element);

--- a/src/utils/textutils.h
+++ b/src/utils/textutils.h
@@ -58,6 +58,7 @@ public:
 	static QString removeXMLEntities(QString svgContent);
 	static bool cleanSodipodi(QString &bytes);
 	static bool fixPixelDimensionsIn(QString &fileContent);
+    static bool fixPixelDimensionsIn(QDomDocument& svg, bool isIllustrator);
 	static bool addCopper1(const QString & filename, QDomDocument & doc, const QString & srcAtt, const QString & destAtt);
 	static void setSVGTransform(QDomElement &, QMatrix &);
 	static QString svgMatrix(const QMatrix &);
@@ -107,6 +108,8 @@ public:
 	static void gornTree(QDomDocument &);
 	static bool elevateTransform(QDomElement &);
 	static bool fixMuch(QString &svg, bool fixStrokeWidth);
+	static bool fixMuch(const QString& svg, QDomDocument& svgDom, bool fixStrokeWidth);
+    static bool fixMuchAndPixelDimensionsIn(QString& svg, bool fixStrokeWidth);
 	static bool fixInternalUnits(QString & svg);
 	static bool fixFonts(QString & svg, const QString & destFont, bool & reallyFixed);
 	static void fixStyleAttribute(QDomElement & element);


### PR DESCRIPTION
One of the more annoying aspects of fritzing is the initial load of parts bins when you scroll through them with your mouse wheel. Thus I decided to start looking through the code to improve the speed of this initial parts bin load (IPBL?). Through the use of linux perf tools I was able to track it down to a series of naive svg processing routines within TextUtils. The SVG DOM was being constructed, modified, converted to string, and then destroyed over and over. According to perf, this took up between 3 and 8 percent of the overall program's execution (well QDomDocument.setContent and QDomDocument.toString are the actual expensive operations). Thus I have changed fixMuch and fixPixelDimensionsIn to be more componentized so I can use the internals without having to construct a new DOM every single time. I can instead just pass an already created DOM in and modify it. I was able to confirm that this is safe because the string representation of the SVG is saved after the main load is performed as well. Loading bins feels very very fast now and I can scroll with the mouse wheel without getting annoyed. Even searches feel faster now. 

I also cleaned up PaletteModel::loadPart so that it is easier to maintain via the use of a static map for pureEqualityChecks and lambdas. New classes of major parts should be much easier to install into the loadPart class without fear of breakage. 

In addition to these fixes, I also did my usual nullptr check fixes and ctor cleanups. 
