### PR TITLE
Improved Mac build in a more automated, flexible, and reproducible way.

### DIFF
--- a/macPrebuild.sh
+++ b/macPrebuild.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+BOOSTURL="https://dl.bintray.com/boostorg/release/1.76.0/source/boost_1_76_0.tar.gz"
+BOOSTFNAME=${BOOSTURL##*/}
+LIBGIT2URL="https://github.com/libgit2/libgit2/releases/download/v0.28.5/libgit2-0.28.5.tar.gz"
+LIBGIT2FNAME=${LIBGIT2URL##*/}
+
+echo Downloading boost and libgit2 sources and placing them in ../
+cd ..
+curl -L -O -# $BOOSTURL
+tar xzf $BOOSTFNAME
+# Nothing to do with boost - it'll get found by fritzing when Makefiles are built
+
+# Next: libgit2 (v 0.28.5)
+curl -L -O -# $LIBGIT2URL
+tar xzf $LIBGIT2FNAME
+mv ${LIBGIT2FNAME%.tar.gz} libgit2
+mkdir libgit2/build
+cd libgit2/build
+
+cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" ..
+# Only ARM64 - cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES="arm64" ..
+# Only x86_64 - cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_ARCHITECTURES="x86_64" ..
+cmake --build .
+
+# this will look at the output and see that it is arm64 based.
+#echo Checking to see the final .a file is arm64 or arm64 and x86_64
+#lipo -info libgit2.a
+
+# Ready for qmake phoenix.pro / Qt Creator build.
+cd ../../fritzing-app
+echo Next step - Create Makefiles from phoenix.pro via 'qmake'. Default is x86_64 build.
+echo "            Universal build not available due to Qt5 issues as of April 2021."
+echo For arm64: Modify phoenix.pro 'QMAKE_APPLE_DEVICE_ARCHS=arm64'
+echo "           Then run qmake from your arm64 Qt5 build - qtbase/bin/qmake phoenix.pro"
+echo Finally build: /Applications/Xcode.app/Contents/Developer/usr/bin/make -f Makefile.Release
+

--- a/phoenix.pro
+++ b/phoenix.pro
@@ -71,8 +71,26 @@ win32 {
     Debug:UI_DIR = $${DEBDIR}
 }
 macx {
-    RELDIR = ../release64
-    DEBDIR = ../debug64
+    # QMAKE_MAC_SDK = macosx11.0            # uncomment/adapt for your version of OSX
+    CONFIG+=sdk_no_version_check
+# Request x86_64 build or arm64 build. 'qmake phoenix.pro' must use the corresponding qmake
+#   for the build type being requested. ie If you're wanting arm64, use the qmake built in
+#   your arm64 folder so it'll create makefiles with the arm64 folder paths for linking.
+#    QMAKE_APPLE_DEVICE_ARCHS=arm64
+    QMAKE_APPLE_DEVICE_ARCHS=x86_64
+    QMAKE_INFO_PLIST = FritzingInfo.plist
+    #DEFINES += QT_NO_DEBUG                # uncomment this for xcode
+    LIBS += -lz -liconv
+    LIBS  += -framework CoreFoundation -framework Carbon -framework IOKit -framework Security
+
+    message("device archs: $${QMAKE_APPLE_DEVICE_ARCHS}")
+    contains(QMAKE_APPLE_DEVICE_ARCHS, x86_64) {
+        RELDIR = ../release64
+        DEBDIR = ../debug64
+    } else {
+        RELDIR = ../releasearm64
+        DEBDIR = ../debugarm64
+    }
     Release:DESTDIR = $${RELDIR}
     Release:OBJECTS_DIR = $${RELDIR}
     Release:MOC_DIR = $${RELDIR}
@@ -84,17 +102,6 @@ macx {
     Debug:MOC_DIR = $${DEBDIR}
     Debug:RCC_DIR = $${DEBDIR}
     Debug:UI_DIR = $${DEBDIR}
-
-    #QMAKE_MAC_SDK = macosx10.11            # uncomment/adapt for your version of OSX
-    CONFIG += x86_64 # x86 ppc
-    QMAKE_INFO_PLIST = FritzingInfo.plist
-    #DEFINES += QT_NO_DEBUG                # uncomment this for xcode
-    LIBS += -lz
-    LIBS += /usr/lib/libz.dylib
-    LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
-    LIBS += /System/Library/Frameworks/Carbon.framework/Carbon
-    LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
-    LIBS += -liconv
 }
 unix {
     !macx { # unix is defined on mac

--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -60,7 +60,7 @@ unix {
             error("static libgit2 library not found in $$LIBGIT2LIB")
         }
         macx {
-            LIBS += $$LIBGIT2LIB/libgit2.a /System/Library/Frameworks/Security.framework/Versions/A/Security
+            LIBS += $$LIBGIT2LIB/libgit2.a
         } else {
             LIBS += $$LIBGIT2LIB/libgit2.a  -lssl -lcrypto
         }


### PR DESCRIPTION
1. Prebuild of libgit2 and boost - downloads and places them as expected as well as building libgit2 into a library. boost 1.76 and libgit2 0.28.5 - version numbers can be changed easily in the head of the script.
2. pri/libgit2detect - corrected errant hardwired library/framework. Settled this properly in phoenix.pro with flexibility.
3. phoenix.pro - defaults to x86_64 but allows arm64 build via simple change of QMAKE_APPLE_DEVICE_ARCHS=arm64. Removes all hardwired framework references and replaces them with -framework references. Also builds x86_64 and arm64 in different folders (../release64 for x86_64 and ../releasearm64 for arm64)