### PR TITLE
resize a stripboard following the current layout,

### DIFF
--- a/src/items/perfboard.cpp
+++ b/src/items/perfboard.cpp
@@ -40,9 +40,9 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 static const int ConnectorIDJump = 1000;
 static const int MaxXDimension = 199;
-static const int MinXDimension = 5;
+static const int MinXDimension = 3;
 static const int MaxYDimension = 199;
-static const int MinYDimension = 5;
+static const int MinYDimension = 3;
 static const int WarningSize = 2000;
 
 static const QString OneHole("M%1,%2a%3,%3 0 1 %5 %4,0 %3,%3 0 1 %5 -%4,0z\n");
@@ -279,7 +279,7 @@ bool Perfboard::canEditPart() {
 	return false;
 }
 
-void Perfboard::changeBoardSize()
+bool Perfboard::boardSizeWarning()
 {
 	if (!m_gotWarning) {
 		int x = m_xEdit->text().toInt();
@@ -303,10 +303,17 @@ void Perfboard::changeBoardSize()
 				getXY(x, y, m_size);
 				m_xEdit->setText(QString::number(x));
 				m_yEdit->setText(QString::number(y));
-				return;
+				return true;
 			}
 		}
 	}
+	return false;
+}
+
+void Perfboard::changeBoardSize()
+{
+	if (boardSizeWarning())
+		return;
 
 	QString newSize = QString("%1.%2").arg(m_xEdit->text()).arg(m_yEdit->text());
 	m_propsMap.insert("size", newSize);

--- a/src/items/perfboard.h
+++ b/src/items/perfboard.h
@@ -66,6 +66,7 @@ protected slots:
 
 protected:
 	static bool getXY(int & x, int & y, const QString & s);
+	bool boardSizeWarning();
 
 protected:
 	static bool m_gotWarning;

--- a/src/items/stripboard.h
+++ b/src/items/stripboard.h
@@ -88,6 +88,9 @@ public:
 	void swapEntry(const QString & text);
 	QStringList collectValues(const QString & family, const QString & prop, QString & value);
 
+protected slots:
+	void changeBoardSize();
+
 protected:
 	void nextBus(QList<ConnectorItem *> & soFar);
 	QString getRowLabel();

--- a/src/sketch/breadboardsketchwidget.cpp
+++ b/src/sketch/breadboardsketchwidget.cpp
@@ -269,3 +269,21 @@ void BreadboardSketchWidget::colorWiresByLength(bool colorByLength) {
 bool BreadboardSketchWidget::coloringWiresByLength() {
 	return m_colorWiresByLength;
 }
+
+bool BreadboardSketchWidget::canCreateWire(Wire * dragWire, ConnectorItem * from, ConnectorItem * to)
+{
+	if ((from) && (to))
+		return true;
+	if (!dragWire)
+		return false;
+	qreal length = dragWire->getPaintLine().length();
+	return ( length > WireMinLength);
+}
+
+Wire * BreadboardSketchWidget::createTempWireForDragging(Wire * fromWire, ModelPart * wireModel, ConnectorItem * connectorItem, ViewGeometry & viewGeometry, ViewLayer::ViewLayerPlacement spec)
+{
+	Wire * wire = SketchWidget::createTempWireForDragging(fromWire, wireModel, connectorItem, viewGeometry, spec);
+	if (fromWire && wire)
+		wire->setColorString(fromWire->colorString(), fromWire->opacity(), false);
+	return wire;
+}

--- a/src/sketch/breadboardsketchwidget.h
+++ b/src/sketch/breadboardsketchwidget.h
@@ -57,8 +57,13 @@ protected:
 	ViewLayer::ViewLayerID getLabelViewLayerID(ItemBase *);
 	double getTraceWidth();
 	const QString & traceColor(ViewLayer::ViewLayerPlacement);
+	bool canCreateWire(Wire * dragWire, ConnectorItem * from, ConnectorItem * to);
+	Wire * createTempWireForDragging(Wire * fromWire, ModelPart * wireModel, ConnectorItem * connectorItem, ViewGeometry & viewGeometry, ViewLayer::ViewLayerPlacement);
 
 	bool m_colorWiresByLength;
+
+	//Only applies to wires that are connected to one connector
+	static constexpr int WireMinLength = 6;
 };
 
 #endif

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -5366,14 +5366,14 @@ void SketchWidget::prepDeleteOtherProps(ItemBase * itemBase, long id, const QStr
 		QString buses = itemBase->prop("buses");
 		QString newBuses = propsMap.value("buses");
 		if (newBuses.isEmpty()) newBuses = buses;
-		if (!buses.isEmpty()) {
+		if (!newBuses.isEmpty()) {
 			new SetPropCommand(this, id, "buses", buses, newBuses, true, parentCommand);
 		}
 
 		QString layout = itemBase->prop("layout");
 		QString newLayout = propsMap.value("layout");
 		if (newLayout.isEmpty()) newLayout = layout;
-		if (!layout.isEmpty()) {
+		if (!newLayout.isEmpty()) {
 			new SetPropCommand(this, id, "layout", layout, newLayout, true, parentCommand);
 		}
 	}


### PR DESCRIPTION
 fixes #3090 #2998 and #3084. The slow performance is still present but the extended area is not short-circuited.