### PR TITLE
Mingw build support

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -33,7 +33,7 @@ CONFIG += c++14
 # TODO: Verify flags for clang and msvc builds
 QMAKE_CXXFLAGS += -O3 -fno-omit-frame-pointer
 
-unix:!macx {
+if(unix:!macx)|mingw {
     CONFIG += link_pkgconfig
 }
 
@@ -47,6 +47,9 @@ win32 {
     DEFINES += _CRT_SECURE_NO_DEPRECATE
     DEFINES += _WINDOWS
     RELEASE_SCRIPT = $$(RELEASE_SCRIPT)    # environment variable set from release script
+    mingw:isEmpty(QMAKE_TARGET.arch) {
+        QMAKE_TARGET.arch = $$(MSYSTEM_CARCH)
+    }
 
     message("target arch: $${QMAKE_TARGET.arch}")
     contains(QMAKE_TARGET.arch, x86_64) {
@@ -58,17 +61,19 @@ win32 {
         DEBDIR = ../debug32
     }
 
-    Release:DESTDIR = $${RELDIR}
-    Release:OBJECTS_DIR = $${RELDIR}
-    Release:MOC_DIR = $${RELDIR}
-    Release:RCC_DIR = $${RELDIR}
-    Release:UI_DIR = $${RELDIR}
+    !mingw {
+        Release:DESTDIR = $${RELDIR}
+        Release:OBJECTS_DIR = $${RELDIR}
+        Release:MOC_DIR = $${RELDIR}
+        Release:RCC_DIR = $${RELDIR}
+        Release:UI_DIR = $${RELDIR}
 
-    Debug:DESTDIR = $${DEBDIR}
-    Debug:OBJECTS_DIR = $${DEBDIR}
-    Debug:MOC_DIR = $${DEBDIR}
-    Debug:RCC_DIR = $${DEBDIR}
-    Debug:UI_DIR = $${DEBDIR}
+        Debug:DESTDIR = $${DEBDIR}
+        Debug:OBJECTS_DIR = $${DEBDIR}
+        Debug:MOC_DIR = $${DEBDIR}
+        Debug:RCC_DIR = $${DEBDIR}
+        Debug:UI_DIR = $${DEBDIR}
+    }
 }
 macx {
     RELDIR = ../release64
@@ -96,13 +101,15 @@ macx {
     LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
     LIBS += -liconv
 }
-unix {
+unix|mingw {
     !macx { # unix is defined on mac
-        HARDWARE_PLATFORM = $$system(uname -m)
-        contains(HARDWARE_PLATFORM, x86_64) {
-            DEFINES += LINUX_64
-        } else {
-            DEFINES += LINUX_32
+        !mingw {
+            HARDWARE_PLATFORM = $$system(uname -m)
+            contains(HARDWARE_PLATFORM, x86_64) {
+                DEFINES += LINUX_64
+            } else {
+                DEFINES += LINUX_32
+            }
         }
         !contains(DEFINES, QUAZIP_INSTALLED) {
             LIBS += -lz

--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -34,7 +34,7 @@ if ($$LIBGIT_STATIC) {
     INCLUDEPATH += $$LIBGIT2INCLUDE
 }
 
-win32 {
+win32:!mingw {
     contains(QMAKE_TARGET.arch, x86_64) {
         LIBGIT2LIB = "$$_PRO_FILE_PWD_/../libgit2/build64/Release"
     } else {
@@ -51,7 +51,7 @@ win32 {
     message($$PKGCONFIG)
 }
 
-unix {
+unix|mingw {
     if ($$LIBGIT_STATIC) {
         LIBGIT2LIB = $$_PRO_FILE_PWD_/../libgit2/build
         exists($$LIBGIT2LIB/libgit2.a) {

--- a/src/autoroute/cmrouter/cmrouter.cpp
+++ b/src/autoroute/cmrouter/cmrouter.cpp
@@ -154,21 +154,21 @@ static inline void infoTile(const QString & message, Tile * tile)
 	}
 
 	DebugDialog::debug(QString("tile:%1 lb:%2 bl:%3 tr:%4 rt%5")
-	                   .arg((long) tile, 0, 16)
-	                   .arg((long) tile->ti_lb, 0, 16)
-	                   .arg((long) tile->ti_bl, 0, 16)
-	                   .arg((long) tile->ti_tr, 0, 16)
-	                   .arg((long) tile->ti_rt, 0, 16));
+	                   .arg((size_t) tile, 0, 16)
+	                   .arg((size_t) tile->ti_lb, 0, 16)
+	                   .arg((size_t) tile->ti_bl, 0, 16)
+	                   .arg((size_t) tile->ti_tr, 0, 16)
+	                   .arg((size_t) tile->ti_rt, 0, 16));
 
 	DebugDialog::debug(QString("%1 tile:%2 l:%3 t:%4 w:%5 h:%6 type:%7 body:%8")
 	                   .arg(message)
-	                   .arg((long) tile, 0, 16)
+	                   .arg((size_t) tile, 0, 16)
 	                   .arg(LEFT(tile))
 	                   .arg(YMIN(tile))
 	                   .arg(WIDTH(tile))
 	                   .arg(HEIGHT(tile))
 	                   .arg(TiGetType(tile))
-	                   .arg((long) TiGetBody(tile), 0, 16)
+	                   .arg((size_t) TiGetBody(tile), 0, 16)
 	                  );
 }
 

--- a/src/connectors/connectoritem.cpp
+++ b/src/connectors/connectoritem.cpp
@@ -475,7 +475,7 @@ ConnectorItem * ConnectorItem::removeConnection(ItemBase * itemBase) {
 			}
 			restoreColor(visited);
 			DebugDialog::debug(QString("remove from:%1 to:%2 count%3")
-			                   .arg((long) this, 0, 16)
+			                   .arg((size_t) this, 0, 16)
 			                   .arg(itemBase->modelPartShared()->title())
 			                   .arg(m_connectedTo.count()) );
 			return removed;
@@ -1944,7 +1944,7 @@ void ConnectorItem::debugInfo(const QString & msg)
 	            .arg(this->attachedToViewLayerPlacement())
 	            .arg(this->attachedTo()->wireFlags())
 	            .arg(this->m_hybrid)
-	            .arg((long) this->bus(), 0, 16)
+	            .arg((size_t) this->bus(), 0, 16)
 	            .arg(this->m_radius)
 	            .arg(this->m_strokeWidth)
 	            .arg(p.x())

--- a/src/items/itembase.cpp
+++ b/src/items/itembase.cpp
@@ -1859,7 +1859,7 @@ void ItemBase::debugInfo2(const QString & msg) const
 	                   .arg(this->viewLayerID())
 	                   .arg(this->viewLayerPlacement())
 	                   .arg(this->wireFlags())
-	                   .arg((long) dynamic_cast<const QGraphicsItem *const>(this), 0, 16)
+	                   .arg((size_t) dynamic_cast<const QGraphicsItem *const>(this), 0, 16)
 	                   .arg(m_viewID)
 	                   .arg(this->zValue())
 	                   .arg(this->pos().x())

--- a/src/items/paletteitem.cpp
+++ b/src/items/paletteitem.cpp
@@ -200,7 +200,7 @@ void PaletteItem::makeOneKin(qint64 & id, ViewLayer::ViewLayerID viewLayerID, Vi
 	if (lkpi->ok()) {
 		DebugDialog::debug(QString("adding layer kin %1 %2 %3 %4")
 		                   .arg(id).arg(m_viewID).arg(viewLayerID)
-		                   .arg((long) lkpi, 0, 16)
+		                   .arg((size_t) lkpi, 0, 16)
 		                  );
 		addLayerKin(lkpi);
 		id++;

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -954,7 +954,7 @@ ItemBase * SketchWidget::findItem(long id) {
 
 void SketchWidget::deleteItem(long id, bool deleteModelPart, bool doEmit, bool later) {
 	ItemBase * pitem = findItem(id);
-	DebugDialog::debug(QString("delete item (1) %1 %2 %3 %4").arg(id).arg(doEmit).arg(m_viewID).arg((long) pitem, 0, 16) );
+	DebugDialog::debug(QString("delete item (1) %1 %2 %3 %4").arg(id).arg(doEmit).arg(m_viewID).arg((size_t) pitem, 0, 16) );
 	if (pitem) {
 		deleteItem(pitem, deleteModelPart, doEmit, later);
 	}
@@ -968,7 +968,7 @@ void SketchWidget::deleteItem(long id, bool deleteModelPart, bool doEmit, bool l
 void SketchWidget::deleteItem(ItemBase * itemBase, bool deleteModelPart, bool doEmit, bool later)
 {
 	long id = itemBase->id();
-	DebugDialog::debug(QString("delete item (2) %1 %2 %3 %4").arg(id).arg(itemBase->title()).arg(m_viewID).arg((long) itemBase, 0, 16) );
+	DebugDialog::debug(QString("delete item (2) %1 %2 %3 %4").arg(id).arg(itemBase->title()).arg(m_viewID).arg((size_t) itemBase, 0, 16) );
 
 	// this is a hack to try to workaround a Qt 4.7 crash in QGraphicsSceneFindItemBspTreeVisitor::visit
 	// when using a custom boundingRect, after deleting an item, it still appears on the visit list.

--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -212,7 +212,7 @@ const QString FolderUtils::libraryPath()
 
 const QString FolderUtils::applicationDirPath() {
 	if (m_appPath.isEmpty()) {
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN) && !defined(__MINGW32__)
 		m_appPath = QCoreApplication::applicationDirPath();
 #else
 		// look in standard Fritzing location (applicationDirPath and parent folders) then in standard linux locations
@@ -220,6 +220,9 @@ const QString FolderUtils::applicationDirPath() {
 		candidates.append(QCoreApplication::applicationDirPath());
 		QDir dir(QCoreApplication::applicationDirPath());
 		if (dir.cdUp()) {
+#ifdef __MINGW32__
+			candidates.append(QDir::cleanPath(dir.absolutePath() + "/share/fritzing"));
+#endif
 			candidates.append(dir.absolutePath());
 			if (dir.cdUp()) {
 				candidates.append(dir.absolutePath());


### PR DESCRIPTION
This pull request gets Fritzing building using mingw-w64, specifically tested under [MSYS2](http://www.msys2.org).

The first commit fixes gcc errors due to casting pointers to `long` which is not large enough to hold a pointer on 64-bit windows.  The second adapts the qmake files to basically treat `mingw` more like `unix` than `win32` (because the msys2 build environment is unix-like), and the third adjusts the search for the `applicationDirPath` to also act like `unix`, plus adds (bindir)/../share/fritzing as a candidate, as the msys2 mingw 'prefix' is relocatable in terms of Windows paths.

These patches were the result of getting Fritzing packaged in msys2/MINGW-packages#7376.