### PR TITLE
force a paint of the item as there were issues when toggling layers.

### DIFF
--- a/src/mainwindow/mainwindow_export.cpp
+++ b/src/mainwindow/mainwindow_export.cpp
@@ -569,6 +569,7 @@ void MainWindow::exportAux(QString fileName, QImage::Format format, int quality,
 	foreach(QGraphicsItem *item,  m_currentGraphicsView->scene()->items()) {
 		if (!item->isVisible()) continue;
 
+		item->update();
 		itemsBoundingRect |= item->sceneBoundingRect();
 	}
 


### PR DESCRIPTION
I just call update, but calling item->setCacheMode(QGraphicsItem::NoCache) also works (even though the items does not have cache by default...)
