### PR TITLE
Fixes dragging bendpoints of 4 or more wires (fixes #3006).

### DIFF
--- a/src/connectors/connectoritem.cpp
+++ b/src/connectors/connectoritem.cpp
@@ -535,6 +535,10 @@ void ConnectorItem::restoreColor(QList<ConnectorItem *> & visited)
 		}
 	}
 
+	//In PCB view, there are two connectors on top of each other.
+	//This line removes the other one which is in the opposite layer.
+	attachedTo.remove(this->getCrossLayerConnectorItem());
+
 	foreach (ConnectorItem * connectorItem, connectorItems) {
 		if (connectorItem->isEverVisible()) {
 			//QString how;

--- a/src/connectors/connectoritem.cpp
+++ b/src/connectors/connectoritem.cpp
@@ -530,14 +530,13 @@ void ConnectorItem::restoreColor(QList<ConnectorItem *> & visited)
 	foreach (ConnectorItem * connectorItem, connectorItems) {
 		if (connectorItem->isEverVisible()) {
 			if (connectorItem->attachedToItemType() != ModelPart::Wire) {
-				attachedTo.insert(connectorItem);
+				//For PCB pad stacks: Only add one connector to the attachedTo list (top or bottom copper)
+				if(!attachedTo.contains(connectorItem->getCrossLayerConnectorItem())) {
+					attachedTo.insert(connectorItem);
+				}
 			}
 		}
 	}
-
-	//In PCB view, there are two connectors on top of each other.
-	//This line removes the other one which is in the opposite layer.
-	attachedTo.remove(this->getCrossLayerConnectorItem());
 
 	foreach (ConnectorItem * connectorItem, connectorItems) {
 		if (connectorItem->isEverVisible()) {
@@ -559,7 +558,24 @@ void ConnectorItem::restoreColor(QList<ConnectorItem *> & visited)
 			}
 		}
 	}
-
+	if (this->attachedToViewID() == 3) {
+		DebugDialog::debug(QString("FAI restore color PCB equalPotential: %1 attachedTo: %2")
+			.arg(connectorItems.count())
+			.arg(attachedTo.count())
+		);
+		for(ConnectorItem * c : connectorItems)
+			DebugDialog::debug(QString("equalPotential conn, title: %1 %2 %3")
+				.arg(c->attachedToTitle())
+				.arg(c->attachedTo()->label())
+				.arg(c->attachedTo()->viewLayerID())
+			);
+		for(ConnectorItem * c : attachedTo)
+			DebugDialog::debug(QString("attachedTo conn, title: %1 %2 %3")
+				.arg(c->attachedToTitle())
+				.arg(c->attachedTo()->label())
+				.arg(c->attachedTo()->viewLayerID())
+			);
+	}
 
 	/*
 	DebugDialog::debug(QString("restore color dobus:%1 bccount:%2 docross:%3 cid:'%4' '%5' id:%6 '%7' vid:%8 vlid:%9 %10")

--- a/src/connectors/connectoritem.cpp
+++ b/src/connectors/connectoritem.cpp
@@ -523,13 +523,14 @@ void ConnectorItem::restoreColor(QList<ConnectorItem *> & visited)
 
 	QList<ConnectorItem *> connectorItems;
 	connectorItems.append(this);
-	collectEqualPotential(connectorItems, true, getSkipFlags());
+	collectEqualPotential(connectorItems, true, getSkipFlags(), false);
 	visited.append(connectorItems);
-	QSet<ItemBase *> attachedTo;
+
+	QSet<ConnectorItem *> attachedTo;
 	foreach (ConnectorItem * connectorItem, connectorItems) {
 		if (connectorItem->isEverVisible()) {
 			if (connectorItem->attachedToItemType() != ModelPart::Wire) {
-				attachedTo.insert(connectorItem->attachedTo()->layerKinChief());
+				attachedTo.insert(connectorItem);
 			}
 		}
 	}
@@ -1315,7 +1316,7 @@ bool ConnectorItem::isConnectedToPart() {
  * @param[in] skipFlags filter for the types of wires that are not to be included
  */
 void ConnectorItem::collectEqualPotential(QList<ConnectorItem *> &connectorItems,
-										  bool crossLayers, ViewGeometry::WireFlags skipFlags)
+										  bool crossLayers, ViewGeometry::WireFlags skipFlags, bool followBuses)
 {
 	// take a local (temporary working) copy of the supplied list, and wipe the original
 	QList<ConnectorItem *> tempItems = connectorItems;
@@ -1365,7 +1366,7 @@ void ConnectorItem::collectEqualPotential(QList<ConnectorItem *> &connectorItems
 		// When the kept connector item is part of a bus, include all of the other
 		// connectors on the bus in the list being processed
 		Bus *bus = connectorItem->bus();
-		if (bus) {
+		if (bus && (followBuses||fromWire)) {
 			QList<ConnectorItem *> busConnectedItems;
 			connectorItem->attachedTo()->busConnectorItems(bus, connectorItem, busConnectedItems);
 #ifndef QT_NO_DEBUG

--- a/src/connectors/connectoritem.h
+++ b/src/connectors/connectoritem.h
@@ -235,7 +235,7 @@ protected:
 	static void collectPart(ConnectorItem * connectorItem, QList<ConnectorItem *> & partsConnectors, ViewLayer::ViewLayerPlacement);
 
 public:
-	static void collectEqualPotential(QList<ConnectorItem *> & connectorItems, bool crossLayers, ViewGeometry::WireFlags skipFlags);
+	static void collectEqualPotential(QList<ConnectorItem *> & connectorItems, bool crossLayers, ViewGeometry::WireFlags skipFlags, bool followBuses  = true);
 	static void collectParts(QList<ConnectorItem *> & connectorItems, QList<ConnectorItem *> & partsConnectors, bool includeSymbols, ViewLayer::ViewLayerPlacement);
 	static void clearEqualPotentialDisplay();
 	static bool isGrounded(ConnectorItem * c1, ConnectorItem * c2);

--- a/src/items/wire.cpp
+++ b/src/items/wire.cpp
@@ -622,7 +622,7 @@ void Wire::mouseMoveEventAux(QPointF eventPos, Qt::KeyboardModifiers modifiers) 
 		}
 	}
 
-	QSet<ConnectorItem *> allTo(allToList.begin(), allToList.end());;
+	QSet<ConnectorItem *> allTo(allToList.begin(), allToList.end());
 
 	// TODO: this could all be determined once at mouse press time
 	if (allTo.count() == 0) {

--- a/src/items/wire.cpp
+++ b/src/items/wire.cpp
@@ -600,22 +600,31 @@ void Wire::mouseMoveEventAux(QPointF eventPos, Qt::KeyboardModifiers modifiers) 
 	}
 	setConnector1Rect();
 
-
-	QSet<ConnectorItem *> allTo;
-	allTo.insert(whichConnectorItem);
+	QList<ConnectorItem *> allToList;
 	foreach (ConnectorItem * toConnectorItem, whichConnectorItem->connectedToItems()) {
 		Wire * chainedWire = qobject_cast<Wire *>(toConnectorItem->attachedTo());
 		if (chainedWire == NULL) continue;
 
-		allTo.insert(toConnectorItem);
-		foreach (ConnectorItem * subTo, toConnectorItem->connectedToItems()) {
-			allTo.insert(subTo);
+		if(!allToList.contains(toConnectorItem)) {
+			allToList.append(toConnectorItem);
 		}
 	}
-	allTo.remove(whichConnectorItem);
+
+	for (int i = 0; i < allToList.size(); i++) {
+		ConnectorItem * conItem = allToList.at(i);
+		foreach(ConnectorItem * toConnectorItem, conItem->connectedToItems()) {
+			Wire * chainedWire = qobject_cast<Wire *>(toConnectorItem->attachedTo());
+			if (chainedWire == NULL) continue;
+
+			if(!allToList.contains(toConnectorItem)) {
+				allToList.append(toConnectorItem);
+			}
+		}
+	}
+
+	QSet<ConnectorItem *> allTo(allToList.begin(), allToList.end());;
 
 	// TODO: this could all be determined once at mouse press time
-
 	if (allTo.count() == 0) {
 		// dragging one end of the wire
 
@@ -684,9 +693,12 @@ void Wire::mouseMoveEventAux(QPointF eventPos, Qt::KeyboardModifiers modifiers) 
 	}
 	else {
 		// dragging a bendpoint
+		DebugDialog::debug("dragging a bendpoint");
+		DebugDialog::debug(QString("CON0 %1 CON1 %2").arg(this->connector0()->connectedToItems().count()).arg(this->connector0()->connectedToItems().count()));
 		foreach (ConnectorItem * toConnectorItem, allTo) {
 			Wire * chained = qobject_cast<Wire *>(toConnectorItem->attachedTo());
 			if (chained) {
+				DebugDialog::debug("dragging a bendpoint123");
 				chained->simpleConnectedMoved(whichConnectorItem, toConnectorItem);
 			}
 		}


### PR DESCRIPTION
This fixes issue #3006. When dragging a bendpoint with a junction of 4 or more wires, all wires are updated correctly. This fixes the schematic and PCB views. 
There is a similar problem  (issue #3580) when dragging a part (the wires connected to that part are not updated correctly). Probably, it is the same cause as in this bug, but in a different part of the code (dragging part code). There is a video of this issue also in #3006.