### PR TITLE
Added shorcuts for rotting, flipping and find part. Fixes #3582

### DIFF
--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -951,6 +951,7 @@ void MainWindow::createPartMenuActions() {
 	connect(m_rotate45cwAct, SIGNAL(triggered()), this, SLOT(rotate45cw()));
 
 	m_rotate90cwAct = new QAction(tr("Rotate 90° Clockwise"), this);
+	m_rotate90cwAct->setShortcut(tr("R"));
 	m_rotate90cwAct->setStatusTip(tr("Rotate the selected parts by 90 degrees clockwise"));
 	connect(m_rotate90cwAct, SIGNAL(triggered()), this, SLOT(rotate90cw()));
 
@@ -959,6 +960,7 @@ void MainWindow::createPartMenuActions() {
 	connect(m_rotate180Act, SIGNAL(triggered()), this, SLOT(rotate180()));
 
 	m_rotate90ccwAct = new QAction(tr("Rotate 90° Counter Clockwise"), this);
+	m_rotate90ccwAct->setShortcut(tr("Shift+R"));
 	m_rotate90ccwAct->setStatusTip(tr("Rotate current selection 90 degrees counter clockwise"));
 	connect(m_rotate90ccwAct, SIGNAL(triggered()), this, SLOT(rotate90ccw()));
 
@@ -967,10 +969,12 @@ void MainWindow::createPartMenuActions() {
 	connect(m_rotate45ccwAct, SIGNAL(triggered()), this, SLOT(rotate45ccw()));
 
 	m_flipHorizontalAct = new QAction(tr("&Flip Horizontal"), this);
+	m_flipHorizontalAct->setShortcut(tr("F"));
 	m_flipHorizontalAct->setStatusTip(tr("Flip current selection horizontally"));
 	connect(m_flipHorizontalAct, SIGNAL(triggered()), this, SLOT(flipHorizontal()));
 
 	m_flipVerticalAct = new QAction(tr("&Flip Vertical"), this);
+	m_flipVerticalAct->setShortcut(tr("Shift+F"));
 	m_flipVerticalAct->setStatusTip(tr("Flip current selection vertically"));
 	connect(m_flipVerticalAct, SIGNAL(triggered()), this, SLOT(flipVertical()));
 
@@ -1073,6 +1077,7 @@ void MainWindow::createPartMenuActions() {
 	connect(m_swapObsoleteAct, SIGNAL(triggered()), this, SLOT(swapObsolete()));
 
 	m_findPartInSketchAct = new QAction(tr("Find part in sketch..."), this);
+	m_findPartInSketchAct->setShortcut(QKeySequence::Find);
 	m_findPartInSketchAct->setStatusTip(tr("Search for parts in a sketch by matching text"));
 	connect(m_findPartInSketchAct, SIGNAL(triggered()), this, SLOT(findPartInSketch()));
 

--- a/src/sketch/pcbsketchwidget.cpp
+++ b/src/sketch/pcbsketchwidget.cpp
@@ -1773,49 +1773,6 @@ void PCBSketchWidget::prereleaseTempWireForDragging(Wire* wire)
 	}
 }
 
-void PCBSketchWidget::rotatePartLabels(double degrees, QTransform & transform, QPointF center, QUndoCommand * parentCommand)
-{
-	QList<ItemBase *> savedValues = m_savedItems.values();
-	/*
-	QSet<ItemBase *> boards;
-	foreach (ItemBase * itemBase, savedValues) {
-	    if (Board::isBoard(itemBase)) {
-	        boards.insert(itemBase);
-	    }
-	}
-
-
-	if (boards.count() == 0) return;
-
-	QRectF bbr;
-	foreach (ItemBase * board, boards.values()) {
-	    bbr |= board->sceneBoundingRect();
-	}
-	*/
-
-	foreach (QGraphicsItem * item, scene()->items()) {
-		PartLabel * partLabel = dynamic_cast<PartLabel *>(item);
-		if (partLabel == NULL) continue;
-		if (!partLabel->isVisible()) continue;
-		//if (!bbr.intersects(partLabel->sceneBoundingRect())) continue;  // if the part is on the board and the label is off the board, this does not rotate
-		if (!savedValues.contains(partLabel->owner()->layerKinChief())) continue;
-
-		QPointF offset = partLabel->pos() - partLabel->owner()->pos();
-		new MoveLabelCommand(this, partLabel->owner()->id(), partLabel->pos(), offset, partLabel->pos(), offset, parentCommand);
-		//Labels need to be readable (change the 90 and 180 degrees orientation to 270 or 0 degrees)
-		//Labels can be still be forced to 90 and 180 degrees through the right click menu
-		double finalOrientation = degrees + atan2(partLabel->transform().m12(), partLabel->transform().m11())/M_PI*180;
-		if(abs(finalOrientation-90) < 0.1 || abs(finalOrientation-180) < 0.1)
-			degrees+=180;
-
-		new RotateFlipLabelCommand(this, partLabel->owner()->id(), degrees, 0, parentCommand);
-		QPointF p = GraphicsUtils::calcRotation(transform, center, partLabel->pos(), partLabel->boundingRect().center());
-		ViewGeometry vg;
-		partLabel->owner()->calcRotation(transform, center, vg);
-		new MoveLabelCommand(this, partLabel->owner()->id(), p, p - vg.loc(), p, p - vg.loc(), parentCommand);
-	}
-}
-
 QString PCBSketchWidget::characterizeGroundFill(ViewLayer::ViewLayerID whichGroundPlane) {
 	QString result = GroundPlane::fillTypeNone;
 	bool gotOne = false;

--- a/src/sketch/pcbsketchwidget.cpp
+++ b/src/sketch/pcbsketchwidget.cpp
@@ -1802,6 +1802,12 @@ void PCBSketchWidget::rotatePartLabels(double degrees, QTransform & transform, Q
 
 		QPointF offset = partLabel->pos() - partLabel->owner()->pos();
 		new MoveLabelCommand(this, partLabel->owner()->id(), partLabel->pos(), offset, partLabel->pos(), offset, parentCommand);
+		//Labels need to be readable (change the 90 and 180 degrees orientation to 270 or 0 degrees)
+		//Labels can be still be forced to 90 and 180 degrees through the right click menu
+		double finalOrientation = degrees + atan2(partLabel->transform().m12(), partLabel->transform().m11())/M_PI*180;
+		if(abs(finalOrientation-90) < 0.1 || abs(finalOrientation-180) < 0.1)
+			degrees+=180;
+
 		new RotateFlipLabelCommand(this, partLabel->owner()->id(), degrees, 0, parentCommand);
 		QPointF p = GraphicsUtils::calcRotation(transform, center, partLabel->pos(), partLabel->boundingRect().center());
 		ViewGeometry vg;

--- a/src/sketch/pcbsketchwidget.h
+++ b/src/sketch/pcbsketchwidget.h
@@ -162,7 +162,6 @@ protected:
 	ViewLayer::ViewLayerPlacement createWireViewLayerPlacement(ConnectorItem * from, ConnectorItem * to);
 	Wire * createTempWireForDragging(Wire * fromWire, ModelPart * wireModel, ConnectorItem * connectorItem, ViewGeometry & viewGeometry, ViewLayer::ViewLayerPlacement);
 	void prereleaseTempWireForDragging(Wire*);
-	void rotatePartLabels(double degrees, QTransform &, QPointF center, QUndoCommand * parentCommand);
 	bool hasNeighbor(ConnectorItem * connectorItem, ViewLayer::ViewLayerID viewLayerID, const QRectF & r);	
 	bool canConnectSeed(QRectF boardRect,
 					 QImage * copperImage,

--- a/src/sketch/schematicsketchwidget.cpp
+++ b/src/sketch/schematicsketchwidget.cpp
@@ -442,11 +442,6 @@ Wire * SchematicSketchWidget::createTempWireForDragging(Wire * fromWire, ModelPa
 	return wire;
 }
 
-void SchematicSketchWidget::rotatePartLabels(double degrees, QTransform & transform, QPointF center, QUndoCommand * parentCommand)
-{
-	PCBSketchWidget::rotatePartLabels(degrees, transform, center, parentCommand);
-}
-
 void SchematicSketchWidget::loadFromModelParts(QList<ModelPart *> & modelParts, BaseCommand::CrossViewType crossViewType, QUndoCommand * parentCommand,
         bool offsetPaste, const QRectF * boundingRect, bool seekOutsideConnections, QList<long> & newIDs)
 {

--- a/src/sketch/schematicsketchwidget.h
+++ b/src/sketch/schematicsketchwidget.h
@@ -67,7 +67,6 @@ public:
 	QString generateCopperFillUnit(ItemBase * itemBase, QPointF whereToStart);
 	double getWireStrokeWidth(Wire *, double wireWidth);
 	Wire * createTempWireForDragging(Wire * fromWire, ModelPart * wireModel, ConnectorItem * connectorItem, ViewGeometry & viewGeometry, ViewLayer::ViewLayerPlacement);
-	void rotatePartLabels(double degrees, QTransform &, QPointF center, QUndoCommand * parentCommand);
 	void loadFromModelParts(QList<ModelPart *> & modelParts, BaseCommand::CrossViewType, QUndoCommand * parentCommand,
 	                        bool offsetPaste, const QRectF * boundingRect, bool seekOutsideConnections, QList<long> & newIDs);
 	LayerList routingLayers(ViewLayer::ViewLayerPlacement);

--- a/src/sketch/sketchwidget.cpp
+++ b/src/sketch/sketchwidget.cpp
@@ -4718,11 +4718,47 @@ void SketchWidget::rotateWire(Wire * wire, QTransform & rotation, QPointF center
 
 }
 
-void SketchWidget::rotatePartLabels(double degrees, QTransform &, QPointF center, QUndoCommand * parentCommand)
+void SketchWidget::rotatePartLabels(double degrees, QTransform & transform, QPointF center, QUndoCommand * parentCommand)
 {
-	Q_UNUSED(center);
-	Q_UNUSED(degrees);
-	Q_UNUSED(parentCommand);
+	QList<ItemBase *> savedValues = m_savedItems.values();
+	/*
+	QSet<ItemBase *> boards;
+	foreach (ItemBase * itemBase, savedValues) {
+		if (Board::isBoard(itemBase)) {
+			boards.insert(itemBase);
+		}
+	}
+
+
+	if (boards.count() == 0) return;
+
+	QRectF bbr;
+	foreach (ItemBase * board, boards.values()) {
+		bbr |= board->sceneBoundingRect();
+	}
+	*/
+
+	foreach (QGraphicsItem * item, scene()->items()) {
+		PartLabel * partLabel = dynamic_cast<PartLabel *>(item);
+		if (partLabel == NULL) continue;
+		if (!partLabel->isVisible()) continue;
+		//if (!bbr.intersects(partLabel->sceneBoundingRect())) continue;  // if the part is on the board and the label is off the board, this does not rotate
+		if (!savedValues.contains(partLabel->owner()->layerKinChief())) continue;
+
+		QPointF offset = partLabel->pos() - partLabel->owner()->pos();
+		new MoveLabelCommand(this, partLabel->owner()->id(), partLabel->pos(), offset, partLabel->pos(), offset, parentCommand);
+		//Labels need to be readable (change the 90 and 180 degrees orientation to 270 or 0 degrees)
+		//Labels can be still be forced to 90 and 180 degrees through the right click menu
+		double finalOrientation = degrees + atan2(partLabel->transform().m12(), partLabel->transform().m11())/M_PI*180;
+		if(abs(finalOrientation-90) < 0.1 || abs(finalOrientation-180) < 0.1)
+			degrees+=180;
+
+		new RotateFlipLabelCommand(this, partLabel->owner()->id(), degrees, 0, parentCommand);
+		QPointF p = GraphicsUtils::calcRotation(transform, center, partLabel->pos(), partLabel->boundingRect().center());
+		ViewGeometry vg;
+		partLabel->owner()->calcRotation(transform, center, vg);
+		new MoveLabelCommand(this, partLabel->owner()->id(), p, p - vg.loc(), p, p - vg.loc(), parentCommand);
+	}
 }
 
 void SketchWidget::flipX(Qt::Orientations orientation, bool rubberBandLegEnabled)

--- a/src/sketch/sketchwidget.h
+++ b/src/sketch/sketchwidget.h
@@ -492,7 +492,7 @@ protected:
 	void changeLegAux(long fromID, const QString & fromConnectorID, const QPolygonF &, bool reset, bool relative, bool active, const QString & why);
 	void moveLegBendpoints(bool undoOnly, QUndoCommand * parentCommand);
 	void moveLegBendpointsAux(ConnectorItem * connectorItem, bool undoOnly, QUndoCommand * parentCommand);
-	virtual void rotatePartLabels(double degrees, QTransform &, QPointF center, QUndoCommand * parentCommand);
+	void rotatePartLabels(double degrees, QTransform &, QPointF center, QUndoCommand * parentCommand);
 	bool checkUpdateRatsnest(QList<ConnectorItem *> & connectorItems);
 	void makeRatsnestViewGeometry(ViewGeometry & viewGeometry, ConnectorItem * source, ConnectorItem * dest);
 	virtual double getTraceWidth();


### PR DESCRIPTION
When I made the examples for the simulator, making the circuits took too much time. These shortcuts will help to make Fritzing more user friendly. I used R and F (without control) as it is the same as in Kicad.
