### PR TITLE
The routing status algorithm needs to handle the part to part connect…

### DIFF
--- a/src/utils/graphutils.cpp
+++ b/src/utils/graphutils.cpp
@@ -515,6 +515,16 @@ bool GraphUtils::scoreOneNet(QList<ConnectorItem *> & partConnectorItems, ViewGe
 			switch (toConnectorItem->attachedToItemType()) {
 			case ModelPart::Wire:
 				break;
+			case ModelPart::Part:
+				//Only the breadboard view allows part to part connections
+				if (toConnectorItem->attachedTo()->isEverVisible() && (myTrace & ViewGeometry::NormalFlag)) {
+					int j = partConnectorItems.indexOf(toConnectorItem);
+					if (j >= 0) {
+						add_edge_d(i, j, G);
+						add_edge_d(j, i, G);
+					}
+				}
+				continue;
 			case ModelPart::Breadboard:
 				if (toConnectorItem->attachedTo()->isEverVisible()) {
 					QList<ConnectorItem *> ends;


### PR DESCRIPTION
…ions (LED in an Arduino for example). Fixes  #2685

There are two things that I do not understand. First, why do we have two methods to calculate the routing status (updateRoutingStatus and showUnrouted)? Both of them do a similar task but how they do it is very different.
The second thing is why do we call three times updateRoutingStatus for each modification, one for each view (bb, schematics and pcb)? Would not be possible to calculate just the view where you are working and update the routing status when you switch to a different view?
