### PR TITLE
Fix Qt6 build failure on QDomDocument::ParseResult conversion error

### DIFF
--- a/src/model/modelbase.cpp
+++ b/src/model/modelbase.cpp
@@ -844,7 +844,7 @@ ModelPart * ModelBase::createOldSchematicPartAux(ModelPart * modelPart, const QS
 		DebugDialog::debug(QString("Unable to open :%1").arg(modelPart->path()));
 	}
 	QDomDocument oldDoc;
-	bool ok = oldDoc.setContent(&newFzp);
+	bool ok = oldDoc.setContent(&newFzp, nullptr);
 	if (!ok) {
 		// this shouldn't happen
 		return nullptr;


### PR DESCRIPTION
```
src/model/modelbase.cpp: In member function ‘ModelPart* ModelBase::createOldSchematicPartAux(ModelPart*, const QString&, const QString&, const QString&)’: src/model/modelbase.cpp:847:36: error: cannot convert ‘QDomDocument::ParseResult’ to ‘bool’ in initialization
  847 |         bool ok = oldDoc.setContent(&newFzp);
      |                   ~~~~~~~~~~~~~~~~~^~~~~~~~~
      |                                    |
      |                                    QDomDocument::ParseResult
```

Ensure Qt6 uses the deprecated:
bool QDomDocument::setContent(const QByteArray &buffer, QString *errorMsg, int *errorLine = nullptr, int *errorColumn = nullptr)

which in Qt5 is:
bool QDomDocument::setContent(const QByteArray &buffer, QString *errorMsg = nullptr, int *errorLine = nullptr, int *errorColumn = nullptr)