### PR TITLE
Fix libgit2 version check to allow building with versions >= 1.0

### DIFF
--- a/src/version/partschecker.cpp
+++ b/src/version/partschecker.cpp
@@ -115,7 +115,7 @@ bool PartsChecker::newPartsAvailable(const QString &repoPath, const QString & sh
 	/**
 	 * Connect to the remote.
 	 */
-#if LIBGIT2_VER_MINOR > 24
+#if LIBGIT2_VER_MAJOR > 0 || (LIBGIT2_VER_MAJOR == 0 && LIBGIT2_VER_MINOR > 24)
 	error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL, NULL);
 #elif LIBGIT2_VER_MINOR == 24
 	error = git_remote_connect(remote, GIT_DIRECTION_FETCH, &callbacks, NULL);


### PR DESCRIPTION
Until now, the check only considers the minor version number, so it breaks with versions greater than 0.99.