### PR TITLE
remove need for hard-coded boost path with unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - mkdir -p ../libgit2/build
         - wget -q -O - https://github.com/libgit2/libgit2/archive/v0.28.1.tar.gz | tar xz && mv libgit2-0.28.1/* ../libgit2/
         - (cd ../libgit2/build && cmake -D BUILD_SHARED_LIBS=OFF .. && cmake --build .)
-        - (cd src/lib && wget -q -O - https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 | tar xj)
+        - (cd .. && wget -q -O - https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 | tar xj)
         - tools/aws_tasks.sh setup
       script:
         - ls /usr/local/opt
@@ -106,7 +106,7 @@ jobs:
         - ./qt-installer.exe --script ./tools/qt_installer_noninteractive.qs
         - curl -fsSL https://github.com/libgit2/libgit2/archive/v0.28.1.zip -o libgit2.zip && 7z x libgit2.zip && mv libgit2-0.28.1 ../libgit2
         - (mkdir ../libgit2/build64 && cd ../libgit2/build64 && cmake -G "Visual Studio 15 2017 Win64" .. && cmake --build . --config Release)
-        - (cd src/lib && curl -L https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 | tar xj)
+        - (cd .. && curl -L https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 | tar xj)
         - tools/aws_tasks.sh setup
 
       script:

--- a/pri/boostdetect.pri
+++ b/pri/boostdetect.pri
@@ -13,44 +13,55 @@
 # along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
 # ********************************************************************/
 
+LATESTBOOST = 0
 
-exists($$boost_root) {
-    INCLUDEPATH += $$absolute_path($$boost_root)
-    message("using boost $$absolute_path($$boost_root)")
+# reduce warning messages by checking if variables are defined before using them
+defined(boost_root, var) {
+    LATESTBOOST = user
+    exists($$boost_root) {
+        # force absolute: relative would break due to detection versus use folder nest level
+        BOOSTPATH = $$absolute_path($$boost_root)
+        absolute_boost = 1
+        unset(absolute_boost)
+    } else {
+        error("requested boost_root $$boost_root does not exist")
+    }
 } else {
-# exists($$BOOST_ROOT) {
-#     INCLUDEPATH += $$BOOST_ROOT
-#     message("using BOOST_ROOT environment")
-# } else {
     # message("Boost auto detect is deprecated, please set boost root variable.")
     message("Using fritzing boost detect script.")
 
-
     # boost_1_54_0 is buggy
     BOOSTS = 43 44 45 46 47 48 49 50 51 52 53 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99
-    LATESTBOOST = 0
     for(boost, BOOSTS) {
         exists(../../boost_1_$${boost}_0) {
             LATESTBOOST = $$boost
+            BOOSTPATH = ../boost_1_$${boost}_0
         }
         exists(../src/lib/boost_1_$${boost}_0) {
             LATESTBOOST = $$boost
+            BOOSTPATH = src/lib/boost_1_$${boost}_0
         }
     }
+}
 
-    contains(LATESTBOOST, 0) {
-        qtCompileTest(boost)
-        config_boost {
-            LATESTBOOST = installed
-            !build_pass:message("using installed Boost library")
-        } else {
-            message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
-            error("Easiest to copy the Boost library to ..., so that you have .../boost_1_xx_0")
-        }
+# do the common configuration after all detection is finished
+contains(LATESTBOOST, 0) {
+    boost = 99
+    qtCompileTest(boost)
+    config_boost {
+        !build_pass:message("using installed Boost library")
+    } else {
+        message("Boost 1.54 has a bug in a function that Fritzing uses, so download or install some other version")
+        error("Easiest to copy the Boost library to ..., so that you have .../boost_1_xx_0")
     }
-
-    !contains(LATESTBOOST, installed) {
-        message("using boost_1_$${LATESTBOOST}_0")
-        INCLUDEPATH += src/lib/boost_1_$${LATESTBOOST}_0 ../boost_1_$${LATESTBOOST}_0
+} else {
+    defined(BOOSTPATH, var) {
+        defined(absolute_boost, var) {
+            BOOSTPATH = $$absolute_path(../$${BOOSTPATH})
+        }
+        message("using $${BOOSTPATH} boost environment")
+        INCLUDEPATH += $$BOOSTPATH
+    } else {
+        error("unknown boost environment")
     }
 }

--- a/pri/boostdetect.pri
+++ b/pri/boostdetect.pri
@@ -21,6 +21,7 @@ defined(boost_root, var) {
     exists($$boost_root) {
         # force absolute: relative would break due to detection versus use folder nest level
         BOOSTPATH = $$absolute_path($$boost_root)
+        # prevent possibly existing absolute_boost flag from breaking already absolute path
         absolute_boost = 1
         unset(absolute_boost)
     } else {
@@ -36,10 +37,6 @@ defined(boost_root, var) {
         exists(../../boost_1_$${boost}_0) {
             LATESTBOOST = $$boost
             BOOSTPATH = ../boost_1_$${boost}_0
-        }
-        exists(../src/lib/boost_1_$${boost}_0) {
-            LATESTBOOST = $$boost
-            BOOSTPATH = src/lib/boost_1_$${boost}_0
         }
     }
 }

--- a/tests/auto/test_svg/test_svg.pro
+++ b/tests/auto/test_svg/test_svg.pro
@@ -13,7 +13,8 @@
 # along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
 # ********************************************************************/
 
-boost_root = ../../boost_1_70_0
+# specify absolute path so that unit test compiles will find the folder
+absolute_boost = 1
 include($$absolute_path(../../../pri/boostdetect.pri))
 
 QT += core xml svg

--- a/tests/auto/test_textutils/test_textutils.pro
+++ b/tests/auto/test_textutils/test_textutils.pro
@@ -13,7 +13,8 @@
 # along with Fritzing. If not, see <http://www.gnu.org/licenses/>.
 # ********************************************************************/
 
-boost_root = ../../boost_1_70_0
+# specify absolute path so that unit test compiles will find the folder
+absolute_boost = 1
 include($$absolute_path(../../../pri/boostdetect.pri))
 
 QT += core xml


### PR DESCRIPTION
I found that the existing unit test `.pro` files had boost_1_70_0 hard-coded for the boost environment. That broke for me, since boost_1_72_0 is being used locally. Trying to get generic detection to work, so that the same boost environment (detection logic) would be used for both phoenix and the unit tests, I discovered that the relative path detected and used by pri/boostdetect.pri did not work for the unit tests. The folder nest level paths do not match the detected path.

I created a new boostdetect version (near rewrite) that takes an optional flag to generate an absolute path. An older version of pri/boostdetect.pri was unconditionally setting an absolute path. That was changed to relative at the same time that the detection search was expanded to look for the boost environment folder in src/lib. Although I see that .gitignore was NOT adjusted to ignore a boost folder in src/lib.

This needs testing with a windows build. I do not have an environment available to do that. Some of the information seen says project and pri files are handled a bit differently on windows, using resource files for some things instead. With this version, phoenix.pro works with or without `absolute_boost = 1`. Without uses the same relative path as previously.
