### PR TITLE
Fix for compiling issues regarding libgit2 etc.

### DIFF
--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -15,6 +15,7 @@
 
 
 packagesExist(libgit2) {
+    LIBGIT_STATIC = false
 } else {
     LIBGIT_STATIC = true
 }


### PR DESCRIPTION
Actual fix for #3595 and #3914; the check for installed packages was not being used hence it always started looking for custom located packages (these locations/files are all seemingly out of date) even though you have them installed properly.