### PR TITLE
Fix the number of allowed digits within the resistor regex

### DIFF
--- a/src/items/resistor.cpp
+++ b/src/items/resistor.cpp
@@ -49,8 +49,7 @@ static QHash<QString, QColor> Tolerances;
 Resistor::Resistor( ModelPart * modelPart, ViewLayer::ViewID viewID, const ViewGeometry & viewGeometry, long id, QMenu * itemMenu, bool doLabel)
 	: Capacitor(modelPart, viewID, viewGeometry, id, itemMenu, doLabel)
 {
-	m_changingPinSpacing = false;
-	if (Resistances.count() == 0) {
+    if (Resistances.empty()) {
 		Resistances
 		        << QString("0") + OhmSymbol
 		        << QString("1") + OhmSymbol << QString("1.5") + OhmSymbol << QString("2.2") + OhmSymbol << QString("3.3") + OhmSymbol << QString("4.7") + OhmSymbol << QString("6.8") + OhmSymbol
@@ -59,10 +58,10 @@ Resistor::Resistor( ModelPart * modelPart, ViewLayer::ViewID viewID, const ViewG
 		        << QString("1k") + OhmSymbol << QString("1.5k") + OhmSymbol << QString("2.2k") + OhmSymbol << QString("3.3k") + OhmSymbol << QString("4.7k") + OhmSymbol << QString("6.8k") + OhmSymbol
 		        << QString("10k") + OhmSymbol << QString("15k") + OhmSymbol << QString("22k") + OhmSymbol << QString("33k") + OhmSymbol << QString("47k") + OhmSymbol << QString("68k") + OhmSymbol
 		        << QString("100k") + OhmSymbol << QString("150k") + OhmSymbol << QString("220k") + OhmSymbol << QString("330k") + OhmSymbol << QString("470k") + OhmSymbol << QString("680k") + OhmSymbol
-		        << QString("1M") + OhmSymbol;
+		        << QString("1M") + OhmSymbol << QString("1G") + OhmSymbol;
 	}
 
-	if (PinSpacings.count() == 0) {
+    if (PinSpacings.empty()) {
 		PinSpacings.insert("100 mil (stand-up right)", "pcb/axial_stand0_2_100mil_pcb.svg");
 		PinSpacings.insert("100 mil (stand-up left)", "pcb/axial_stand1_2_100mil_pcb.svg");
 		PinSpacings.insert("200 mil", "pcb/axial_lay_2_200mil_pcb.svg");
@@ -73,7 +72,7 @@ Resistor::Resistor( ModelPart * modelPart, ViewLayer::ViewID viewID, const ViewG
 		PinSpacings.insert("800 mil", "pcb/axial_lay_2_800mil_pcb.svg");
 	}
 
-	if (ColorBands.count() == 0) {
+    if (ColorBands.empty()) {
 		ColorBands.insert(0, QColor(0, 0, 0));
 		ColorBands.insert(1, QColor(138, 61, 6));
 		ColorBands.insert(2, QColor(196, 8, 8));
@@ -88,7 +87,7 @@ Resistor::Resistor( ModelPart * modelPart, ViewLayer::ViewID viewID, const ViewG
 		ColorBands.insert(-2, QColor(192, 192, 192));
 	}
 
-	if (Tolerances.count() == 0) {
+	if (Tolerances.empty()) {
 		// TODO: move this into properties.xml
 		Tolerances.insert(PlusMinusSymbol + "0.05%", QColor(140, 140, 140));
 		Tolerances.insert(PlusMinusSymbol + "0.1%", QColor(130, 16, 210));
@@ -114,9 +113,6 @@ Resistor::Resistor( ModelPart * modelPart, ViewLayer::ViewID viewID, const ViewG
 	}
 
 	updateResistances(m_ohms);
-}
-
-Resistor::~Resistor() {
 }
 
 void Resistor::setResistance(QString resistance, QString pinSpacing, bool force) {
@@ -266,7 +262,7 @@ bool Resistor::collectExtraInfo(QWidget * parent, const QString & family, const 
 		validator->setSymbol(OhmSymbol);
 		validator->setConverter(TextUtils::convertFromPowerPrefix);
 		validator->setBounds(0, 9900000000.0);
-		validator->setRegExp(QRegExp(QString("((\\d{1,3})|(\\d{1,3}\\.)|(\\d{1,3}\\.\\d{1,2}))[\\x%1umkMG]{0,1}[\\x03A9]{0,1}").arg(TextUtils::MicroSymbolCode, 4, 16, QChar('0'))));
+		validator->setRegExp(QRegExp(QString("((\\d{1,10})|(\\d{1,10}\\.)|(\\d{1,10}\\.\\d{1,5}))[\\x%1umkMG]{0,1}[\\x03A9]{0,1}").arg(TextUtils::MicroSymbolCode, 4, 16, QChar('0'))));
 		focusOutComboBox->setValidator(validator);
 		connect(focusOutComboBox, SIGNAL(currentIndexChanged(const QString &)), this, SLOT(resistanceEntry(const QString &)));
 

--- a/src/items/resistor.h
+++ b/src/items/resistor.h
@@ -35,7 +35,7 @@ class Resistor : public Capacitor
 public:
 	// after calling this constructor if you want to render the loaded svg (either from model or from file), MUST call <renderImage>
 	Resistor(ModelPart *, ViewLayer::ViewID, const ViewGeometry & viewGeometry, long id, QMenu * itemMenu, bool doLabel);
-	~Resistor();
+	~Resistor() = default;
 
 	QString retrieveSvg(ViewLayer::ViewLayerID, QHash<QString, QString> & svgHash, bool blackOnly, double dpi, double & factor);
 	bool collectExtraInfo(QWidget * parent, const QString & family, const QString & prop, const QString & value, bool swappingEnabled, QString & returnProp, QString & returnValue, QWidget * & returnWidget, bool & hide);
@@ -70,7 +70,7 @@ protected:
 	QString m_ohms;
 	QString m_pinSpacing;
 	QString m_title;
-	bool m_changingPinSpacing;
+	bool m_changingPinSpacing = false;
 	QString m_iconSvgFile;
 	QString m_breadboardSvgFile;
 };


### PR DESCRIPTION
Increased the precision of the resistor values regex to 10 digits before the decimal and 5 digits after the decimal. Also added 1G ohm to the default set for good measure. Did some slight ctor cleanup as well. See #3292 for more information. 