### PR TITLE
clipablewire.cpp: Dropping usage of register storage class

### DIFF
--- a/src/items/clipablewire.cpp
+++ b/src/items/clipablewire.cpp
@@ -50,7 +50,7 @@ static double connectorRectClipInset = 0.5;
 int CrossingsTest( double pgon[][2], int numverts, double point[2] )
 {
 #ifdef	WINDING
-	register int	crossings ;
+	int	crossings ;
 #endif
 	int	j, yflag0, yflag1, inside_flag, xflag0 ;
 	double ty, tx, *vtx0, *vtx1 ;


### PR DESCRIPTION
The register storage class has been depreacted in C++14 and completely removed in C++17. Thus resulting in buils errors such as:

clipablewire.cpp:55:2: error: ISO C++17 does not allow register storage class specifier [-Wregister]

Refer: https://en.cppreference.com/w/cpp/language/storage_duration
Bug: https://bugs.gentoo.org/898070