### PR TITLE
Deselect all items before exporting an image to PNG or JPG. Fixes  #3712

### DIFF
--- a/src/mainwindow/mainwindow_export.cpp
+++ b/src/mainwindow/mainwindow_export.cpp
@@ -557,6 +557,9 @@ void MainWindow::exportAux(QString fileName, QImage::Format format, int quality,
 {
 	if (m_currentGraphicsView == NULL) return;
 
+	//Deselect all items before creating the image
+	m_currentGraphicsView->selectDeselectAllCommand(false);
+
 	double resMultiplier = 3;
 
 	QRectF itemsBoundingRect;

--- a/src/mainwindow/mainwindow_export.cpp
+++ b/src/mainwindow/mainwindow_export.cpp
@@ -557,8 +557,11 @@ void MainWindow::exportAux(QString fileName, QImage::Format format, int quality,
 {
 	if (m_currentGraphicsView == NULL) return;
 
-	//Deselect all items before creating the image
-	m_currentGraphicsView->selectDeselectAllCommand(false);
+	//Deselect all the items that are selected before creating the image
+	QList<QGraphicsItem*> selItems = m_currentGraphicsView->scene()->selectedItems();
+	foreach(QGraphicsItem *item, selItems) {
+		item->setSelected(false);
+	}
 
 	double resMultiplier = 3;
 
@@ -608,6 +611,11 @@ void MainWindow::exportAux(QString fileName, QImage::Format format, int quality,
 	painter.end();
 
 	//image.save(FolderUtils::getUserDataStorePath("") + "/export.png");
+
+	//Select the items that were selected
+	foreach(QGraphicsItem *item, selItems) {
+		item->setSelected(true);
+	}
 
 	if (removeBackground) {
 		m_currentGraphicsView->setBackground(color);


### PR DESCRIPTION
The items are deselected, but they can be still be seen as selected in the app. After the screen is refreshed (f. ex. by zooming in the app or moving a component), they are shown correctly.
