### PR TITLE
Add support for QuaZip 1.x

### DIFF
--- a/phoenix.pro
+++ b/phoenix.pro
@@ -205,7 +205,11 @@ include(test/version.pri)
 
 contains(DEFINES, QUAZIP_INSTALLED) {
     !build_pass:message("using installed QuaZIP library")
-    LIBS += -lquazip5
+    contains(DEFINES, QUAZIP_1X) {
+        PKGCONFIG += quazip1-qt5
+    } else {
+        LIBS += -lquazip5
+    }
 } else {
     include(pri/quazip.pri)
 }

--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -35,12 +35,17 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "../debugdialog.h"
 #ifdef QUAZIP_INSTALLED
+#ifdef QUAZIP_1X
+#include <quazip/quazip.h>
+#include <quazip/quazipfile.h>
+#else
 #include <quazip5/quazip.h>
 #include <quazip5/quazipfile.h>
+#endif /* QUAZIP_1X */
 #else
 #include "../lib/quazip/quazip.h"
 #include "../lib/quazip/quazipfile.h"
-#endif
+#endif /* QUAZIP_INSTALLED */
 #include "../lib/qtsysteminfo/QtSystemInfo.h"
 
 


### PR DESCRIPTION
QuaZip 1.x uses different include paths and ships with pkgconfig
metadata, so we can use PKGCONFIG instead of explicit library name. Use
the presence of QUAZIP_1X in defines to switch between QuaZip 1.x and
the legacy 0.x versions.