### PR TITLE
Fix issue #3683

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -466,7 +466,7 @@ ChangeConnectionCommand::ChangeConnectionCommand(SketchWidget * sketchWidget, Ba
         bool connect, QUndoCommand * parent)
 	: BaseCommand(crossView, sketchWidget, parent)
 {
-	//DebugDialog::debug(QString("ccc: from %1 %2; to %3 %4").arg(fromID).arg(fromConnectorID).arg(toID).arg(toConnectorID) );
+	//DebugDialog::debug(QString("ccc: from %1 %2; to %3 %4, connect %5, layer %6").arg(fromID).arg(fromConnectorID).arg(toID).arg(toConnectorID).arg(connect).arg(viewLayerPlacement) );
 	m_enabled = true;
 	m_fromID = fromID;
 	m_fromConnectorID = fromConnectorID;

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -3369,8 +3369,8 @@ bool SketchWidget::checkMoved(bool wait)
 				fromConnectorItem->setOverConnectorItem(nullptr);   // clean up
 				gotConnection = true;
 				extendChangeConnectionCommand(BaseCommand::CrossView, fromConnectorItem, toConnectorItem,
-				                              ViewLayer::specFromID(toConnectorItem->attachedToViewLayerID()),
-				                              true, parentCommand);
+											  ViewLayer::specFromID(toConnectorItem->attachedToViewLayerID()),
+											  true, parentCommand);
 			}
 			restoreConnectorItems.append(fromConnectorItem);
 			fromConnectorItem->clearConnectorHover();
@@ -3586,24 +3586,28 @@ void SketchWidget::prepLegBendpointMove(ConnectorItem * from, int index, QPointF
 
 
 		if (former.count() > 0) {
-			QList<ConnectorItem *> connectorItems;
-			connectorItems.append(from);
-			ConnectorItem::collectEqualPotential(connectorItems, true, ViewGeometry::RatsnestFlag | ViewGeometry::PCBTraceFlag | ViewGeometry::SchematicTraceFlag);
-
 			foreach (ConnectorItem * formerConnectorItem, former) {
-				ChangeConnectionCommand * ccc = extendChangeConnectionCommand(BaseCommand::CrossView, from, formerConnectorItem,
-				                                ViewLayer::specFromID(from->attachedToViewLayerID()),
-				                                false, parentCommand);
+
+				ItemBase * toItem = formerConnectorItem->attachedTo();
+				if (toItem) {
+					if (toItem->wireFlags() & (ViewGeometry::RatsnestFlag | ViewGeometry::PCBTraceFlag | ViewGeometry::SchematicTraceFlag)) continue;
+				}
+
+				ChangeConnectionCommand * ccc = extendChangeConnectionCommand(
+					                                BaseCommand::CrossView, from, formerConnectorItem,
+					                                ViewLayer::specFromID(from->attachedToViewLayerID()),
+					                                false, parentCommand
+					);
 				ccc->setUpdateConnections(false);
 				from->tempRemove(formerConnectorItem, false);
 				formerConnectorItem->tempRemove(from, false);
 			}
-
 		}
 		if (to) {
 			ChangeConnectionCommand * ccc = extendChangeConnectionCommand(BaseCommand::CrossView, from, to, ViewLayer::specFromID(from->attachedToViewLayerID()), true, parentCommand);
 			ccc->setUpdateConnections(false);
 		}
+
 	}
 	else {
 		parentCommand->setText(QObject::tr("Change leg of %1,%2")


### PR DESCRIPTION
This fixes the following use case:

Add two parts into an empty project,
one of them with a bendable leg (for example a resistor)
Go to the PCB view, connect the parts.
Go to the breadboard view. You see a ratsnest line
for the unrouted connection. Grab the bendable leg
at its endpoint and move it.

The connection is separated in breadboard view,
and not in PCB view, resulting in the view being
out of sync. The fix will keep this kind
of connections. The same applies for schematic view
instead of PCV view.