### PR TITLE
Install app icon in XDG hicolor icon theme

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -126,8 +126,8 @@ unix {
     manpage.path = $$DATADIR/man/man1
     manpage.files += Fritzing.1
 
-    icon.path = $$DATADIR/pixmaps
-    icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/pixmaps/fritzing.png
+    icon.path = $$DATADIR/icons/hicolor/256x256/apps
+    icon.extra = install -D -m 0644 $$PWD/resources/images/fritzing_icon.png $(INSTALL_ROOT)$$DATADIR/icons/hicolor/256x256/apps/fritzing.png
 
     parts.path = $$PKGDATADIR
     parts.files += parts


### PR DESCRIPTION
Install the icon of the application in the hicolor XDG icon theme; this way it can be properly loaded by XDG menus in the currently set XDG icon theme, without looking in the legacy pixmaps location.