### PR TITLE
Add StartupWMClass to .desktop file

### DIFF
--- a/org.fritzing.Fritzing.desktop
+++ b/org.fritzing.Fritzing.desktop
@@ -14,3 +14,4 @@ Categories=Development;IDE;Electronics;
 Keywords=EDA;PCB;prototype;circuit;schematic;
 StartupNotify=true
 MimeType=application/x-fritzing-fz;application/x-fritzing-fzz;application/x-fritzing-fzp;application/x-fritzing-fzpz;application/x-fritzing-fzb;application/x-fritzing-fzbz;application/x-fritzing-fzm;
+StartupWMClass=Fritzing


### PR DESCRIPTION
This solves a problem where running Fritzing as a Flatpak app on elementaryOS will duplicate the Dock icon.

The maintainer of the flathub repository [suggested I contribute this fix upstream](https://github.com/flathub/org.fritzing.Fritzing/pull/12), since setting the StartupWMClass is a sensible thing to do even outside of the flatpak runtime.

Please see https://github.com/elementary/dock/issues/64 for some background information on this problem.