### PR TITLE
Fixed linkage errors on macOS

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -90,10 +90,9 @@ macx {
     QMAKE_INFO_PLIST = FritzingInfo.plist
     #DEFINES += QT_NO_DEBUG                # uncomment this for xcode
     LIBS += -lz
-    LIBS += /usr/lib/libz.dylib
-    LIBS += /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
-    LIBS += /System/Library/Frameworks/Carbon.framework/Carbon
-    LIBS += /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
+    LIBS += -framework CoreFoundation
+    LIBS += -framework Carbon
+    LIBS += -framework IOKit
     LIBS += -liconv
 }
 unix {

--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -59,7 +59,7 @@ unix {
             error("static libgit2 library not found in $$LIBGIT2LIB")
         }
         macx {
-            LIBS += $$LIBGIT2LIB/libgit2.a /System/Library/Frameworks/Security.framework/Versions/A/Security
+            LIBS += $$LIBGIT2LIB/libgit2.a -framework Security
         } else {
             LIBS += $$LIBGIT2LIB/libgit2.a  -lssl -lcrypto
         }


### PR DESCRIPTION
Linkage for macOS is specified in a strange and non-standard way in the .pro files, which makes it brittle. This caused it not to work on my system. These changes switch from using the "-l" option with absolute system paths to using the "-framework" option to include frameworks. Additionally, libz was included twice with "-lz" and with an absolute path. I removed the absolute path, as we don't need to copies and "-lz" is more general.