### PR TITLE
Adv custom spice

### DIFF
--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -315,4 +315,8 @@
 	<suffix suffix="beab33bd7feee277622ef76dd6e79e4d"/>
 </property>
 
+<property name="spice model" symbol="" minValue="" maxValue="" defaultValue="" numeric="no" editable="yes">
+	<suffix suffix="CustomSpiceModuleID"/>
+</property>
+
 </properties>

--- a/src/items/capacitor.cpp
+++ b/src/items/capacitor.cpp
@@ -102,7 +102,7 @@ bool Capacitor::collectExtraInfo(QWidget * parent, const QString & family, const
 				focusOutComboBox->setCurrentIndex(ix);
 			}
 
-			if (propertyDef->editable) {
+			if (propertyDef->editable && propertyDef->numeric) {
 				BoundedRegExpValidator * validator = new BoundedRegExpValidator(focusOutComboBox);
 				validator->setSymbol(propertyDef->symbol);
 				validator->setConverter(TextUtils::convertFromPowerPrefix);

--- a/src/items/moduleidnames.cpp
+++ b/src/items/moduleidnames.cpp
@@ -78,3 +78,4 @@ const QString ModuleIDNames::SchematicFrameModuleIDName = "SchematicFrameModuleI
 const QString ModuleIDNames::CopperBlockerModuleIDName = "BlockerModuleID";
 const QString ModuleIDNames::Copper0BlockerModuleIDName = "Copper0BlockerModuleID";
 const QString ModuleIDNames::Copper1BlockerModuleIDName = "Copper1BlockerModuleID";
+const QString ModuleIDNames::CustomSpiceModuleIDName = "CustomSpiceModuleIDName";

--- a/src/items/moduleidnames.h
+++ b/src/items/moduleidnames.h
@@ -80,6 +80,7 @@ public:
 	static const QString CopperBlockerModuleIDName;
 	static const QString Copper1BlockerModuleIDName;
 	static const QString Copper0BlockerModuleIDName;
+	static const QString CustomSpiceModuleIDName;
 };
 
 #endif


### PR DESCRIPTION
This code is just an initial implementation for feedback. 

This commit (with the respective commit in the parts repository) implements parts where users can adjusts their spice models without creating new parts. This can be useful in debugging simulations. Each part defines its own property "spice model" which thus can be different  from other parts. For now, two of the parts are implemented: diodes and NPN transistors, but there are several more if this is proposal is accepted (see ngSpice manual).
 
