### PR TITLE
improvements to introduce values in the properties of the objects. 

### DIFF
--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -225,23 +225,23 @@
 	<menuItem value="12.1" />
 </property>
 
-<property  name="maximum resistance" symbol="&#937;" minValue="" maxValue="" defaultValue="" numeric="yes" editable="yes">
+<property  name="maximum resistance" symbol="&#937;" minValue="0" maxValue="1000000000000" defaultValue="" numeric="yes" editable="yes">
 	<suffix suffix="PotentiometerModuleID"/>
 	<suffix suffix="alps-starter-pot9mm" />
 </property>
 
-<property name="inductance" symbol="H" minValue="" maxValue="" defaultValue="" numeric="yes" editable="yes">
+<property name="inductance" symbol="H" minValue="0" maxValue="1000000000000" defaultValue="" numeric="yes" editable="yes">
 	<suffix suffix="InductorModuleID"/>
 </property>
 
-  <property name="current" symbol="A" minValue="" maxValue="" defaultValue="" numeric="yes" editable="yes">
+  <property name="current" symbol="A" minValue="0" maxValue="1000000000000" defaultValue="" numeric="yes" editable="yes">
 	<suffix suffix="InductorModuleID"/>
 	<suffix suffix="LEDModuleID"/>
 </property>
 
-<property name="power" symbol="W" minValue="" maxValue="" defaultValue="" numeric="yes" editable="yes">
+<property name="power" symbol="W" minValue="0" maxValue="1000000000000" defaultValue="" numeric="yes" editable="yes">
 	<suffix suffix="ResistorModuleID"/>
 	<suffix suffix="PotentiometerModuleID"/>
 </property>
-
+</property>
 </properties>

--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -243,5 +243,4 @@
 	<suffix suffix="ResistorModuleID"/>
 	<suffix suffix="PotentiometerModuleID"/>
 </property>
-</property>
 </properties>

--- a/src/items/capacitor.cpp
+++ b/src/items/capacitor.cpp
@@ -62,6 +62,13 @@ bool Capacitor::collectExtraInfo(QWidget * parent, const QString & family, const
 			}
 
 			if (propertyDef->numeric) {
+				focusOutComboBox->setToolTip(tr("Select from the dropdown, or type in a %1 value\n"
+												"Range: [%2 - %3] %4\n"
+												"Background: Green = ok, Red = incorrect value, Grey = current value").
+											 arg(returnProp).
+											 arg(TextUtils::convertToPowerPrefix(propertyDef->minValue)).
+											 arg(TextUtils::convertToPowerPrefix(propertyDef->maxValue)).
+											 arg(propertyDef->symbol));
 				if (!current.isEmpty()) {
 					double val = TextUtils::convertFromPowerPrefixU(current, propertyDef->symbol);
 					if (!propertyDef->menuItems.contains(val)) {
@@ -97,7 +104,7 @@ bool Capacitor::collectExtraInfo(QWidget * parent, const QString & family, const
 				if (propertyDef->maxValue > propertyDef->minValue) {
 					validator->setBounds(propertyDef->minValue, propertyDef->maxValue);
 				}
-				QString pattern = QString("((\\d{1,3})|(\\d{1,3}\\.)|(\\d{1,3}\\.\\d{1,2}))[%1]{0,1}[%2]{0,1}")
+				QString pattern = QString("((\\d{0,3})|(\\d{0,3}\\.)|(\\d{0,3}\\.\\d{1,3}))[%1]{0,1}[%2]{0,1}")
 				                  .arg(TextUtils::PowerPrefixesString)
 				                  .arg(propertyDef->symbol);
 				validator->setRegExp(QRegExp(pattern));

--- a/src/mainwindow/mainwindow_export.cpp
+++ b/src/mainwindow/mainwindow_export.cpp
@@ -66,6 +66,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../utils/autoclosemessagebox.h"
 #include "../svg/gerbergenerator.h"
 #include "../processeventblocker.h"
+#include "../items/propertydef.h"
 
 static QString eagleActionType = ".eagle";
 static QString gerberActionType = ".gerber";
@@ -1397,12 +1398,27 @@ void MainWindow::exportSpiceNetlist() {
 				}
 			}
 			else {
+				//Find the symbol of this property
+				QString symbol;
+				QHash<PropertyDef *, QString> propertyDefs;
+				PropertyDefMaster::initPropertyDefs(itemBase->modelPart(), propertyDefs);
+				foreach (PropertyDef * propertyDef, propertyDefs.keys()) {
+					if (token.compare(propertyDef->name, Qt::CaseInsensitive) == 0) {
+						symbol = propertyDef->symbol;
+						break;
+					}
+				}
+				//Find the value of the property
 				QVariant variant = itemBase->modelPart()->localProp(token);
 				if (variant.isNull()) {
 					replacement = itemBase->modelPart()->properties().value(token, "");
 				}
 				else {
 					replacement = variant.toString();
+				}
+				//Remove the symbol, if any
+				if (!symbol.isEmpty()) {
+					replacement.replace(symbol, "");
 				}
 			}
 

--- a/src/utils/textutils.cpp
+++ b/src/utils/textutils.cpp
@@ -803,6 +803,8 @@ bool TextUtils::addCopper1(const QString & filename, QDomDocument & domDocument,
 QString TextUtils::convertToPowerPrefix(double q) {
 	initPowerPrefixes();
 
+	if (q == 0) return QString::number(q);
+
 	for (int i = 0; i < PowerPrefixes.count(); i++) {
 		if (q < 100 * PowerPrefixValues[i]) {
 			q /= PowerPrefixValues[i];


### PR DESCRIPTION
The rules have been relaxed to allow intermediate values. The feasibility of the value is displayed in the background of the cell (red: unfeasible, green: feasible). Added a fixup function in case that the user presses enter or the combobox looses focus. The fixup function modifies the value to an acceptable value. The tip is more informative now, shows the range of feasible values for the property. Fixes #1262 
I am not sure if the fixup function should be change to set the min or max value if the value is out of range.
