### PR TITLE
Do not show hybrid connectors tooltip Fixes #3578

### DIFF
--- a/src/sketch/fgraphicsscene.cpp
+++ b/src/sketch/fgraphicsscene.cpp
@@ -40,7 +40,7 @@ void FGraphicsScene::helpEvent(QGraphicsSceneHelpEvent *helpEvent)
 	bool found = false;
 	QString text;
 	QPoint point;
-	QGraphicsItem * item;
+	QGraphicsItem * item = nullptr;
 
 	//Find connectors first
 	for (int i = 0; i < itemList.size(); i++) {
@@ -68,6 +68,7 @@ void FGraphicsScene::helpEvent(QGraphicsSceneHelpEvent *helpEvent)
 		}
 	}
 
+	if(!item) return;
 
 	if (!item->toolTip().isEmpty()) {
 		text = item->toolTip();

--- a/src/sketch/fgraphicsscene.cpp
+++ b/src/sketch/fgraphicsscene.cpp
@@ -35,22 +35,39 @@ FGraphicsScene::FGraphicsScene( QObject * parent) : QGraphicsScene(parent)
 void FGraphicsScene::helpEvent(QGraphicsSceneHelpEvent *helpEvent)
 {
 	// TODO: how do we get a QTransform?
-	QGraphicsItem * item = this->itemAt(helpEvent->scenePos(), QTransform());
-	if (item == NULL) return;
+	QList<QGraphicsItem*> itemList = this->items(helpEvent->scenePos(), Qt::IntersectsItemShape, Qt::DescendingOrder, QTransform());
 
+	bool found = false;
 	QString text;
 	QPoint point;
-	ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
-	if (itemBase == NULL) {
-		ConnectorItem * connectorItem = dynamic_cast<ConnectorItem *>(item);
-		if (connectorItem) {
-			connectorItem->updateTooltip();
-		}
+	QGraphicsItem * item;
 
+	//Find connectors first
+	for (int i = 0; i < itemList.size(); i++) {
+		item = itemList.at(i);
+		ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
+		if (itemBase == NULL) {
+			ConnectorItem * connectorItem = dynamic_cast<ConnectorItem *>(item);
+			if (connectorItem && !connectorItem->isHybrid()) {
+				connectorItem->updateTooltip();
+				found = true;
+				break;
+			}
+		}
 	}
-	else {
-		itemBase->updateTooltip();
+
+	//If there are not connectors, find parts
+	if (!found){
+		for (int i = 0; i < itemList.size(); i++) {
+			item = itemList.at(i);
+			ItemBase * itemBase = dynamic_cast<ItemBase *>(item);
+			if (itemBase) {
+				itemBase->updateTooltip();
+				break;
+			}
+		}
 	}
+
 
 	if (!item->toolTip().isEmpty()) {
 		text = item->toolTip();


### PR DESCRIPTION

This PR fixes https://github.com/fritzing/fritzing-app/issues/3578. When the top most item is a hybrid connector, we should look for other connectors or items under it to display the info of a non-hybrid connector.