### PR TITLE
fix: resolve QStringBuilder type mismatch in ternary operator

### DIFF
--- a/src/utils/folderutils.cpp
+++ b/src/utils/folderutils.cpp
@@ -835,7 +835,7 @@ bool FolderUtils::checkFileLoadability(QWidget* parent, const QString& filePath)
 		}
 
 		QString errorDetail = errorDetails.isEmpty() ?
-			"" : "\n\nPossible issues:\n• " + errorDetails.join("\n• ");
+			QString("") : "\n\nPossible issues:\n• " + errorDetails.join("\n• ");
 
 		FMessageBox::warning(
 			parent,


### PR DESCRIPTION
### Description

##### Fixes a compilation failure occurring under explicit compilation configurations where `QT_USE_QSTRINGBUILDER` is enforced.

### Problem

##### At line 837 in `src/utils/folderutils.cpp`, a ternary conditional operator (? :) evaluates an empty string literal `(const char*)` on the left branch, and a concatenated `QString` expression on the right branch. Under `QT_USE_QSTRINGBUILDER` optimizations, the right-hand expression evaluates as a lazy `QStringBuilder` template type. Because C++ strict type resolution requires uniform type yields across both conditional evaluation paths, the compiler throws a fatal initialization error due to type mismatch.

### The Solution

##### Explicitly returned an optimized, default-constructed `QString("")` on the true branch evaluation block to satisfy type parity across compiler configurations.

##### note: This is my very first Pull Request to an open-source project. If there are any project-specific formatting preferences, commit linting styles, or documentation guidelines I missed, please let me know