### PR TITLE
Fix linkage error when building with vs2019

### DIFF
--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -48,6 +48,13 @@ win32 {
     }
 
     LIBS += -L$$LIBGIT2LIB -lgit2
+
+    win32-msvc* {
+        MSVC_VER=$$(VisualStudioVersion)
+        equals(MSVC_VER, 16.0) {
+            LIBS += -lWinhttp -lAdvapi32 -lCrypt32 -lRpcrt4 -lOle32
+        }
+    }
 }
 
 unix {


### PR DESCRIPTION
Added missing libraries for libgit2 into LIB list when building with vs2019

Issue : #3914