### PR TITLE
Svg parse tests

### DIFF
--- a/tests/auto/test_svg/test_pathlexer_protected.cpp
+++ b/tests/auto/test_svg/test_pathlexer_protected.cpp
@@ -1,0 +1,50 @@
+#include "svg/svgpathgrammar_p.h"
+
+/*
+Test how SVGPathLexer::lexer cleans up (pre-processes) various svg path element
+data strings
+
+Testing that needs access to protected members of the class under test. This
+is not the best way to do this, but it is simple, and is fine for the
+functionality cases. Can break if class member allocation order is important
+*/
+
+// Get access to protected members of class SVGPathLexer for testing
+#define protected public
+#include "svg/svgpathlexer.h"
+#undef protected
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( pathlexer_clean )
+{
+	const QStringList test_cases = {
+		"m0,0",
+		"m 0 ,  0 \t\n   ",
+		"m0,0x",
+		"m 0 , 0 x",
+		"m 0 0\nx\n",
+		"m0,0a 2.6,2.6 0 0 1 5.2,0v5.2a 2.6, 2.6 0 0 1-5.2,0 z "
+			"m 0.5,3 a 1,\t 1\n   0 0 0 4.2,0v-0.8a 1,  1   0 0 0 -4.2,0z  "
+	};
+	const QStringList expected_results = {
+		"m0,0",
+		"m0,0",
+		"m0,0x",
+		"m0,0x",
+		"m0 0x",
+		"m0,0a2.6,2.6 0 0 1 5.2,0v5.2a2.6,2.6 0 0 1-5.2,0z"
+			"m0.5,3a1,1 0 0 0 4.2,0v-0.8a1,1 0 0 0 -4.2,0z"
+	};
+	for (int i = 0; i < test_cases.size(); ++i) {
+		BOOST_CHECK_NO_THROW({
+			QString dataCopy(test_cases.at(i));
+			SVGPathLexer lexer(dataCopy);
+			if (lexer.m_source != expected_results.at(i)) {
+				BOOST_ERROR("check lexer.m_source.toStdString() == expected_results.at("
+					<< i << ").toStdString() has failed [\n\"" << lexer.m_source.toStdString()
+					<< "\" != \n\"" << expected_results.at(i).toStdString() << "\"]");
+			}
+		});
+	}
+}

--- a/tests/auto/test_svg/test_pathlexer_public.cpp
+++ b/tests/auto/test_svg/test_pathlexer_public.cpp
@@ -1,0 +1,188 @@
+#include "svg/svgpathgrammar_p.h"
+#include "svg/svgpathlexer.h"
+
+/*
+Test how SVGPathLexer::lexer processes various svg path element data strings
+*/
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( pathlexer_tree )
+{
+	const QStringList inputs = {
+		"m0,0",
+		"m0,0z",
+		"m0,0x",
+		"m 0 , 0 x",
+		"m 0 0\nx\n",
+		"m0,0a 2.6,2.6 0 0 1 5.2,0v5.2a 2.6,2.6 0 0 1-5.2,0z"
+			"m 0.5,3a 1,  1   0 0 0 4.2,0v-0.8a 1,  1   0 0 0-4.2,0z  ",
+		"m0,0a 2.6,2.6 0 0 1 5.2,0v5.2a 2.6,2.6 0 0 1 -5.2,0z\n  "
+			"m 0.5,3a 1,  1   0 0 0 4.2,0v-0.8a 1,  1   0 0 0-4.2,0z  "
+	};
+	const QList<QString> expectedCommands = {
+		"mmmmm", // "m0,0"
+		"mmmmzz", // "m0,0z"
+		"mmmmxx", // "m0,0x"
+		"mmmmxx", // "m 0 , 0 x"
+		"mmmmxx", // "m 0 0\nx\n"
+		"mmmm" // m0,0
+			"aaaaaaaaaaaaaa" // a 2.6,2.6 0 0 1 5.2,0
+			"vv" // v5.2
+			"aaaaaaaaaaaaa" // a 2.6,2.6 0 0 1-5.2,0
+			"z" // z
+			"mmmm" // m 0.5,3
+			"aaaaaaaaaaaaaa" // a 1,  1   0 0 0 4.2,0
+			"vv" // v-0.8
+			"aaaaaaaaaaaaa" // a 1,  1   0 0 0-4.2,0
+			"zz", // z  "
+		"mmmm" // m0,0
+			"aaaaaaaaaaaaaa" // a 2.6,2.6 0 0 1 5.2,0
+			"vv" // v5.2
+			"aaaaaaaaaaaaaa" // a 2.6,2.6 0 0 1 -5.2,0
+			"z" // z\n  "
+			"mmmm" // m 0.5,3
+			"aaaaaaaaaaaaaa" // a 1,  1   0 0 0 4.2,0
+			"vv" // v-0.8
+			"aaaaaaaaaaaaa" // a 1,  1   0 0 0-4.2,0
+			"zz", // z  "
+	};
+	const QList<QList<double>> expectedNumbers = {
+		{ 0.0, 0.0, 0.0, 0.0, 0.0 }, // "m0,0"
+		{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }, // "m0,0z"
+		{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }, // "m0,0x"
+		{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }, // "m 0 , 0 x"
+		{ 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }, // "m 0 0\nx\n"
+		{ 0.0, 0.0, 0.0, 0.0, // m0,0
+			0.0, 2.6, 2.6, 2.6, 2.6, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 5.2, 5.2, 0.0, // a 2.6,2.6 0 0 1 5.2,0
+			0.0, 5.2, // v5.2
+			5.2, 2.6, 2.6, 2.6, 2.6, 0.0, 0.0, 0.0, 0.0, 1.0, -5.2, -5.2, 0.0, // a 2.6,2.6 0 0 1-5.2,0
+			0.0, // z
+			0.0, 0.5, 0.5, 3.0, // m 0.5,3
+			3.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4.2, 4.2, 0.0, // a 1,  1   0 0 0 4.2,0
+			0.0, -0.8, // v-0.8
+			-0.8, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -4.2, -4.2, 0.0, // a 1,  1   0 0 0-4.2,0
+			0.0, 0.0 }, // "z  "
+		{ 0.0, 0.0, 0.0, 0.0, // m0,0
+			0.0, 2.6, 2.6, 2.6, 2.6, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 5.2, 5.2, 0.0, // a 2.6,2.6 0 0 1 5.2,0
+			0.0, 5.2, // v5.2
+			5.2, 2.6, 2.6, 2.6, 2.6, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, -5.2, -5.2, 0.0, // a 2.6,2.6 0 0 1 -5.2,0
+			0.0, // z
+			0.0, 0.5, 0.5, 3.0, // m 0.5,3
+			3.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 4.2, 4.2, 0.0, // a 1,  1   0 0 0 4.2,0
+			0.0, -0.8, // v-0.8
+			-0.8, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -4.2, -4.2, 0.0, // a 1,  1   0 0 0-4.2,0
+			0.0, 0.0 }, // z
+	};
+	const QList<QList<int>> expectedResults = {
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER,
+		  SVGPathGrammar::EOF_SYMBOL // "m0,0"
+		},
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER,
+		  SVGPathGrammar::ZEE, SVGPathGrammar::EOF_SYMBOL // "m0,0z"
+		},
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER,
+		  SVGPathGrammar::EKS, SVGPathGrammar::EOF_SYMBOL // "m0,0x"
+		},
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER,
+		  SVGPathGrammar::EKS, SVGPathGrammar::EOF_SYMBOL // "m 0 , 0 x"
+		},
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER,
+		  SVGPathGrammar::EKS, SVGPathGrammar::EOF_SYMBOL // "m 0 0\nx\n"
+		},
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 3 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 7 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 9 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 11 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 13 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 15 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 17 */
+		  SVGPathGrammar::VEE, SVGPathGrammar::NUMBER, /* 19 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 23 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 25 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 27 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 29 */
+			SVGPathGrammar::NUMBER, /* 30 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 32 */
+		  SVGPathGrammar::ZEE, /* 33 */
+		  SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 37 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 41 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 43 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 45 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 47 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 49 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 51 */
+		  SVGPathGrammar::VEE, SVGPathGrammar::NUMBER, /* 53 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 57 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 59 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 61 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 63 */
+			SVGPathGrammar::NUMBER, /* 64 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 66 */
+		  SVGPathGrammar::ZEE, /* 67 */
+		  SVGPathGrammar::EOF_SYMBOL /* 68 */
+		},
+		{ SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 3 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 7 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 9 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 11 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER,  /* 13 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 15 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 17 */
+		  SVGPathGrammar::VEE, SVGPathGrammar::NUMBER, /* 19 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 23 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 25 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 27 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 29 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 31 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 33 */
+		  SVGPathGrammar::ZEE, /* 34 */
+		  SVGPathGrammar::EM, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 38 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 42 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 44 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 46 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 48 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 50 */
+			SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 52 */
+		  SVGPathGrammar::VEE, SVGPathGrammar::NUMBER, /* 54 */
+		  SVGPathGrammar::AE, SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 58 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 60 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 62 */
+			SVGPathGrammar::WHITESPACE, SVGPathGrammar::NUMBER, /* 64 */
+			SVGPathGrammar::NUMBER, SVGPathGrammar::COMMA, SVGPathGrammar::NUMBER, /* 67 */
+		  SVGPathGrammar::ZEE, /* 68 */
+		  SVGPathGrammar::EOF_SYMBOL /* 69 */
+		}
+	};
+
+	for (int inp = 0; inp < inputs.size(); ++inp) {
+		QString dataCopy(inputs.at(inp));
+		SVGPathLexer lexer(dataCopy);
+		QList<int> inputResults = expectedResults.at(inp);
+		QString inputCommands = expectedCommands.at(inp);
+		QList<double> inputNumbers = expectedNumbers.at(inp);
+		for (int step = 0; step < inputResults.size(); step++) {
+			BOOST_CHECK_NO_THROW({
+				int lexerResult = lexer.lex();
+				if (lexerResult != inputResults.at(step)) {
+					BOOST_ERROR("for input " << inp
+						<< ", check lexer.lex() == inputResults.at(" << step << ") has failed ["
+						<< lexerResult << " != " << inputResults.at(step) << "]");
+				}
+				QChar currentCommand = lexer.currentCommand();
+				if (currentCommand != inputCommands.at(step)) {
+					BOOST_ERROR("for input " << inp
+						<< ", check lexer.currentCommand() == inputCommands.at(" << step << ") has failed ["
+						<< currentCommand.toLatin1() << " != " << inputCommands.at(step).toLatin1() << "]"
+					);
+				}
+				double currentNumber = lexer.currentNumber();
+				if (currentNumber != inputNumbers.at(step)) {
+					BOOST_ERROR("for input " << inp
+						<< ", check lexer.currentNumber() == inputNumbers.at(" << step << ") has failed ["
+						<< currentNumber << " != " << inputNumbers.at(step) << "]");
+				}
+			});
+		}
+	}
+}

--- a/tests/auto/test_svg/test_pathparse.cpp
+++ b/tests/auto/test_svg/test_pathparse.cpp
@@ -1,0 +1,86 @@
+#include "svg/svgpathparser.h"
+#include "svg/svgpathlexer.h"
+
+/*
+Testing how SVGPathParser::parser handles various valid svg path element
+specifcation strings, and segments
+*/
+
+#include <algorithm>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( pathparse_good )
+{
+	// reference: https://www.w3.org/TR/SVG/paths.html
+	const QStringList goodInputs = {
+		"m0,0x", // 0
+		"m5,9.9x", // 1 standard comma separated coordinates
+		"m-5,-9.9x", // 2 same for negative values
+		"m-4 -9.8x", // 3 whitespace instead of comma separator
+		"m-3-9.7x", // 4 no separator when 2nd value is negative
+		"m0,0z", // 5 'real' close marker
+		"m1,-2a2.6,3.5,0,0,1,-5.2,0x", // 6 all comma separators
+		"m2 -2a2.6 3.5 0 0 1 -5.2 0x", // 7 all whitespace separators
+		"m3-2a2.6 3.5 0 0 1-5.2 0x", // 8 no separator before negative value
+		"m4-2a2.6-3.5 0 0 1-5.2 0x", // 9 no separator before negative value
+		"m-2+9.7x", // 10 "+" separator before positive value
+	};
+	const QList<QList<QVariant>> expectedStacks = {
+		{ QChar('m'), double(0), double(0) }, // "m0,0x" // 0
+		{ QChar('m'), double(5), double(9.9) }, // "m5,9.9x" // 1
+		{ QChar('m'), double(-5), double(-9.9) }, // "m-5,-9.9x" // 2
+		{ QChar('m'), double(-4), double(-9.8) }, // "m-4 -9.8x" // 3
+		{ QChar('m'), double(-3), double(-9.7) }, // "m-3-9.7x" // 4
+		{ QChar('m'), double(0), double(0), QChar('z') }, // "m0,0z" // 5
+		{ QChar('m'), double(1), double(-2), // "m1,-2" // 6
+		  QChar('a'), double(2.6), double(3.5), double(0), double(0), double(1), double(-5.2), double(0) }, // "a2.6,3.5,0,0,1,-5.2,0x"
+		{ QChar('m'), double(2), double(-2), // "m2 -2" // 7
+		  QChar('a'), double(2.6), double(3.5), double(0), double(0), double(1), double(-5.2), double(0) }, // "a2.6 3.5 0 0 1 -5.2 0x"
+		{ QChar('m'), double(3), double(-2), // "m3-2" // 8
+		  QChar('a'), double(2.6), double(3.5), double(0), double(0), double(1), double(-5.2), double(0) }, // "a2.6 3.5 0 0 1-5.2 0x"
+		{ QChar('m'), double(4), double(-2), // "m4-2" // 8
+		  QChar('a'), double(2.6), double(-3.5), double(0), double(0), double(1), double(-5.2), double(0) }, // "a2.6-3.5 0 0 1-5.2 0x"
+		{ QChar('m'), double(-2), double(+9.7) }, // "m-2+9.7x" // 10
+	};
+
+	for (int inp = 0; inp < goodInputs.size(); ++inp) { // Sequence through the sample strings
+		QList<QVariant> goodResult = expectedStacks.at(inp);
+		SVGPathParser parser; // Create a new parser instance each time
+		BOOST_CHECK_NO_THROW({ // Nothing here is ever supposed to raise an exception
+			QString dataCopy(goodInputs.at(inp));
+			SVGPathLexer lexer(dataCopy);
+			int parseResult = parser.parse(lexer);
+			if (!parseResult) {
+				BOOST_ERROR("for input " << inp << ", check parser.parse(lexer) has failed");
+			}
+		});
+		// Detailed comparison of the parsed stack with what is expected for the input
+		QVector<QVariant> parseStack = parser.symStack();
+		if (parseStack.size() != goodResult.size()) { // The stack size better match
+			BOOST_ERROR("for input " << inp
+				<< ", check parseStack.size() == goodResult.size() has failed ["
+				<< parseStack.size() << " != " << goodResult.size() << "]");
+		}
+		for (int entry = 0; entry < std::min(parseStack.size(), goodResult.size()); entry++) {
+			// Every entry on the stack should match
+			QVariant parseEntry = parseStack.at(entry);
+			QVariant goodEntry = goodResult.at(entry);
+			// if (parseEntry != goodEntry) { // Will compare equal if one is int, other double, with matching value
+			if (parseEntry.type() != goodEntry.type() || parseEntry != goodEntry) {
+				BOOST_ERROR("for input " << inp
+					<< ", check parseStack.at(" << entry << ") == goodResult.at(" << entry << ") has failed ["
+					<< "<" << parseEntry.typeName() << ">"
+					<< ((QMetaType::Type)parseEntry.type() == QMetaType::QChar
+						? boost::lexical_cast<std::string>(parseEntry.toChar().toLatin1())
+						: boost::lexical_cast<std::string>(parseEntry.toDouble()))
+					<< " != <" << goodEntry.typeName() << ">"
+					<< ((QMetaType::Type)goodEntry.type() == QMetaType::QChar
+						? boost::lexical_cast<std::string>(goodEntry.toChar().toLatin1())
+						: boost::lexical_cast<std::string>(goodEntry.toDouble()))
+				);
+			}
+		}
+	}
+}

--- a/tests/auto/test_svg/test_svg.pro
+++ b/tests/auto/test_svg/test_svg.pro
@@ -25,6 +25,15 @@ SOURCES += $$files(*.cpp)
 INCLUDEPATH += $$absolute_path(../../../src)
 
 HEADERS += $$files(../../../src/svg/svgtext.h)
+HEADERS += $$files(../../../src/svg/svgpathlexer.h)
+HEADERS += $$files(../../../src/utils/textutils.h)
+HEADERS += $$files(../../../src/svg/svgpathgrammar_p.h)
+HEADERS += $$files(../../../src/svg/svgpathparser.h)
+
 SOURCES += $$files(../../../src/svg/svgtext.cpp)
+SOURCES += $$files(../../../src/svg/svgpathlexer.cpp)
+SOURCES += $$files(../../../src/svg/svgpathparser.cpp)
+SOURCES += $$files(../../../src/svg/svgpathgrammar.cpp)
+SOURCES += $$files(../../../src/utils/textutils.cpp)
 #INCLUDEPATH += $$top_srcdir
 # unix:QMAKE_POST_LINK = $$PWD/generated/test_svg


### PR DESCRIPTION
Unit tests for the low level svg path parsing Fritzing classes. The failures from test_pathparse.cpp are the important ones. That is the cause for #3647. The others are (currently) cosmetic, and avoided by preprocessing before parsing starts.