### PR TITLE
Update the timer for swapping parts

### DIFF
--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -311,7 +311,7 @@ MainWindow::MainWindow(ReferenceModel *referenceModel, QWidget * parent) :
 	setAcceptDrops(true);
 	m_activeWire = NULL;
 	m_activeConnectorItem = NULL;
-	m_swapTimer.setInterval(30);
+	m_swapTimer.setInterval(300);
 	m_swapTimer.setParent(this);
 	m_swapTimer.setSingleShot(true);
 	connect(&m_swapTimer, SIGNAL(timeout()), this, SLOT(swapSelectedTimeout()));


### PR DESCRIPTION
This change fixes issue #1431. I am not sure that this is the right way of fixing this issue, but at least it will mitigate the issue.
I would disable the change of the properties by scrolling, except that the property combobox had been selected. This will avoid the fact that you can unintentionally change properties of the part when scrolling through the inspector pane.