### PR TITLE
Add /include version of boost paths

### DIFF
--- a/pri/boostdetect.pri
+++ b/pri/boostdetect.pri
@@ -51,6 +51,6 @@ exists($$boost_root) {
 
     !contains(LATESTBOOST, installed) {
         message("using boost_1_$${LATESTBOOST}_0")
-        INCLUDEPATH += src/lib/boost_1_$${LATESTBOOST}_0 ../boost_1_$${LATESTBOOST}_0
+        INCLUDEPATH += src/lib/boost_1_$${LATESTBOOST}_0 ../boost_1_$${LATESTBOOST}_0 src/lib/boost_1_$${LATESTBOOST}_0/include ../boost_1_$${LATESTBOOST}_0/include
     }
 }


### PR DESCRIPTION
boostdetect.pri adds boost to the include path, but in Boost 1.72 (latest in mac homebrew) the headers are located in boost/include