### PR TITLE
Add automatic breadboard component placement and routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ saved_state
 *.qm
 index
 /.qtc_clangd/compile_commands.json
+
+experiments/**/node_modules/
+experiments/netlist-to-fzz/bigmuff.fz
+artifacts/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |master|[![Build Status](https://travis-ci.org/fritzing/fritzing-app.svg?branch=master)](https://travis-ci.org/fritzing/fritzing-app)|
 |develop|[![Build Status](https://travis-ci.org/fritzing/fritzing-app.svg?branch=develop)](https://travis-ci.org/fritzing/fritzing-app)|
 
-The Fritzing application is an Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists. It offers a unique real-life "breadboard" view, and a parts library with many commonly used high-level components. Fritzing makes it very easy to communicate about circuits, as well as to turn them into PCB layouts ready for production. It is particularly popular among Arduino and Raspberry Pi users, and is widely used in education and creative tinkering.
+The Fritzing application is an Electronic Design Automation software with a low entry barrier, suited for the needs of makers and hobbyists. It offers a unique real-life "breadboard" view that can automatically place compatible components and route jumper wires, and a parts library with many commonly used high-level components. Fritzing makes it very easy to communicate about circuits, as well as to turn them into PCB layouts ready for production. It is particularly popular among Arduino and Raspberry Pi users, and is widely used in education and creative tinkering.
 
 * For more information on Fritzing and its related activities, visit [http://fritzing.org](http://fritzing.org). There you can also [download](http://fritzing.org/download) the latest releases for all platforms and get help on getting started.
 

--- a/pri/autoroute.pri
+++ b/pri/autoroute.pri
@@ -17,7 +17,9 @@ HEADERS += \
 src/autoroute/autorouter.h \
 src/autoroute/breadboardautorouter.h \
 src/autoroute/breadboardpartpolicy.h \
+src/autoroute/breadboardplacementkernel.h \
 src/autoroute/breadboardroutegraph.h \
+src/autoroute/breadboardroutegraphcore.h \
 src/autoroute/breadboardroutingscore.h \
 src/autoroute/breadboardtopology.h \
 src/autoroute/autorouteprogressdialog.h \
@@ -33,7 +35,9 @@ SOURCES += \
 src/autoroute/autorouter.cpp \
 src/autoroute/breadboardautorouter.cpp \
 src/autoroute/breadboardpartpolicy.cpp \
+src/autoroute/breadboardplacementkernel.cpp \
 src/autoroute/breadboardroutegraph.cpp \
+src/autoroute/breadboardroutegraphcore.cpp \
 src/autoroute/breadboardroutingscore.cpp \
 src/autoroute/breadboardtopology.cpp \
 src/autoroute/autorouteprogressdialog.cpp \

--- a/pri/autoroute.pri
+++ b/pri/autoroute.pri
@@ -15,6 +15,11 @@
 
 HEADERS += \
 src/autoroute/autorouter.h \
+src/autoroute/breadboardautorouter.h \
+src/autoroute/breadboardpartpolicy.h \
+src/autoroute/breadboardroutegraph.h \
+src/autoroute/breadboardroutingscore.h \
+src/autoroute/breadboardtopology.h \
 src/autoroute/autorouteprogressdialog.h \
 src/autoroute/autoroutersettingsdialog.h \
 src/autoroute/checker.h  \
@@ -26,6 +31,11 @@ src/autoroute/drc.h \
 
 SOURCES += \
 src/autoroute/autorouter.cpp \
+src/autoroute/breadboardautorouter.cpp \
+src/autoroute/breadboardpartpolicy.cpp \
+src/autoroute/breadboardroutegraph.cpp \
+src/autoroute/breadboardroutingscore.cpp \
+src/autoroute/breadboardtopology.cpp \
 src/autoroute/autorouteprogressdialog.cpp \
 src/autoroute/autoroutersettingsdialog.cpp \
 src/autoroute/checker.cpp  \

--- a/pri/clipper1detect.pri
+++ b/pri/clipper1detect.pri
@@ -23,5 +23,15 @@ win32 {
 message("including $$absolute_path($${CLIPPER1}/include)")
 INCLUDEPATH += $$absolute_path($${CLIPPER1}/include/polyclipping)
 
-LIBS += -L$$absolute_path($${CLIPPER1}/lib) -lpolyclipping
-QMAKE_RPATHDIR += $$absolute_path($${CLIPPER1}/lib)
+win32 {
+    CONFIG(debug, debug|release):exists($$absolute_path($${CLIPPER1}/lib/debug/polyclipping.lib)) {
+        LIBS += $$absolute_path($${CLIPPER1}/lib/debug/polyclipping.lib)
+        QMAKE_RPATHDIR += $$absolute_path($${CLIPPER1}/lib/debug)
+    } else {
+        LIBS += $$absolute_path($${CLIPPER1}/lib/polyclipping.lib)
+        QMAKE_RPATHDIR += $$absolute_path($${CLIPPER1}/lib)
+    }
+} else {
+    LIBS += -L$$absolute_path($${CLIPPER1}/lib) -lpolyclipping
+    QMAKE_RPATHDIR += $$absolute_path($${CLIPPER1}/lib)
+}

--- a/pri/quazipdetect.pri
+++ b/pri/quazipdetect.pri
@@ -12,6 +12,10 @@ message("Using Fritzing quazip detect script.")
 # and check https://github.com/stachenov/quazip/issues/185
 QUAZIP_VERSION=1.4
 QUAZIP_PATH=$$absolute_path($$PWD/../../quazip-$$QT_VERSION-$$QUAZIP_VERSION)intuisphere
+QUAZIP_DEBUG_PATH=$$absolute_path($$PWD/../../quazip-$$QT_VERSION-$$QUAZIP_VERSION)intuisphere-debug
+win32:CONFIG(debug, debug|release):exists($$QUAZIP_DEBUG_PATH) {
+	QUAZIP_PATH=$$QUAZIP_DEBUG_PATH
+}
 QUAZIP_INCLUDE_PATH=$$QUAZIP_PATH/include/QuaZip-Qt6-$$QUAZIP_VERSION
 QUAZIP_LIB_PATH=$$QUAZIP_PATH/lib
 
@@ -25,7 +29,11 @@ exists($$QUAZIP_PATH) {
 	}
 
 INCLUDEPATH += $$QUAZIP_INCLUDE_PATH
-LIBS += -L$$QUAZIP_LIB_PATH -lquazip1-qt$$QT_MAJOR_VERSION
+win32:CONFIG(debug, debug|release):exists($$QUAZIP_LIB_PATH/quazip1-qt$${QT_MAJOR_VERSION}d.lib) {
+	LIBS += $$QUAZIP_LIB_PATH/quazip1-qt$${QT_MAJOR_VERSION}d.lib
+} else {
+	LIBS += -L$$QUAZIP_LIB_PATH -lquazip1-qt$$QT_MAJOR_VERSION
+}
 
 unix {
 	message("set rpath for quazip")

--- a/src/autoroute/breadboardautorouter.cpp
+++ b/src/autoroute/breadboardautorouter.cpp
@@ -20,8 +20,14 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "breadboardautorouter.h"
 #include "breadboardpartpolicy.h"
+#include "breadboardplacementkernel.h"
 #include "breadboardroutegraph.h"
+#include "breadboardroutegraphcore.h"
 #include "breadboardtopology.h"
+
+#include <climits>
+#include <functional>
+#include <memory>
 
 #include <QHash>
 #include <QDateTime>
@@ -30,6 +36,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QGraphicsScene>
 #include <QGraphicsItem>
 #include <QSet>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QtMath>
@@ -42,11 +49,40 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../commands.h"
 #include "../items/itembase.h"
 #include "../items/wire.h"
+#include "../processeventblocker.h"
 #include "../sketch/breadboardsketchwidget.h"
 #include "../waitpushundostack.h"
 
 namespace
 {
+	// How to swap the two pin positions of a part so crossed legs uncross
+	// while every net stays on its own pin. Mirroring keeps the body visually
+	// upright and is preferred when the part's fzp allows it; parts without
+	// flip support (e.g. resistors, which are axially symmetric anyway) fall
+	// back to a 180 degree rotation.
+	enum class PinSwap
+	{
+		None,
+		FlipHorizontal,
+		FlipVertical,
+		Rotate180
+	};
+
+	QPointF swappedPoint(const QPointF &point, PinSwap swap, const QPointF &center)
+	{
+		switch (swap)
+		{
+		case PinSwap::FlipHorizontal:
+			return QPointF(center.x() * 2.0 - point.x(), point.y());
+		case PinSwap::FlipVertical:
+			return QPointF(point.x(), center.y() * 2.0 - point.y());
+		case PinSwap::Rotate180:
+			return center * 2.0 - point;
+		default:
+			return point;
+		}
+	}
+
 	struct PlacementCandidate
 	{
 		ItemBase *item = nullptr;
@@ -56,12 +92,19 @@ namespace
 		QHash<ConnectorItem *, QPolygonF> pinToLeg;
 		double score = std::numeric_limits<double>::max();
 		bool usesLegPlacement = false;
+		PinSwap pinSwap = PinSwap::None;
 	};
+
+	constexpr double FlipRotationDegrees = 180.0;
+
+	// Progress is reported as a weighted percentage: placement dominates
+	// wall-clock on real sketches, routing search is comparatively quick.
+	constexpr int PlacementProgressSpan = 70;
+	constexpr int RoutingProgressEnd = 95;
 
 	constexpr double HoleMatchTolerance = 12.0;
 	constexpr double PlacementKeepoutMargin = 8.0;
 	constexpr double BendablePlacementKeepoutMargin = 1.0;
-	constexpr double MaxBendableLegLength = 120.0;
 
 	ViewGeometry::WireFlags generatedWireFlags()
 	{
@@ -74,12 +117,171 @@ namespace
 		return QLineF(from->sceneAdjustedTerminalPoint(nullptr), to->sceneAdjustedTerminalPoint(nullptr));
 	}
 
-	BreadboardRouteGraph::Options routeGraphOptions(const QList<QLineF> &plannedSegments)
+	// A female connector only counts as a breadboard hole when its owner IS
+	// a breadboard. Breakout boards (LSM303C etc.) have female header
+	// sockets too; treating those as holes turned them into phantom board
+	// anchors that routing could never reach.
+	bool isBreadboardHoleConnector(ConnectorItem *connectorItem)
 	{
-		BreadboardRouteGraph::Options options = BreadboardRouteGraph::Options::fromEnvironment();
-		options.existingSegments = plannedSegments;
+		if (connectorItem == nullptr || connectorItem->connectorType() != Connector::Female)
+			return false;
+		ItemBase *owner = connectorItem->attachedTo();
+		if (owner == nullptr)
+			return false;
+		return BreadboardTopology::isBreadboardItem(owner->layerKinChief());
+	}
+
+	BreadboardRouteGraphCore::Options coreRouteOptions()
+	{
+		const BreadboardRouteGraph::Options env = BreadboardRouteGraph::Options::fromEnvironment();
+		BreadboardRouteGraphCore::Options options;
+		options.maxJumperLength = env.maxJumperLength;
+		options.jumperPenalty = env.jumperPenalty;
+		options.crossingPenalty = env.crossingPenalty;
+		options.overlapPenalty = env.overlapPenalty;
+		options.candidatesPerBusPair = env.candidatesPerBusPair;
 		return options;
 	}
+
+	// Builds the static bus graph ONCE per routing pass. Everything that
+	// changes as routing proceeds - reserved holes and planned segments -
+	// is supplied per route() query. Results are mapped back to the old
+	// ConnectorItem-based Result so call sites stay unchanged.
+	struct RouteGraphSession
+	{
+		QList<ConnectorItem *> holes;
+		QHash<ConnectorItem *, int> indexForHole;
+		QVector<bool> baseBlocked;
+		QVector<int> busGroupForHole;    // global bus group id per hole
+		QVector<int> denseBusForHole;    // session-dense bus id per hole
+		int denseBusCount = 0;
+		std::function<int(int)> ownerOfBusGroup;
+		std::shared_ptr<BreadboardRouteGraphCore> core;
+
+		static RouteGraphSession build(const QList<ConnectorItem *> &routeHoles,
+									   const std::function<int(ConnectorItem *)> &busGroup,
+									   const std::function<int(int)> &ownerOfBusGroup)
+		{
+			RouteGraphSession session;
+			session.holes = routeHoles;
+			session.ownerOfBusGroup = ownerOfBusGroup;
+			QVector<QPointF> positions(routeHoles.count());
+			QVector<int> busIds(routeHoles.count(), -1);
+			session.baseBlocked = QVector<bool>(routeHoles.count(), false);
+			session.busGroupForHole = QVector<int>(routeHoles.count(), -1);
+			QHash<int, int> denseBusFor;
+			for (int i = 0; i < routeHoles.count(); i++)
+			{
+				ConnectorItem *hole = routeHoles.at(i);
+				if (hole == nullptr)
+					continue;
+				session.indexForHole.insert(hole, i);
+				positions[i] = hole->sceneAdjustedTerminalPoint(nullptr);
+				const int group = busGroup(hole);
+				session.busGroupForHole[i] = group;
+				auto found = denseBusFor.constFind(group);
+				if (found == denseBusFor.constEnd())
+				{
+					busIds[i] = denseBusFor.count();
+					denseBusFor.insert(group, busIds[i]);
+				}
+				else
+				{
+					busIds[i] = found.value();
+				}
+				// Occupancy is stable during a pass: wire commands only
+				// execute at push, after routing has finished.
+				session.baseBlocked[i] = hole->connectionsCount() != 0;
+			}
+			session.denseBusForHole = busIds;
+			session.denseBusCount = denseBusFor.count();
+			session.core = std::make_shared<BreadboardRouteGraphCore>(positions, busIds, coreRouteOptions());
+			return session;
+		}
+
+		// Build once per batch of route() calls sharing the same reserved
+		// set, planned segments, and querying net - this replaces the old
+		// per-batch graph reconstruction at a fraction of its cost. Buses
+		// owned by any other key are blocked outright (prime invariant).
+		BreadboardRouteGraphCore::QueryContext prepare(const QSet<ConnectorItem *> &reserved,
+													   const QList<QLineF> &plannedSegments,
+													   int netOwnerKey) const
+		{
+			QVector<bool> blocked = baseBlocked;
+			Q_FOREACH (ConnectorItem *hole, reserved)
+			{
+				const int index = indexForHole.value(hole, -1);
+				if (index >= 0)
+					blocked[index] = true;
+			}
+			QVector<bool> busBlocked(denseBusCount, false);
+			for (int i = 0; i < holes.count(); i++)
+			{
+				const int dense = denseBusForHole.at(i);
+				if (dense < 0 || busBlocked.at(dense))
+					continue;
+				const int owner = ownerOfBusGroup ? ownerOfBusGroup(busGroupForHole.at(i)) : -1;
+				if (owner != -1 && owner != netOwnerKey)
+					busBlocked[dense] = true;
+			}
+			return core->prepareQuery(blocked, busBlocked, plannedSegments);
+		}
+
+		BreadboardRouteGraph::Result mapResult(const BreadboardRouteGraphCore::Result &result) const
+		{
+			BreadboardRouteGraph::Result mapped;
+			mapped.found = result.found;
+			mapped.cost = result.cost;
+			mapped.score = result.score;
+			mapped.reason = result.reason;
+			Q_FOREACH (const BreadboardRouteGraphCore::Segment &segment, result.segments)
+			{
+				BreadboardRouteGraph::Segment mappedSegment;
+				mappedSegment.from = holes.at(segment.fromHole);
+				mappedSegment.to = holes.at(segment.toHole);
+				mappedSegment.cost = segment.cost;
+				mapped.segments.append(mappedSegment);
+			}
+			return mapped;
+		}
+
+		BreadboardRouteGraph::Result route(ConnectorItem *from, ConnectorItem *to,
+										   const BreadboardRouteGraphCore::QueryContext &context) const
+		{
+			const int fromIndex = indexForHole.value(from, -1);
+			const int toIndex = indexForHole.value(to, -1);
+			if (fromIndex < 0 || toIndex < 0)
+			{
+				BreadboardRouteGraph::Result mapped;
+				mapped.reason = "endpoint is not a routable breadboard hole";
+				return mapped;
+			}
+			return mapResult(core->route(fromIndex, toIndex, context));
+		}
+
+		// One Dijkstra from `source` answers every later extract() in O(path).
+		BreadboardRouteGraphCore::MultiResult routeFrom(ConnectorItem *source,
+														const BreadboardRouteGraphCore::QueryContext &context) const
+		{
+			const int index = indexForHole.value(source, -1);
+			if (index < 0)
+				return BreadboardRouteGraphCore::MultiResult();
+			return core->routeFrom(index, context);
+		}
+
+		BreadboardRouteGraph::Result extract(const BreadboardRouteGraphCore::MultiResult &multi,
+											 ConnectorItem *target) const
+		{
+			const int index = indexForHole.value(target, -1);
+			if (index < 0)
+			{
+				BreadboardRouteGraph::Result mapped;
+				mapped.reason = "endpoint is not a routable breadboard hole";
+				return mapped;
+			}
+			return mapResult(core->extractRoute(multi, index));
+		}
+	};
 
 	double leadCongestionPenalty(ConnectorItem *from, ConnectorItem *to, const QList<QLineF> &plannedSegments)
 	{
@@ -190,25 +392,24 @@ namespace
 		return edgeDistance * 8.0 + perpendicularDistance + manhattanDistance(terminalPoint, entryPoint) * 0.1;
 	}
 
-	QPolygonF translatedLegForTarget(ConnectorItem *pin, const QPointF &offset, ConnectorItem *hole)
+	QPolygonF translatedLegForTarget(ConnectorItem *pin, const QPointF &offset, ConnectorItem *hole,
+									 PinSwap swap = PinSwap::None, const QPointF &swapCenter = QPointF())
 	{
 		QPolygonF translated;
 		if (pin == nullptr || hole == nullptr)
 			return translated;
 
+		// Do not preserve the leg's historical bend points: after the part
+		// moves they describe a stale shape, and snapping only the endpoint
+		// to the hole produces zigzag leads. Bend a fresh straight lead from
+		// the leg root at the body to the assigned hole instead.
 		QPolygonF oldLeg = pin->sceneAdjustedLeg();
-		if (oldLeg.count() < 2)
-		{
-			translated << pin->sceneAdjustedTerminalPoint(nullptr) + offset;
-			translated << hole->sceneAdjustedTerminalPoint(nullptr);
-			return translated;
-		}
-
-		Q_FOREACH (QPointF point, oldLeg)
-		{
-			translated << point + offset;
-		}
-		translated.replace(translated.count() - 1, hole->sceneAdjustedTerminalPoint(nullptr));
+		QPointF root = oldLeg.count() >= 2
+			? oldLeg.first()
+			: pin->sceneAdjustedTerminalPoint(nullptr);
+		root = swappedPoint(root, swap, swapCenter);
+		translated << root + offset;
+		translated << hole->sceneAdjustedTerminalPoint(nullptr);
 		return translated;
 	}
 
@@ -272,6 +473,19 @@ BreadboardAutorouter::BreadboardAutorouter(BreadboardSketchWidget *sketchWidget)
 {
 }
 
+QString BreadboardAutorouter::PhaseStats::toString() const
+{
+	return QString("clear=%1ms collect=%2ms placeSearch=%3ms placeExec=%4ms routeSearch=%5ms routeExec=%6ms completion=%7ms cleanup=%8ms")
+		.arg(clearMs)
+		.arg(collectMs)
+		.arg(placeSearchMs)
+		.arg(placeExecMs)
+		.arg(routeSearchMs)
+		.arg(routeExecMs)
+		.arg(completionMs)
+		.arg(cleanupMs);
+}
+
 BreadboardAutorouter::~BreadboardAutorouter()
 {
 	clearCollectedNets();
@@ -285,40 +499,27 @@ void BreadboardAutorouter::start()
 	elapsed.start();
 	m_componentLeadLength = 0.0;
 	m_lastRoutingScore = BreadboardRoutingScore();
+	m_phaseStats = PhaseStats();
+	QElapsedTimer phaseTimer;
+	phaseTimer.start();
+	auto takePhaseMs = [&phaseTimer]() {
+		const qint64 ms = phaseTimer.elapsed();
+		phaseTimer.restart();
+		return ms;
+	};
 
 	QFile::remove(logFilePath());
 	logAutoroute("========== breadboard autoroute start ==========");
 	logAutoroute(QString("log file: %1").arg(logFilePath()));
-
-	const int cleared = clearPreviousAutorouteWires();
-	if (cleared > 0)
-	{
-		Q_EMIT setMaximumProgress(1);
-		Q_EMIT setProgressValue(1);
-		Q_EMIT setProgressMessage(QObject::tr("Breadboard routes cleared."));
-		Q_EMIT setProgressMessage2(QObject::tr("Removed %1 generated breadboard wire(s).").arg(cleared));
-		logAutoroute(QString("clear complete: removedWires=%1").arg(cleared));
-		logAutoroute("========== breadboard autoroute end ==========");
-		return;
-	}
-
-	clearCollectedNets();
-
-	QHash<ConnectorItem *, int> indexer;
-	m_sketchWidget->collectAllNets(indexer, m_allPartConnectorItems, false, false, false);
-	logAutoroute(QString("collectAllNets: nets=%1 indexer=%2").arg(m_allPartConnectorItems.count()).arg(indexer.count()));
-
-	if (m_allPartConnectorItems.isEmpty())
-	{
-		logAutoroute("abort: no breadboard connections to route");
-		QMessageBox::information(nullptr, QObject::tr("Fritzing"), QObject::tr("No breadboard connections to route."));
-		return;
-	}
-
-	Q_EMIT setMaximumProgress(m_allPartConnectorItems.count());
-	Q_EMIT setProgressValue(0);
-	Q_EMIT setProgressMessage(QObject::tr("Placing breadboard parts..."));
-	Q_EMIT setProgressMessage2(QString());
+	loadTuning();
+	logAutoroute(QString("tuning: maxLegLength=%1 leadLengthWeight=%2 jumperPenalty=%3 leadAngleWeight=%4 foldbackWeight=%5")
+				 .arg(m_maxLegLength)
+				 .arg(m_leadLengthWeight)
+				 .arg(m_jumperPenalty)
+				 .arg(m_leadAngleWeight)
+				 .arg(m_foldbackWeight));
+	// Flush immediately so external watchers see the log recreated at start.
+	flushAutorouteLog();
 
 	auto *undoStack = m_sketchWidget->undoStack();
 	const int undoCountBefore = undoStack->count();
@@ -327,28 +528,110 @@ void BreadboardAutorouter::start()
 				 .arg(undoCountBefore)
 				 .arg(undoIndexBefore));
 	undoStack->beginMacro(QObject::tr("Breadboard autoroute"));
+
+	invalidateRoutingCaches();
+	phaseTimer.restart();
+	const int cleared = clearPreviousAutorouteWires();
+	m_phaseStats.clearMs = takePhaseMs();
+	invalidateRoutingCaches();
+	if (cleared > 0)
+	{
+		logAutoroute(QString("clear complete: removedWires=%1").arg(cleared));
+		Q_EMIT setProgressMessage(QObject::tr("Cleared previous breadboard routes..."));
+		Q_EMIT setProgressMessage2(QObject::tr("Removed %1 generated breadboard wire(s).").arg(cleared));
+	}
+
+	clearCollectedNets();
+
+	QHash<ConnectorItem *, int> indexer;
+	m_sketchWidget->collectAllNets(indexer, m_allPartConnectorItems, false, false, false);
+	sortCollectedNets();
+	m_phaseStats.collectMs = takePhaseMs();
+	logAutoroute(QString("collectAllNets: nets=%1 indexer=%2").arg(m_allPartConnectorItems.count()).arg(indexer.count()));
+
+	if (m_allPartConnectorItems.isEmpty())
+	{
+		undoStack->endMacro();
+		logAutoroute("abort: no breadboard connections to route");
+		flushAutorouteLog();
+		QMessageBox::information(nullptr, QObject::tr("Fritzing"), QObject::tr("No breadboard connections to route."));
+		return;
+	}
+
+	Q_EMIT setMaximumProgress(100);
+	Q_EMIT setProgressValue(0);
+	Q_EMIT setProgressMessage(QObject::tr("Placing breadboard parts..."));
+	Q_EMIT setProgressMessage2(QString());
+	m_progressPumpTimer.start();
+
+	// Prime invariant machinery: seed bus ownership from existing
+	// connections and record net contacts that already exist so the
+	// post-route conformance audit only fails on connections WE created.
+	seedBusOwnership();
+	m_preExistingNetContacts.clear();
+	{
+		QStringList ignored;
+		verifySchematicConformance(ignored, true);
+		if (!m_preExistingNetContacts.isEmpty())
+			logAutoroute(QString("pre-existing net contacts (exempt from audit): %1").arg(m_preExistingNetContacts.count()));
+	}
+
+	phaseTimer.restart();
 	int placed = autoplacePartsOnBreadboard();
+	// placeExecMs is recorded inside autoplace around its command push.
+	m_phaseStats.placeSearchMs = takePhaseMs() - m_phaseStats.placeExecMs;
 	logAutoroute(QString("undo transaction after placement: count=%1 index=%2")
 				 .arg(undoStack->count())
 				 .arg(undoStack->index()));
 	logAutoroute(QString("autoplace complete: placed=%1").arg(placed));
+	if (placed < 0)
+	{
+		clearCollectedNets();
+		undoStack->endMacro();
+		undoStack->undo();
+		logAutoroute("abort: placement connection verification failed; transaction rolled back");
+		flushAutorouteLog();
+		QMessageBox messageBox(QMessageBox::Critical,
+							   QObject::tr("Fritzing"),
+							   QObject::tr("Breadboard placement produced detached component pins and was rolled back."));
+		messageBox.setDetailedText(m_lastPlacementReport);
+		messageBox.exec();
+		return;
+	}
 	if (placed > 0)
 	{
 		clearCollectedNets();
 		indexer.clear();
 		m_sketchWidget->collectAllNets(indexer, m_allPartConnectorItems, false, false, false);
+		sortCollectedNets();
 		logAutoroute(QString("collectAllNets after placement: nets=%1 indexer=%2").arg(m_allPartConnectorItems.count()).arg(indexer.count()));
-		Q_EMIT setMaximumProgress(m_allPartConnectorItems.count());
+
+		// Placement merges equal-potential groups (pins now share buses), so
+		// this collection numbers nets differently from the one that seeded
+		// bus ownership - and net indices double as ownership keys. Re-derive
+		// ownership and the audit baseline from the current scene so routing,
+		// claims and the conformance audit all key off THIS collection.
+		// Everything placement claimed is re-derivable: its pins are
+		// physically connected by now, and any placement-created short would
+		// surface here as a logged seed conflict.
+		seedBusOwnership();
+		m_preExistingNetContacts.clear();
+		{
+			QStringList ignored;
+			verifySchematicConformance(ignored, true);
+		}
 	}
 
 	Q_EMIT setProgressMessage(QObject::tr("Routing breadboard jumpers..."));
 
 	auto *parentCommand = new QUndoCommand(QObject::tr("Route breadboard jumpers"));
 
+	phaseTimer.restart();
 	int created = routeCollectedNets(parentCommand);
+	m_phaseStats.routeSearchMs = takePhaseMs();
 	logAutoroute(QString("route complete: createdWires=%1").arg(created));
 
-	Q_EMIT setProgressValue(m_allPartConnectorItems.count());
+	Q_EMIT setProgressValue(RoutingProgressEnd);
 
 	if (placed <= 0 && created <= 0)
 	{
@@ -361,6 +644,7 @@ void BreadboardAutorouter::start()
 		logAutoroute("abort: no valid placement or route");
 		if (!m_lastPlacementReport.isEmpty())
 			logAutoroute(QString("placement report:\n%1").arg(m_lastPlacementReport));
+		flushAutorouteLog();
 		QMessageBox messageBox(QMessageBox::Information,
 							   QObject::tr("Fritzing"),
 							   QObject::tr("Breadboard autoroute did not find a valid placement or route."));
@@ -374,23 +658,128 @@ void BreadboardAutorouter::start()
 
 	new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, parentCommand);
 	new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, parentCommand);
+	phaseTimer.restart();
 	undoStack->push(parentCommand);
+	m_phaseStats.routeExecMs = takePhaseMs();
+	// Pushed commands created wires: the cached wire-ends list is stale.
+	invalidateRoutingCaches();
+
+	// The net-level planner minimizes jumpers, but Fritzing's ratsnest model is
+	// the authoritative completion check. Route only demands that remain after
+	// the optimized commands have executed; never report success over ratnests.
+	int residualRatsnests = countUnresolvedNets();
+	if (residualRatsnests > 0)
+	{
+		logAutoroute(QString("completion pass begin: residualRatsnests=%1").arg(residualRatsnests));
+		auto *completionCommand = new QUndoCommand(QObject::tr("Complete breadboard routes"));
+		const int completed = routeRatsnestDemands(completionCommand);
+		if (completed > 0)
+		{
+			new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, completionCommand);
+			new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, completionCommand);
+			undoStack->push(completionCommand);
+			invalidateRoutingCaches();
+			created += completed;
+		}
+		else
+		{
+			delete completionCommand;
+		}
+		residualRatsnests = countUnresolvedNets();
+		logAutoroute(QString("completion pass end: createdWires=%1 residualRatsnests=%2")
+					 .arg(completed)
+					 .arg(residualRatsnests));
+	}
+	m_phaseStats.completionMs = takePhaseMs();
+
+	// PRIME INVARIANT audit: the routed result must not connect nets that
+	// the schematic keeps separate. Any violation is our bug - roll the
+	// entire autoroute back rather than ship a wrong circuit.
+	// PRIME INVARIANT audit: bus-ownership prevents shorts by construction;
+	// this is the independent belt-and-braces check (breadboard-only bus
+	// union-find, verified to report 0 on valid routes). Any violation is
+	// our bug - roll the whole autoroute back rather than ship a wrong
+	// circuit.
+	{
+		QStringList violations;
+		if (!verifySchematicConformance(violations))
+		{
+			logAutoroute(QString("SCHEMATIC CONFORMANCE FAILED (%1 shorts):\n%2")
+							 .arg(violations.count())
+							 .arg(violations.join('\n')));
+			undoStack->endMacro();
+			undoStack->undo();
+			flushAutorouteLog();
+			QMessageBox messageBox(QMessageBox::Critical,
+								   QObject::tr("Fritzing"),
+								   QObject::tr("Autoroute created connections that do not exist in the schematic and was rolled back."));
+			messageBox.setDetailedText(violations.join('\n'));
+			messageBox.exec();
+			return;
+		}
+		logAutoroute("schematic conformance verified: no breadboard shorts between schematic nets");
+	}
+
 	logAutoroute(QString("undo transaction after routing: count=%1 index=%2")
 				 .arg(undoStack->count())
 				 .arg(undoStack->index()));
 	undoStack->endMacro();
+	m_phaseStats.cleanupMs = takePhaseMs();
 	logAutoroute(QString("undo transaction end: count=%1 index=%2 delta=%3")
 				 .arg(undoStack->count())
 				 .arg(undoStack->index())
 				 .arg(undoStack->count() - undoCountBefore));
-	m_lastRoutingScore.failedNets = countUnresolvedNets();
+	m_lastRoutingScore.failedNets = residualRatsnests;
+	logAutoroute(QString("phase-summary: %1 total=%2ms score={%3}")
+				 .arg(m_phaseStats.toString())
+				 .arg(elapsed.elapsed())
+				 .arg(m_lastRoutingScore.toString()));
 	logAutoroute(QString("benchmark: %1 elapsedMs=%2")
 				 .arg(m_lastRoutingScore.toString())
 				 .arg(elapsed.elapsed()));
 
-	Q_EMIT setProgressMessage2(QObject::tr("Placed %1 part(s), created %2 breadboard jumper wire(s).").arg(placed).arg(created));
-	logAutoroute(QString("success: placed=%1 createdWires=%2").arg(placed).arg(created));
+	if (residualRatsnests > 0)
+	{
+		Q_EMIT setProgressMessage2(QObject::tr("Routing incomplete: %1 connection(s) remain.").arg(residualRatsnests));
+		logAutoroute(QString("failure: placed=%1 createdWires=%2 residualRatsnests=%3")
+					 .arg(placed)
+					 .arg(created)
+					 .arg(residualRatsnests));
+		flushAutorouteLog();
+		// Honest guidance: the usual cause is exhausted free bus space.
+		QMessageBox::information(nullptr, QObject::tr("Fritzing"),
+								 QObject::tr("Autoroute could not complete %1 connection(s).\n\n"
+											 "The breadboard's free bus space may be exhausted. "
+											 "Adding another breadboard next to the existing one and "
+											 "running Autoroute again may allow the circuit to complete.")
+									 .arg(residualRatsnests));
+	}
+	else
+	{
+		Q_EMIT setProgressMessage2(QObject::tr("Placed %1 part(s), created %2 breadboard jumper wire(s).").arg(placed).arg(created));
+		logAutoroute(QString("success: placed=%1 createdWires=%2").arg(placed).arg(created));
+	}
+	// Diagnostic: any rubber-band leg with more than two points has been
+	// reshaped after placement set it to a straight root-to-hole lead.
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *connectorItem = dynamic_cast<ConnectorItem *>(graphicsItem);
+		if (connectorItem == nullptr || !connectorItem->hasRubberBandLeg())
+			continue;
+		const QPolygonF leg = connectorItem->sceneAdjustedLeg();
+		if (leg.count() <= 2)
+			continue;
+		QStringList points;
+		Q_FOREACH (const QPointF &point, leg)
+			points << QString("(%1,%2)").arg(point.x()).arg(point.y());
+		logAutoroute(QString("leg audit: %1 points=%2 %3")
+						 .arg(connectorSummary(connectorItem))
+						 .arg(leg.count())
+						 .arg(points.join(" ")));
+	}
+	Q_EMIT setProgressValue(100);
 	logAutoroute("========== breadboard autoroute end ==========");
+	flushAutorouteLog();
 }
 
 int BreadboardAutorouter::clearPreviousAutorouteWires()
@@ -479,27 +868,50 @@ int BreadboardAutorouter::clearPreviousAutorouteWires()
 	return generatedWires.count();
 }
 
-int BreadboardAutorouter::autoplacePartsOnBreadboard()
+// One part-placement pass over the sketch. The pass owns the state every
+// phase shares (board topology, hole caches, incremental planning state,
+// rejection counters); autoplacePartsOnBreadboard() is reduced to building
+// the pass and driving parts through its phases in connectivity order.
+//
+// Search and commit are deliberately separate per part: the searches only
+// read scene state and fill a PlacementCandidate, while commitBest() alone
+// creates undo commands - and those still execute only when finish() pushes
+// the parent command. This is the seam a future plan/commit split (parallel
+// candidate search) hangs off.
+struct BreadboardAutorouter::PlacementPass
 {
-	m_lastPlacementReport.clear();
+	BreadboardAutorouter *self = nullptr;
 
+	// Scene input: every visible breadboard-view part.
 	QList<ItemBase *> parts;
-	m_sketchWidget->collectParts(parts);
-	logAutoroute(QString("autoplace: visible parts collected=%1").arg(parts.count()));
-	if (parts.isEmpty())
-	{
-		m_lastPlacementReport = QObject::tr("No breadboard-view parts were found.");
-		logAutoroute("autoplace abort: no parts");
-		return 0;
-	}
 
+	// Schematic netlist view, indexed once up front.
+	QHash<ConnectorItem *, int> netForConnector;
+	QHash<int, QList<ConnectorItem *> > connectorsForNet;
+
+	// Board topology and per-run hole caches.
 	QList<ConnectorItem *> breadboardHoles;
 	QList<ItemBase *> targetBreadboards;
 	QSet<ConnectorItem *> reservedHoles;
+	QRectF targetBoardBounds;
+	QVector<QRectF> boardRects;
+	QPointF breadboardCenter;
+	QVector<QPointF> boardCenters;              // per-board hole centroid
+	QHash<ConnectorItem *, int> boardIdForHole; // hole -> index into boardRects
+	QHash<ConnectorItem *, int> busIdForHole;
+	QHash<ConnectorItem *, QPointF> holePositions;
+	BreadboardPlacementKernel::HoleSpatialIndex holeSpatialIndex;
+	int targetSceneConnectors = 0;
+
+	// Mutable planning state, updated as each part is placed.
 	QList<QRectF> occupiedRects;
-	QHash<ConnectorItem *, int> netForConnector;
-	QHash<int, QList<ConnectorItem *>> connectorsForNet;
-	QHash<ConnectorItem *, ConnectorItem *> placedTargets;
+	QList<ItemBase *> movableParts;
+	QHash<ConnectorItem *, ConnectorItem *> placedTargets;      // pin -> hole, incl. pre-placed pins
+	QHash<ConnectorItem *, ConnectorItem *> newlyPlacedTargets; // pin -> hole, this run only
+	QUndoCommand *parentCommand = nullptr;
+	int moved = 0;
+
+	// Rejection/progress counters feeding the failure report and summary log.
 	int candidateAttempts = 0;
 	int rejectedPinGeometry = 0;
 	int rejectedSameBus = 0;
@@ -512,72 +924,6 @@ int BreadboardAutorouter::autoplacePartsOnBreadboard()
 	int failedBoardFit = 0;
 	int placedRigid = 0;
 	int placedWithLegs = 0;
-
-	for (int netIndex = 0; netIndex < m_allPartConnectorItems.count(); netIndex++)
-	{
-		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
-		if (net == nullptr)
-			continue;
-		Q_FOREACH (ConnectorItem *connectorItem, *net)
-		{
-			if (connectorItem == nullptr)
-				continue;
-			netForConnector.insert(connectorItem, netIndex);
-			connectorsForNet[netIndex].append(connectorItem);
-			ConnectorItem *breadboardHole = breadboardHoleFor(connectorItem);
-			if (breadboardHole != nullptr && breadboardHole->connectorType() == Connector::Female)
-			{
-				placedTargets.insert(connectorItem, breadboardHole);
-			}
-		}
-	}
-
-	BreadboardTopology topology;
-	topology.discover(m_sketchWidget->scene(), m_sketchWidget->scene()->selectedItems());
-	Q_FOREACH (const QString &line, topology.diagnosticLines())
-	{
-		logAutoroute(line);
-	}
-
-	breadboardHoles = topology.holes();
-	targetBreadboards = topology.boardItems();
-	reservedHoles = topology.reservedHoles();
-	QRectF targetBoardBounds = topology.bounds();
-	int targetBoardConnectors = topology.itemConnectorCount();
-	int targetSceneConnectors = topology.sceneConnectorCount();
-
-	if (breadboardHoles.isEmpty())
-	{
-		m_lastPlacementReport = QObject::tr(
-									"No target breadboard holes were found.\n"
-									"Target breadboard(s): %1\n"
-									"Connectors on target breadboard item(s): %2\n"
-									"Scene connectors inside target board bounds: %3\n\n"
-									"If both connector counts are zero, no scene item owns enough breadboard holes.")
-									.arg(targetBreadboards.count())
-									.arg(targetBoardConnectors)
-									.arg(targetSceneConnectors);
-		logAutoroute(QString("autoplace abort: no holes\n%1").arg(m_lastPlacementReport));
-		return 0;
-	}
-
-	QRectF targetKeepoutBounds = targetBoardBounds.adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
-
-	std::sort(breadboardHoles.begin(), breadboardHoles.end(), [](ConnectorItem *a, ConnectorItem *b)
-			  {
-		QPointF ap = a->sceneAdjustedTerminalPoint(nullptr);
-		QPointF bp = b->sceneAdjustedTerminalPoint(nullptr);
-		if (!qFuzzyCompare(ap.y(), bp.y())) return ap.y() < bp.y();
-		return ap.x() < bp.x(); });
-
-	QPointF breadboardCenter;
-	Q_FOREACH (ConnectorItem *hole, breadboardHoles)
-	{
-		breadboardCenter += hole->sceneAdjustedTerminalPoint(nullptr);
-	}
-	breadboardCenter /= breadboardHoles.count();
-
-	QList<ItemBase *> movableParts;
 	int skippedNull = 0;
 	int skippedInvisible = 0;
 	int skippedRatsnest = 0;
@@ -585,98 +931,318 @@ int BreadboardAutorouter::autoplacePartsOnBreadboard()
 	int skippedWire = 0;
 	int skippedLocked = 0;
 	int skippedAlreadyOnBreadboard = 0;
-	Q_FOREACH (ItemBase *part, parts)
+
+	explicit PlacementPass(BreadboardAutorouter *router)
+		: self(router)
 	{
-		BreadboardPartPolicy::Decision policy = BreadboardPartPolicy::classify(part);
-		QString skipReason;
-		if (part == nullptr)
+	}
+
+	// Phase 1: index the schematic netlist. Also seeds placedTargets with
+	// pins the user already plugged in, so netPlacementCost() pulls each
+	// net's remaining pins toward its seated ones from the very first part.
+	void indexNets()
+	{
+		for (int netIndex = 0; netIndex < self->m_allPartConnectorItems.count(); netIndex++)
 		{
-			skippedNull++;
-			skipReason = "null";
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "not visible")
-		{
-			skippedInvisible++;
-			skipReason = policy.reason;
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "ratsnest")
-		{
-			skippedRatsnest++;
-			skipReason = policy.reason;
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "breadboard")
-		{
-			skippedBreadboard++;
-			skipReason = policy.reason;
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "breadboard decoration")
-		{
-			skippedBreadboard++;
-			skipReason = policy.reason;
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "wire")
-		{
-			skippedWire++;
-			skipReason = policy.reason;
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "move locked")
-		{
-			skippedLocked++;
-			skipReason = policy.reason;
-		}
-		else if (policy.classification == BreadboardPartPolicy::Classification::Peripheral)
-		{
-			leftPeripheral++;
-			skipReason = QString("peripheral: %1").arg(policy.reason);
-		}
-		else if (policy.classification != BreadboardPartPolicy::Classification::BoardPlaceable)
-		{
-			rejectedByPolicy++;
-			skipReason = policy.reason;
-		}
-		else
-		{
-			bool alreadyOnBreadboard = false;
-			Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+			QList<ConnectorItem *> *net = self->m_allPartConnectorItems.at(netIndex);
+			if (net == nullptr)
+				continue;
+			Q_FOREACH (ConnectorItem *connectorItem, *net)
 			{
 				if (connectorItem == nullptr)
 					continue;
-				if (!isPlaceablePin(connectorItem))
+				netForConnector.insert(connectorItem, netIndex);
+				connectorsForNet[netIndex].append(connectorItem);
+				if (connectorItem->connectorType() == Connector::Female
+				    || connectorItem->attachedToItemType() == ModelPart::Wire)
 					continue;
-				Q_FOREACH (ConnectorItem *connected, connectorItem->connectedToItems())
-				{
-					if (connected != nullptr && connected->connectorType() == Connector::Female)
-					{
-						alreadyOnBreadboard = true;
-						break;
-					}
-				}
-				if (alreadyOnBreadboard)
-					break;
-			}
-			if (alreadyOnBreadboard)
-			{
-				skippedAlreadyOnBreadboard++;
-				skipReason = "already connected to female connector";
+				ConnectorItem *breadboardHole = self->connectedBreadboardHoleFor(connectorItem);
+				if (breadboardHole != nullptr && breadboardHole->connectorType() == Connector::Female)
+					placedTargets.insert(connectorItem, breadboardHole);
 			}
 		}
+	}
 
-		logAutoroute(QString("part policy: class=%1 reason=%2 pins=%3 bendableLegs=%4 family='%5' taxonomy='%6' package='%7' module=%8 title='%9'")
-						 .arg(BreadboardPartPolicy::classificationName(policy.classification))
-						 .arg(policy.reason)
-						 .arg(policy.placeablePins)
-						 .arg(policy.hasBendableLegs ? "yes" : "no")
-						 .arg(policy.family)
-						 .arg(policy.taxonomy)
-						 .arg(policy.package)
-						 .arg(policy.moduleID)
-						 .arg(policy.title));
-
-		if (skipReason.isEmpty())
+	// Phase 2: discover the target breadboard(s). Returns false - with the
+	// user-facing report set - when the scene offers no breadboard holes.
+	bool discoverBoards()
+	{
+		BreadboardTopology topology;
+		topology.discover(self->m_sketchWidget->scene(), self->m_sketchWidget->scene()->selectedItems());
+		Q_FOREACH (const QString &line, topology.diagnosticLines())
 		{
+			self->logAutoroute(line);
+		}
+
+		breadboardHoles = topology.holes();
+		targetBreadboards = topology.boardItems();
+		reservedHoles = topology.reservedHoles();
+		targetBoardBounds = topology.bounds();
+		// Union bounds cover the empty gap BETWEEN boards on multi-board
+		// sketches; a body is only legal fully inside some single board.
+		Q_FOREACH (const BreadboardTopology::Board &board, topology.boards())
+		{
+			const int boardId = boardRects.count();
+			boardRects.append(board.bounds);
+			Q_FOREACH (ConnectorItem *hole, board.holes)
+				boardIdForHole.insert(hole, boardId);
+		}
+		Q_FOREACH (const QRectF &boardRect, boardRects)
+			self->logAutoroute(QString("board rect: (%1,%2)-(%3,%4)")
+							   .arg(boardRect.left()).arg(boardRect.top())
+							   .arg(boardRect.right()).arg(boardRect.bottom()));
+		targetSceneConnectors = topology.sceneConnectorCount();
+
+		if (breadboardHoles.isEmpty())
+		{
+			self->m_lastPlacementReport = QObject::tr(
+										"No target breadboard holes were found.\n"
+										"Target breadboard(s): %1\n"
+										"Connectors on target breadboard item(s): %2\n"
+										"Scene connectors inside target board bounds: %3\n\n"
+										"If both connector counts are zero, no scene item owns enough breadboard holes.")
+										.arg(targetBreadboards.count())
+										.arg(topology.itemConnectorCount())
+										.arg(targetSceneConnectors);
+			self->logAutoroute(QString("autoplace abort: no holes\n%1").arg(self->m_lastPlacementReport));
+			return false;
+		}
+		return true;
+	}
+
+	// Phase 3: hole caches. connectorsShareBreadboardBus() rebuilds the bus
+	// member list on every call, which is far too slow inside the O(holes^2)
+	// candidate loops; precompute one integer bus id per hole plus every
+	// hole's scene position and use those instead.
+	void buildHoleCaches()
+	{
+		std::sort(breadboardHoles.begin(), breadboardHoles.end(), [](ConnectorItem *a, ConnectorItem *b)
+				  {
+			QPointF ap = a->sceneAdjustedTerminalPoint(nullptr);
+			QPointF bp = b->sceneAdjustedTerminalPoint(nullptr);
+			if (!qFuzzyCompare(ap.y(), bp.y())) return ap.y() < bp.y();
+			return ap.x() < bp.x(); });
+
+		Q_FOREACH (ConnectorItem *hole, breadboardHoles)
+		{
+			breadboardCenter += hole->sceneAdjustedTerminalPoint(nullptr);
+		}
+		breadboardCenter /= breadboardHoles.count();
+
+		// Per-board hole centroids, accumulated in the same sorted hole order
+		// as breadboardCenter so a single-board sketch computes bitwise the
+		// same centre it did before multi-board support.
+		QVector<QPointF> boardSums(boardRects.count(), QPointF());
+		QVector<int> boardHoleCounts(boardRects.count(), 0);
+		Q_FOREACH (ConnectorItem *hole, breadboardHoles)
+		{
+			const int boardId = boardIdForHole.value(hole, -1);
+			if (boardId < 0 || boardId >= boardSums.count())
+				continue;
+			boardSums[boardId] += hole->sceneAdjustedTerminalPoint(nullptr);
+			boardHoleCounts[boardId]++;
+		}
+		for (int boardId = 0; boardId < boardSums.count(); boardId++)
+			boardCenters.append(boardHoleCounts.at(boardId) > 0
+									? boardSums.at(boardId) / boardHoleCounts.at(boardId)
+									: breadboardCenter);
+
+		int busCount = 0;
+		QVector<QPointF> indexedPositions;
+		QVector<int> indexedBoardIds;
+		indexedPositions.reserve(breadboardHoles.count());
+		indexedBoardIds.reserve(breadboardHoles.count());
+		Q_FOREACH (ConnectorItem *hole, breadboardHoles)
+		{
+			const QPointF position = hole->sceneAdjustedTerminalPoint(nullptr);
+			holePositions.insert(hole, position);
+			indexedPositions.append(position);
+			indexedBoardIds.append(boardIdForHole.value(hole, -1));
+			if (busIdForHole.contains(hole))
+				continue;
+			const int busId = busCount++;
+			busIdForHole.insert(hole, busId);
+			ItemBase *board = hole->attachedTo();
+			QList<ConnectorItem *> busHoles;
+			if (board == nullptr || !board->busConnectorItems(hole, busHoles))
+				continue;
+			Q_FOREACH (ConnectorItem *sibling, busHoles)
+				busIdForHole.insert(sibling, busId);
+		}
+		// Four breadboard pitches per cell keeps each bucket compact while
+		// avoiding excessive cell traversal for normal bendable lead radii.
+		holeSpatialIndex = BreadboardPlacementKernel::HoleSpatialIndex(indexedPositions, indexedBoardIds, 36.0);
+	}
+
+	bool holesShareBus(ConnectorItem *first, ConnectorItem *second) const
+	{
+		return busIdForHole.value(first, -1) == busIdForHole.value(second, -2);
+	}
+
+	// A body is only legal fully inside a single board; fall back to the
+	// union when board rects are unavailable so we never reject everything.
+	bool anyBoardContains(const QRectF &bounds) const
+	{
+		if (boardRects.isEmpty())
+			return targetBoardBounds.contains(bounds);
+		Q_FOREACH (const QRectF &boardRect, boardRects)
+		{
+			if (boardRect.contains(bounds))
+				return true;
+		}
+		return false;
+	}
+
+	bool overlapsOccupied(const QRectF &keepout) const
+	{
+		Q_FOREACH (const QRectF &occupied, occupiedRects)
+		{
+			if (keepout.intersects(occupied))
+				return true;
+		}
+		return false;
+	}
+
+	// Pull candidates toward the nearest board's own hole centroid: the mean
+	// of ALL holes sits in the empty gap between boards on multi-board
+	// sketches and would drag every part there.
+	double distanceToNearestBoardCenter(const QPointF &point) const
+	{
+		if (boardCenters.isEmpty())
+			return manhattanDistance(point, breadboardCenter);
+		double best = std::numeric_limits<double>::max();
+		Q_FOREACH (const QPointF &center, boardCenters)
+			best = qMin(best, manhattanDistance(point, center));
+		return best;
+	}
+
+	// A part body cannot span two boards: every mapped hole must belong to
+	// the same board.
+	bool mappedHolesShareBoard(const QHash<ConnectorItem *, ConnectorItem *> &pinToHole) const
+	{
+		int sharedBoardId = -2;
+		for (auto it = pinToHole.constBegin(); it != pinToHole.constEnd(); ++it)
+		{
+			const int holeBoardId = boardIdForHole.value(it.value(), -1);
+			if (sharedBoardId == -2)
+				sharedBoardId = holeBoardId;
+			if (holeBoardId != sharedBoardId)
+				return false;
+		}
+		return true;
+	}
+
+	// A part with any placeable pin already seated in a female socket was
+	// positioned by the user (or a previous run); leave it where it is.
+	bool isAlreadySeated(ItemBase *part) const
+	{
+		Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+		{
+			if (connectorItem == nullptr)
+				continue;
+			if (!self->isPlaceablePin(connectorItem))
+				continue;
+			Q_FOREACH (ConnectorItem *connected, connectorItem->connectedToItems())
+			{
+				if (connected != nullptr && connected->connectorType() == Connector::Female)
+					return true;
+			}
+		}
+		return false;
+	}
+
+	// Ignore-classified parts bucket into per-reason counters so the failure
+	// report can say WHY nothing was movable.
+	QString ignoreReasonFor(const BreadboardPartPolicy::Decision &policy)
+	{
+		if (policy.reason == "not visible")
+		{
+			skippedInvisible++;
+			return policy.reason;
+		}
+		if (policy.reason == "ratsnest")
+		{
+			skippedRatsnest++;
+			return policy.reason;
+		}
+		if (policy.reason == "breadboard" || policy.reason == "breadboard decoration")
+		{
+			skippedBreadboard++;
+			return policy.reason;
+		}
+		if (policy.reason == "wire")
+		{
+			skippedWire++;
+			return policy.reason;
+		}
+		if (policy.reason == "move locked")
+		{
+			skippedLocked++;
+			return policy.reason;
+		}
+		rejectedByPolicy++;
+		return policy.reason;
+	}
+
+	// Empty result = movable. One guard per skip cause, each with its own
+	// report counter.
+	QString skipReasonFor(ItemBase *part, const BreadboardPartPolicy::Decision &policy)
+	{
+		if (part == nullptr)
+		{
+			skippedNull++;
+			return QStringLiteral("null");
+		}
+		if (policy.classification == BreadboardPartPolicy::Classification::Ignore)
+			return ignoreReasonFor(policy);
+		if (policy.classification == BreadboardPartPolicy::Classification::Peripheral)
+		{
+			leftPeripheral++;
+			return QString("peripheral: %1").arg(policy.reason);
+		}
+		if (policy.classification != BreadboardPartPolicy::Classification::BoardPlaceable)
+		{
+			rejectedByPolicy++;
+			return policy.reason;
+		}
+		if (isAlreadySeated(part))
+		{
+			skippedAlreadyOnBreadboard++;
+			return QStringLiteral("already connected to female connector");
+		}
+		return QString();
+	}
+
+	// Phase 4: split the scene's parts into movable candidates and skips,
+	// logging every decision (the log is the primary answer to "why did my
+	// part not move?").
+	void collectMovableParts()
+	{
+		Q_FOREACH (ItemBase *part, parts)
+		{
+			const BreadboardPartPolicy::Decision policy = BreadboardPartPolicy::classify(part);
+			const QString skipReason = skipReasonFor(part, policy);
+
+			self->logAutoroute(QString("part policy: class=%1 reason=%2 pins=%3 bendableLegs=%4 family='%5' taxonomy='%6' package='%7' module=%8 title='%9'")
+							 .arg(BreadboardPartPolicy::classificationName(policy.classification))
+							 .arg(policy.reason)
+							 .arg(policy.placeablePins)
+							 .arg(policy.hasBendableLegs ? "yes" : "no")
+							 .arg(policy.family)
+							 .arg(policy.taxonomy)
+							 .arg(policy.package)
+							 .arg(policy.moduleID)
+							 .arg(policy.title));
+
+			if (!skipReason.isEmpty())
+			{
+				self->logAutoroute(QString("skip part: reason=%1 item=%2").arg(skipReason).arg(self->itemSummary(part)));
+				continue;
+			}
+
 			movableParts.append(part);
-			logAutoroute(QString("movable part: %1 connectors=%2 placeablePins=%3 bendableLegs=%4 bounds=[%5,%6 %7x%8]")
-							 .arg(itemSummary(part))
+			self->logAutoroute(QString("movable part: %1 connectors=%2 placeablePins=%3 bendableLegs=%4 bounds=[%5,%6 %7x%8]")
+							 .arg(self->itemSummary(part))
 							 .arg(part->cachedConnectorItems().count())
 							 .arg(policy.placeablePins)
 							 .arg(policy.hasBendableLegs ? "yes" : "no")
@@ -685,395 +1251,625 @@ int BreadboardAutorouter::autoplacePartsOnBreadboard()
 							 .arg(part->sceneBoundingRect().width())
 							 .arg(part->sceneBoundingRect().height()));
 		}
-		else
-		{
-			logAutoroute(QString("skip part: reason=%1 item=%2").arg(skipReason).arg(itemSummary(part)));
-		}
+		self->logAutoroute(QString("movable filter summary: movable=%1 null=%2 invisible=%3 ratsnest=%4 breadboard=%5 wire=%6 locked=%7 alreadyFemale=%8 rejectedByPolicy=%9 leftPeripheral=%10")
+						 .arg(movableParts.count())
+						 .arg(skippedNull)
+						 .arg(skippedInvisible)
+						 .arg(skippedRatsnest)
+						 .arg(skippedBreadboard)
+						 .arg(skippedWire)
+						 .arg(skippedLocked)
+						 .arg(skippedAlreadyOnBreadboard)
+						 .arg(rejectedByPolicy)
+						 .arg(leftPeripheral));
 	}
-	logAutoroute(QString("movable filter summary: movable=%1 null=%2 invisible=%3 ratsnest=%4 breadboard=%5 wire=%6 locked=%7 alreadyFemale=%8 rejectedByPolicy=%9 leftPeripheral=%10")
-					 .arg(movableParts.count())
-					 .arg(skippedNull)
-					 .arg(skippedInvisible)
-					 .arg(skippedRatsnest)
-					 .arg(skippedBreadboard)
-					 .arg(skippedWire)
-					 .arg(skippedLocked)
-					 .arg(skippedAlreadyOnBreadboard)
-					 .arg(rejectedByPolicy)
-					 .arg(leftPeripheral));
 
-	Q_FOREACH (ItemBase *part, parts)
+	// Phase 5: everything staying put near the board blocks area candidates
+	// may not overlap (bodies of peripherals, user-locked parts, ...).
+	void collectOccupiedRects()
 	{
-		if (part == nullptr)
-			continue;
-		if (!part->isEverVisible())
-			continue;
-		ItemBase *chief = part->layerKinChief();
-		if (isBreadboardItem(part) || isBreadboardItem(chief))
-			continue;
-		if (isBreadboardDecorationItem(part) || isBreadboardDecorationItem(chief))
-			continue;
-		if (targetBreadboards.contains(part) || targetBreadboards.contains(chief))
-			continue;
-		if (movableParts.contains(part))
-			continue;
-
-		QRectF partBounds = part->sceneBoundingRect().adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
-		if (partBounds.intersects(targetKeepoutBounds))
+		const QRectF targetKeepoutBounds = targetBoardBounds.adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
+		Q_FOREACH (ItemBase *part, parts)
 		{
+			if (part == nullptr)
+				continue;
+			if (!part->isEverVisible())
+				continue;
+			ItemBase *chief = part->layerKinChief();
+			if (self->isBreadboardItem(part) || self->isBreadboardItem(chief))
+				continue;
+			if (self->isBreadboardDecorationItem(part) || self->isBreadboardDecorationItem(chief))
+				continue;
+			if (targetBreadboards.contains(part) || targetBreadboards.contains(chief))
+				continue;
+			if (movableParts.contains(part))
+				continue;
+
+			QRectF partBounds = part->sceneBoundingRect().adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
+			if (!partBounds.intersects(targetKeepoutBounds))
+				continue;
 			occupiedRects.append(partBounds);
-			logAutoroute(QString("occupied rect: item=%1 bounds=[%2,%3 %4x%5]")
-							 .arg(itemSummary(part))
+			self->logAutoroute(QString("occupied rect: item=%1 bounds=[%2,%3 %4x%5]")
+							 .arg(self->itemSummary(part))
 							 .arg(partBounds.x())
 							 .arg(partBounds.y())
 							 .arg(partBounds.width())
 							 .arg(partBounds.height()));
 		}
+		self->logAutoroute(QString("occupied rects considered=%1").arg(occupiedRects.count()));
 	}
-	logAutoroute(QString("occupied rects considered=%1").arg(occupiedRects.count()));
 
-	std::sort(movableParts.begin(), movableParts.end(), [this, &netForConnector, &connectorsForNet](ItemBase *a, ItemBase *b)
-			  {
-		double aScore = partConnectivityScore(a, netForConnector, connectorsForNet);
-		double bScore = partConnectivityScore(b, netForConnector, connectorsForNet);
-		if (!qFuzzyCompare(aScore, bScore)) return aScore > bScore;
-
-		double aArea = a == nullptr ? 0 : a->sceneBoundingRect().width() * a->sceneBoundingRect().height();
-		double bArea = b == nullptr ? 0 : b->sceneBoundingRect().width() * b->sceneBoundingRect().height();
-		if (!qFuzzyCompare(aArea, bArea)) return aArea > bArea;
-
-		QPointF ap = a == nullptr ? QPointF() : a->sceneBoundingRect().center();
-		QPointF bp = b == nullptr ? QPointF() : b->sceneBoundingRect().center();
-		if (!qFuzzyCompare(ap.x(), bp.x())) return ap.x() < bp.x();
-		return ap.y() < bp.y(); });
-
-	QStringList placementOrder;
-	Q_FOREACH (ItemBase *part, movableParts)
+	// Phase 6: most-connected (then largest) parts place first, so the parts
+	// with the least freedom get first pick of the board.
+	void sortByConnectivity()
 	{
-		placementOrder.append(QString("%1 score=%2")
-								  .arg(itemSummary(part))
-								  .arg(partConnectivityScore(part, netForConnector, connectorsForNet)));
-	}
-	logAutoroute(QString("placement order: %1").arg(placementOrder.join(" || ")));
+		std::sort(movableParts.begin(), movableParts.end(), [this](ItemBase *a, ItemBase *b)
+				  {
+			double aScore = self->partConnectivityScore(a, netForConnector, connectorsForNet);
+			double bScore = self->partConnectivityScore(b, netForConnector, connectorsForNet);
+			if (!qFuzzyCompare(aScore, bScore)) return aScore > bScore;
 
-	auto *parentCommand = new QUndoCommand(QObject::tr("Autoplace breadboard parts"));
-	// This command is the first child of the outer autoroute macro, so its
-	// undo-only cleanup runs after both generated wires and placement
-	// connections have been undone. Cleaning inside the routing child leaves
-	// stale ratsnests because placement is undone later.
-	new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
-	new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
-	int moved = 0;
+			double aArea = a == nullptr ? 0 : a->sceneBoundingRect().width() * a->sceneBoundingRect().height();
+			double bArea = b == nullptr ? 0 : b->sceneBoundingRect().width() * b->sceneBoundingRect().height();
+			if (!qFuzzyCompare(aArea, bArea)) return aArea > bArea;
 
-	Q_FOREACH (ItemBase *part, movableParts)
-	{
-		QList<ConnectorItem *> pins;
-		Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+			QPointF ap = a == nullptr ? QPointF() : a->sceneBoundingRect().center();
+			QPointF bp = b == nullptr ? QPointF() : b->sceneBoundingRect().center();
+			if (!qFuzzyCompare(ap.x(), bp.x())) return ap.x() < bp.x();
+			return ap.y() < bp.y(); });
+
+		QStringList placementOrder;
+		Q_FOREACH (ItemBase *part, movableParts)
 		{
-			if (connectorItem == nullptr)
-				continue;
-			if (isPlaceablePin(connectorItem))
-				pins.append(connectorItem);
+			placementOrder.append(QString("%1 score=%2")
+									  .arg(self->itemSummary(part))
+									  .arg(self->partConnectivityScore(part, netForConnector, connectorsForNet)));
 		}
-		if (pins.isEmpty())
-			continue;
-		partsWithPlaceablePins++;
-		bool canUseBendableLegPlacement = pins.count() == 2 && allPinsHaveBendableLegs(pins);
-		logAutoroute(QString("placement begin: %1 placeablePins=%2 strategy=%3")
-						 .arg(itemSummary(part))
-						 .arg(pins.count())
-						 .arg(canUseBendableLegPlacement ? "rigid-or-bendable-leg" : "rigid"));
+		self->logAutoroute(QString("placement order: %1").arg(placementOrder.join(" || ")));
+	}
 
-		PlacementCandidate best;
-		best.item = part;
-		best.oldLoc = part->getViewGeometry().loc();
+	// Phase 7: the pass's undo command. It is the first child of the outer
+	// autoroute macro, so its undo-only cleanup runs after both generated
+	// wires and placement connections have been undone. Cleaning inside the
+	// routing child leaves stale ratsnests because placement is undone later.
+	void beginCommand()
+	{
+		parentCommand = new QUndoCommand(QObject::tr("Autoplace breadboard parts"));
+		new CleanUpWiresCommand(self->m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
+		new CleanUpRatsnestsCommand(self->m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
+	}
 
-		if (!canUseBendableLegPlacement)
+	// Prime invariant, placement side: a candidate may only put a pin on a
+	// bus that is free or already owned by that pin's net. No-net pins
+	// (unused DIP outputs are still outputs!) may only take FREE buses.
+	bool conflictsWithPlacedNets(const QHash<ConnectorItem *, ConnectorItem *> &pinToHole) const
+	{
+		for (auto candidate = pinToHole.constBegin(); candidate != pinToHole.constEnd(); ++candidate)
 		{
-			Q_FOREACH (ConnectorItem *anchorPin, pins)
+			if (candidate.value() == nullptr)
+				continue;
+			const int busGroup = self->busGroupFor(candidate.value());
+			const int candidateNet = netForConnector.value(candidate.key(), -1);
+			if (candidateNet < 0)
 			{
-				QPointF anchorPinPos = anchorPin->sceneAdjustedTerminalPoint(nullptr);
-				Q_FOREACH (ConnectorItem *anchorHole, breadboardHoles)
-				{
-					if (reservedHoles.contains(anchorHole))
-						continue;
-					candidateAttempts++;
+				if (self->busOwner(busGroup) != -1)
+					return true;
+				continue;
+			}
+			if (!self->busAvailableFor(busGroup, candidateNet))
+				return true;
+		}
+		return false;
+	}
 
-					QPointF offset = anchorHole->sceneAdjustedTerminalPoint(nullptr) - anchorPinPos;
-					QSet<ConnectorItem *> candidateReserved;
-					QHash<ConnectorItem *, ConnectorItem *> pinToHole;
-					bool fits = true;
+	// How much routing a hole choice buys or costs: free when it lands on a
+	// bus already carrying the pin's net, a distance pull toward the net's
+	// placed pins otherwise, plus the tunable jumper penalty because one
+	// additional occupied bus implies at least one additional jumper. The
+	// penalty keeps jumper count lexicographically more important than
+	// geometric terms by default; lowering it makes the router trade jumpers
+	// for shorter, straighter component leads.
+	double netPlacementCost(ConnectorItem *pin, ConnectorItem *targetHole) const
+	{
+		const int netIndex = netForConnector.value(pin, -1);
+		if (netIndex < 0 || targetHole == nullptr)
+			return 0.0;
 
-					Q_FOREACH (ConnectorItem *pin, pins)
-					{
-						QPointF target = pin->sceneAdjustedTerminalPoint(nullptr) + offset;
-						ConnectorItem *nearestHole = nullptr;
-						double nearestDistance = HoleMatchTolerance;
+		const QPointF targetPos = holePositions.value(targetHole, targetHole->sceneAdjustedTerminalPoint(nullptr));
+		double bestDistance = std::numeric_limits<double>::max();
+		bool hasPlacedTarget = false;
+		bool sharesPlacedBus = false;
+		Q_FOREACH (ConnectorItem *other, connectorsForNet.value(netIndex))
+		{
+			if (other == pin)
+				continue;
+			ConnectorItem *otherTarget = placedTargets.value(other, nullptr);
+			if (otherTarget == nullptr)
+				continue;
+			hasPlacedTarget = true;
+			bestDistance = qMin(bestDistance, manhattanDistance(targetPos, holePositions.value(otherTarget, otherTarget->sceneAdjustedTerminalPoint(nullptr))));
+			if (holesShareBus(targetHole, otherTarget))
+				sharesPlacedBus = true;
+		}
 
-						Q_FOREACH (ConnectorItem *hole, breadboardHoles)
-						{
-							if (reservedHoles.contains(hole) || candidateReserved.contains(hole))
-								continue;
-							double distance = QLineF(target, hole->sceneAdjustedTerminalPoint(nullptr)).length();
-							if (distance <= nearestDistance)
-							{
-								nearestHole = hole;
-								nearestDistance = distance;
-							}
-						}
+		if (!hasPlacedTarget)
+			return distanceToNearestBoardCenter(targetPos) * 0.05;
+		if (sharesPlacedBus)
+			return bestDistance * 0.01;
+		return self->m_jumperPenalty + bestDistance;
+	}
 
-						if (nearestHole == nullptr)
-						{
-							fits = false;
-							break;
-						}
-
-						candidateReserved.insert(nearestHole);
-						pinToHole.insert(pin, nearestHole);
-					}
-
-					if (!fits)
-					{
-						rejectedPinGeometry++;
-						continue;
-					}
-
-					bool shortsPart = false;
-					QList<ConnectorItem *> mappedHoles = pinToHole.values();
-					for (int fromIndex = 0; fromIndex < mappedHoles.count(); fromIndex++)
-					{
-						for (int toIndex = fromIndex + 1; toIndex < mappedHoles.count(); toIndex++)
-						{
-							if (connectorsShareBreadboardBus(mappedHoles.at(fromIndex), mappedHoles.at(toIndex)))
-							{
-								shortsPart = true;
-								break;
-							}
-						}
-						if (shortsPart)
-							break;
-					}
-					if (shortsPart)
-					{
-						rejectedSameBus++;
-						continue;
-					}
-
-					QRectF movedBounds = part->sceneBoundingRect().translated(offset);
-					QRectF movedKeepout = movedBounds.adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
-					if (!targetBoardBounds.contains(movedBounds))
-					{
-						rejectedOffBoard++;
-						continue;
-					}
-
-					bool overlaps = false;
-					Q_FOREACH (const QRectF &occupied, occupiedRects)
-					{
-						if (movedKeepout.intersects(occupied))
-						{
-							overlaps = true;
-							break;
-						}
-					}
-					if (overlaps)
-					{
-						rejectedOverlap++;
-						continue;
-					}
-
-					acceptedCandidates++;
-					double score = manhattanDistance(movedBounds.center(), breadboardCenter) * 0.15;
-
-					Q_FOREACH (ConnectorItem *pin, pins)
-					{
-						int netIndex = netForConnector.value(pin, -1);
-						if (netIndex < 0)
-							continue;
-
-						ConnectorItem *targetHole = pinToHole.value(pin, nullptr);
-						if (targetHole == nullptr)
-							continue;
-						QPointF targetPos = targetHole->sceneAdjustedTerminalPoint(nullptr);
-
-						double bestNetDistance = std::numeric_limits<double>::max();
-						Q_FOREACH (ConnectorItem *other, connectorsForNet.value(netIndex))
-						{
-							if (other == pin)
-								continue;
-							ConnectorItem *otherTarget = placedTargets.value(other, nullptr);
-							if (otherTarget == nullptr)
-								continue;
-							bestNetDistance = qMin(bestNetDistance, manhattanDistance(targetPos, otherTarget->sceneAdjustedTerminalPoint(nullptr)));
-						}
-
-						if (bestNetDistance == std::numeric_limits<double>::max())
-						{
-							score += manhattanDistance(targetPos, breadboardCenter) * 0.05;
-						}
-						else
-						{
-							score += bestNetDistance;
-						}
-					}
-
-					if (score < best.score)
-					{
-						best.newLoc = best.oldLoc + offset;
-						best.pinToHole = pinToHole;
-						best.pinToLeg.clear();
-						best.score = score;
-						best.usesLegPlacement = false;
-						logAutoroute(QString("placement best update: part=%1 score=%2 offset=(%3,%4) anchorHole=%5")
-										 .arg(itemSummary(part))
-										 .arg(score)
-										 .arg(offset.x())
-										 .arg(offset.y())
-										 .arg(connectorSummary(anchorHole)));
-					}
-				}
+	// Nearest free hole within snap tolerance of a target point, or null.
+	ConnectorItem *nearestFreeHole(const QPointF &target, const QSet<ConnectorItem *> &candidateReserved) const
+	{
+		ConnectorItem *nearestHole = nullptr;
+		double nearestDistance = HoleMatchTolerance;
+		const QVector<int> nearbyHoleIndices = holeSpatialIndex.withinRadius(target, HoleMatchTolerance);
+		for (int holeIndex : nearbyHoleIndices)
+		{
+			ConnectorItem *hole = breadboardHoles.at(holeIndex);
+			if (reservedHoles.contains(hole) || candidateReserved.contains(hole))
+				continue;
+			double distance = QLineF(target, holePositions.value(hole)).length();
+			if (distance <= nearestDistance)
+			{
+				nearestHole = hole;
+				nearestDistance = distance;
 			}
 		}
+		return nearestHole;
+	}
 
-		if (canUseBendableLegPlacement)
+	// Different pins of one part must never land on one bus: that solders
+	// the part's own pins together (e.g. a DIP not straddling the channel).
+	bool anyMappedPairSharesBus(const QHash<ConnectorItem *, ConnectorItem *> &pinToHole) const
+	{
+		QList<ConnectorItem *> mappedHoles = pinToHole.values();
+		for (int fromIndex = 0; fromIndex < mappedHoles.count(); fromIndex++)
 		{
-			ConnectorItem *firstPin = pins.at(0);
-			ConnectorItem *secondPin = pins.at(1);
-			logAutoroute(QString("bendable placement search: %1 pins=[%2 | %3]")
-							 .arg(itemSummary(part))
-							 .arg(connectorSummary(firstPin))
-							 .arg(connectorSummary(secondPin)));
-
-			Q_FOREACH (ConnectorItem *firstHole, breadboardHoles)
+			for (int toIndex = fromIndex + 1; toIndex < mappedHoles.count(); toIndex++)
 			{
+				if (self->connectorsShareBreadboardBus(mappedHoles.at(fromIndex), mappedHoles.at(toIndex)))
+					return true;
+			}
+		}
+		return false;
+	}
+
+	// One rigid candidate: the offset that drops the anchor pin exactly onto
+	// anchorHole. Rejection order runs cheapest-first; counters record which
+	// filter killed the candidate.
+	void evaluateRigidOffset(ItemBase *part, const QList<ConnectorItem *> &pins, const QPointF &offset,
+							 ConnectorItem *anchorHole, PlacementCandidate &best)
+	{
+		QSet<ConnectorItem *> candidateReserved;
+		QHash<ConnectorItem *, ConnectorItem *> pinToHole;
+		Q_FOREACH (ConnectorItem *pin, pins)
+		{
+			ConnectorItem *nearestHole = nearestFreeHole(pin->sceneAdjustedTerminalPoint(nullptr) + offset, candidateReserved);
+			if (nearestHole == nullptr)
+			{
+				rejectedPinGeometry++;
+				return;
+			}
+			candidateReserved.insert(nearestHole);
+			pinToHole.insert(pin, nearestHole);
+		}
+
+		if (!mappedHolesShareBoard(pinToHole))
+		{
+			rejectedPinGeometry++;
+			return;
+		}
+		if (anyMappedPairSharesBus(pinToHole))
+		{
+			rejectedSameBus++;
+			return;
+		}
+		if (conflictsWithPlacedNets(pinToHole))
+		{
+			rejectedSameBus++;
+			return;
+		}
+
+		QRectF movedBounds = part->sceneBoundingRect().translated(offset);
+		if (!anyBoardContains(movedBounds))
+		{
+			rejectedOffBoard++;
+			return;
+		}
+		if (overlapsOccupied(movedBounds.adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin)))
+		{
+			rejectedOverlap++;
+			return;
+		}
+
+		acceptedCandidates++;
+		double score = distanceToNearestBoardCenter(movedBounds.center()) * 0.15;
+		Q_FOREACH (ConnectorItem *pin, pins)
+			score += netPlacementCost(pin, pinToHole.value(pin, nullptr));
+		if (score >= best.score)
+			return;
+
+		best.newLoc = best.oldLoc + offset;
+		best.pinToHole = pinToHole;
+		best.pinToLeg.clear();
+		best.score = score;
+		best.usesLegPlacement = false;
+		self->logAutoroute(QString("placement best update: part=%1 score=%2 offset=(%3,%4) anchorHole=%5")
+						 .arg(self->itemSummary(part))
+						 .arg(score)
+						 .arg(offset.x())
+						 .arg(offset.y())
+						 .arg(self->connectorSummary(anchorHole)));
+	}
+
+	// Rigid search: slide the whole part so one pin (the "anchor") lands
+	// exactly on a free hole, then require EVERY pin to find its own free
+	// hole within HoleMatchTolerance of where that slide puts it. No
+	// rotation, no leg bending - the strategy for multi-pin packages whose
+	// pin grid must match the hole grid (DIPs, headers).
+	void searchRigid(ItemBase *part, const QList<ConnectorItem *> &pins, PlacementCandidate &best)
+	{
+		Q_FOREACH (ConnectorItem *anchorPin, pins)
+		{
+			QPointF anchorPinPos = anchorPin->sceneAdjustedTerminalPoint(nullptr);
+			Q_FOREACH (ConnectorItem *anchorHole, breadboardHoles)
+			{
+				if (reservedHoles.contains(anchorHole))
+					continue;
+				candidateAttempts++;
+				evaluateRigidOffset(part, pins,
+									anchorHole->sceneAdjustedTerminalPoint(nullptr) - anchorPinPos,
+									anchorHole, best);
+			}
+		}
+	}
+
+	// Working data one bendable-leg candidate needs; bundled so the hole-pair
+	// evaluation can be a named function instead of a fourth nesting level.
+	struct BendableCandidate
+	{
+		ItemBase *part = nullptr;
+		ConnectorItem *firstPin = nullptr;
+		ConnectorItem *secondPin = nullptr;
+		ConnectorItem *firstHole = nullptr;
+		ConnectorItem *secondHole = nullptr;
+		QPointF firstPinPos;  // pin positions after the candidate swap
+		QPointF secondPinPos;
+		QPointF firstHolePos;
+		QPointF secondHolePos;
+		QPointF pinAxisDir;
+		QPointF partCenter;
+		QRectF partBounds;
+		double pinPairSpan = 0.0;
+		PinSwap swap = PinSwap::None;
+	};
+
+	// Profile counters for one part's bendable search, logged once per part.
+	struct BendableSearchProfile
+	{
+		qint64 pairCount = 0;
+		qint64 shiftIterations = 0;
+		qint64 postCutoffEvaluations = 0;
+	};
+
+	// Score one concrete body position for a bendable-leg candidate and fold
+	// it into `best` when it wins. Rejection order runs cheapest-first.
+	void evaluateBendablePlacement(const BendableCandidate &candidate, const QPointF &desiredCenter,
+								   BendableSearchProfile &profile, PlacementCandidate &best)
+	{
+		QPointF offset = desiredCenter - candidate.partCenter;
+		QRectF movedBounds = candidate.partBounds.translated(offset);
+		if (!anyBoardContains(movedBounds))
+		{
+			rejectedOffBoard++;
+			return;
+		}
+		if (overlapsOccupied(movedBounds.adjusted(-BendablePlacementKeepoutMargin, -BendablePlacementKeepoutMargin, BendablePlacementKeepoutMargin, BendablePlacementKeepoutMargin)))
+		{
+			rejectedOverlap++;
+			return;
+		}
+
+		QPointF movedFirstPin = candidate.firstPinPos + offset;
+		QPointF movedSecondPin = candidate.secondPinPos + offset;
+		double firstLegLength = QLineF(movedFirstPin, candidate.firstHolePos).length();
+		double secondLegLength = QLineF(movedSecondPin, candidate.secondHolePos).length();
+		if (firstLegLength > self->m_maxLegLength || secondLegLength > self->m_maxLegLength)
+		{
+			rejectedPinGeometry++;
+			return;
+		}
+
+		acceptedCandidates++;
+		double score = distanceToNearestBoardCenter(movedBounds.center()) * 0.15
+					 + (firstLegLength + secondLegLength) * self->m_leadLengthWeight;
+
+		// Straight leads only look straight when they leave along the body
+		// axis. Penalize perpendicular drift (diagonal leads) and hole pairs
+		// tighter than the pin spacing (leads folding back under the body).
+		if (candidate.pinPairSpan > 0.001)
+		{
+			const QPointF firstLegVector = candidate.firstHolePos - movedFirstPin;
+			const QPointF secondLegVector = candidate.secondHolePos - movedSecondPin;
+			const double perpendicularDrift =
+				qAbs(candidate.pinAxisDir.x() * firstLegVector.y() - candidate.pinAxisDir.y() * firstLegVector.x())
+				+ qAbs(candidate.pinAxisDir.x() * secondLegVector.y() - candidate.pinAxisDir.y() * secondLegVector.x());
+			const double holeSpan = (candidate.secondHolePos.x() - candidate.firstHolePos.x()) * candidate.pinAxisDir.x()
+								  + (candidate.secondHolePos.y() - candidate.firstHolePos.y()) * candidate.pinAxisDir.y();
+			const double compression = qMax(0.0, candidate.pinPairSpan - holeSpan);
+			score += perpendicularDrift * self->m_leadAngleWeight + compression * self->m_foldbackWeight;
+		}
+
+		// Net placement costs only ever add, so a candidate whose geometric
+		// score already loses cannot win: skip the expensive conflict and
+		// net-cost evaluation entirely.
+		if (score >= best.score)
+			return;
+		profile.postCutoffEvaluations++;
+
+		QHash<ConnectorItem *, ConnectorItem *> pinToHole;
+		pinToHole.insert(candidate.firstPin, candidate.firstHole);
+		pinToHole.insert(candidate.secondPin, candidate.secondHole);
+		if (conflictsWithPlacedNets(pinToHole))
+		{
+			rejectedSameBus++;
+			return;
+		}
+		score += netPlacementCost(candidate.firstPin, candidate.firstHole);
+		score += netPlacementCost(candidate.secondPin, candidate.secondHole);
+		if (score >= best.score)
+			return;
+
+		best.newLoc = best.oldLoc + offset;
+		best.pinToHole = pinToHole;
+		best.pinToLeg.clear();
+		best.pinToLeg.insert(candidate.firstPin, translatedLegForTarget(candidate.firstPin, offset, candidate.firstHole, candidate.swap, candidate.partCenter));
+		best.pinToLeg.insert(candidate.secondPin, translatedLegForTarget(candidate.secondPin, offset, candidate.secondHole, candidate.swap, candidate.partCenter));
+		best.score = score;
+		best.usesLegPlacement = true;
+		best.pinSwap = candidate.swap;
+		self->logAutoroute(QString("bendable placement best update: part=%1 score=%2 offset=(%3,%4) holes=[%5 | %6] legLengths=[%7,%8]")
+						 .arg(self->itemSummary(candidate.part))
+						 .arg(score)
+						 .arg(offset.x())
+						 .arg(offset.y())
+						 .arg(self->connectorSummary(candidate.firstHole))
+						 .arg(self->connectorSummary(candidate.secondHole))
+						 .arg(firstLegLength)
+						 .arg(secondLegLength));
+	}
+
+	// One hole pair: the body need not sit centered between its holes -
+	// sliding it along the pin axis lets both leads leave the body forward
+	// instead of folding back when the hole pair is narrower than the pin
+	// spacing. Leg length varies linearly with the slide along the axis, so
+	// the only shifts worth evaluating are the ones that zero each leg's
+	// axial component, plus their midpoint.
+	void evaluateBendablePair(const BendableCandidate &candidate, BendableSearchProfile &profile, PlacementCandidate &best)
+	{
+		const QPointF baseCenter = (candidate.firstHolePos + candidate.secondHolePos) / 2.0;
+		const QPointF baseOffset = baseCenter - candidate.partCenter;
+		const QPointF baseFirstPin = candidate.firstPinPos + baseOffset;
+		const QPointF baseSecondPin = candidate.secondPinPos + baseOffset;
+		const double firstAxial = (candidate.firstHolePos.x() - baseFirstPin.x()) * candidate.pinAxisDir.x()
+								+ (candidate.firstHolePos.y() - baseFirstPin.y()) * candidate.pinAxisDir.y();
+		const double secondAxial = (candidate.secondHolePos.x() - baseSecondPin.x()) * candidate.pinAxisDir.x()
+								 + (candidate.secondHolePos.y() - baseSecondPin.y()) * candidate.pinAxisDir.y();
+		const double axialShifts[] = {(firstAxial + secondAxial) / 2.0, firstAxial, secondAxial};
+		for (double axialShift : axialShifts)
+		{
+			profile.shiftIterations++;
+			const QPointF desiredCenter = baseCenter
+										+ QPointF(candidate.pinAxisDir.x() * axialShift, candidate.pinAxisDir.y() * axialShift);
+			evaluateBendablePlacement(candidate, desiredCenter, profile, best);
+		}
+	}
+
+	// Bendable-leg search for two-pin parts: pick any two free holes on
+	// different buses within leg reach and bend each leg to its hole.
+	void searchBendable(ItemBase *part, ConnectorItem *firstPin, ConnectorItem *secondPin, PlacementCandidate &best)
+	{
+		self->logAutoroute(QString("bendable placement search: %1 pins=[%2 | %3]")
+						 .arg(self->itemSummary(part))
+						 .arg(self->connectorSummary(firstPin))
+						 .arg(self->connectorSummary(secondPin)));
+
+		BendableCandidate candidate;
+		candidate.part = part;
+		candidate.firstPin = firstPin;
+		candidate.secondPin = secondPin;
+		const QPointF unflippedFirstPinPos = firstPin->sceneAdjustedTerminalPoint(nullptr);
+		const QPointF unflippedSecondPinPos = secondPin->sceneAdjustedTerminalPoint(nullptr);
+		candidate.pinPairSpan = QLineF(unflippedFirstPinPos, unflippedSecondPinPos).length();
+		candidate.partBounds = part->sceneBoundingRect();
+		candidate.partCenter = candidate.partBounds.center();
+
+		QElapsedTimer searchTimer;
+		searchTimer.start();
+		BendableSearchProfile profile;
+
+		// Both legs are capped, so viable hole pairs lie within an annulus
+		// around the pin spacing; everything else can be rejected on a
+		// single distance test before any geometry work.
+		const double maxHoleSpan = candidate.pinPairSpan + 2.0 * self->m_maxLegLength;
+
+		// Also search with the pins swapped, so crossed legs can uncross.
+		// Prefer a mirror across the pin axis (body stays upright) when the
+		// part's breadboard view allows flipping; otherwise fall back to a
+		// 180 degree rotation.
+		const bool axisMostlyHorizontal =
+			qAbs(unflippedSecondPinPos.x() - unflippedFirstPinPos.x())
+			>= qAbs(unflippedSecondPinPos.y() - unflippedFirstPinPos.y());
+		const Qt::Orientations flipOrientation = axisMostlyHorizontal ? Qt::Horizontal : Qt::Vertical;
+		const PinSwap swapMode = part->canFlip(flipOrientation)
+			? (axisMostlyHorizontal ? PinSwap::FlipHorizontal : PinSwap::FlipVertical)
+			: PinSwap::Rotate180;
+
+		for (int flip = 0; flip <= 1; flip++)
+		{
+			candidate.swap = flip == 1 ? swapMode : PinSwap::None;
+			candidate.firstPinPos = swappedPoint(unflippedFirstPinPos, candidate.swap, candidate.partCenter);
+			candidate.secondPinPos = swappedPoint(unflippedSecondPinPos, candidate.swap, candidate.partCenter);
+			candidate.pinAxisDir = candidate.pinPairSpan > 0.001
+				? QPointF((candidate.secondPinPos.x() - candidate.firstPinPos.x()) / candidate.pinPairSpan,
+						  (candidate.secondPinPos.y() - candidate.firstPinPos.y()) / candidate.pinPairSpan)
+				: QPointF(1.0, 0.0);
+
+			for (int firstHoleIndex = 0; firstHoleIndex < breadboardHoles.count(); firstHoleIndex++)
+			{
+				ConnectorItem *firstHole = breadboardHoles.at(firstHoleIndex);
 				if (reservedHoles.contains(firstHole))
 					continue;
-				QPointF firstHolePos = firstHole->sceneAdjustedTerminalPoint(nullptr);
-				Q_FOREACH (ConnectorItem *secondHole, breadboardHoles)
+				candidate.firstHole = firstHole;
+				candidate.firstHolePos = holePositions.value(firstHole);
+				const int boardId = boardIdForHole.value(firstHole, -1);
+				const QVector<int> nearbyHoleIndices = holeSpatialIndex.withinRadius(candidate.firstHolePos, maxHoleSpan, boardId);
+				for (int secondHoleIndex : nearbyHoleIndices)
 				{
+					ConnectorItem *secondHole = breadboardHoles.at(secondHoleIndex);
 					if (firstHole == secondHole)
 						continue;
 					if (reservedHoles.contains(secondHole))
 						continue;
 					candidateAttempts++;
 
-					if (connectorsShareBreadboardBus(firstHole, secondHole))
-					{
-						rejectedSameBus++;
-						continue;
-					}
-
-					QPointF secondHolePos = secondHole->sceneAdjustedTerminalPoint(nullptr);
-					QPointF desiredCenter = (firstHolePos + secondHolePos) / 2.0;
-					QPointF offset = desiredCenter - part->sceneBoundingRect().center();
-					QRectF movedBounds = part->sceneBoundingRect().translated(offset);
-					QRectF movedKeepout = movedBounds.adjusted(-BendablePlacementKeepoutMargin, -BendablePlacementKeepoutMargin, BendablePlacementKeepoutMargin, BendablePlacementKeepoutMargin);
-
-					if (!targetBoardBounds.contains(movedBounds))
-					{
-						rejectedOffBoard++;
-						continue;
-					}
-
-					bool overlaps = false;
-					Q_FOREACH (const QRectF &occupied, occupiedRects)
-					{
-						if (movedKeepout.intersects(occupied))
-						{
-							overlaps = true;
-							break;
-						}
-					}
-					if (overlaps)
-					{
-						rejectedOverlap++;
-						continue;
-					}
-
-					QPointF movedFirstPin = firstPin->sceneAdjustedTerminalPoint(nullptr) + offset;
-					QPointF movedSecondPin = secondPin->sceneAdjustedTerminalPoint(nullptr) + offset;
-					double firstLegLength = QLineF(movedFirstPin, firstHolePos).length();
-					double secondLegLength = QLineF(movedSecondPin, secondHolePos).length();
-					if (firstLegLength > MaxBendableLegLength || secondLegLength > MaxBendableLegLength)
+					candidate.secondHole = secondHole;
+					candidate.secondHolePos = holePositions.value(secondHole);
+					const double spanDx = candidate.secondHolePos.x() - candidate.firstHolePos.x();
+					const double spanDy = candidate.secondHolePos.y() - candidate.firstHolePos.y();
+					if (spanDx * spanDx + spanDy * spanDy > maxHoleSpan * maxHoleSpan)
 					{
 						rejectedPinGeometry++;
 						continue;
 					}
-
-					acceptedCandidates++;
-					double score = manhattanDistance(movedBounds.center(), breadboardCenter) * 0.15 + firstLegLength + secondLegLength;
-					QHash<ConnectorItem *, ConnectorItem *> pinToHole;
-					pinToHole.insert(firstPin, firstHole);
-					pinToHole.insert(secondPin, secondHole);
-
-					Q_FOREACH (ConnectorItem *pin, pins)
+					if (holesShareBus(firstHole, secondHole))
 					{
-						int netIndex = netForConnector.value(pin, -1);
-						if (netIndex < 0)
-							continue;
-
-						ConnectorItem *targetHole = pinToHole.value(pin, nullptr);
-						if (targetHole == nullptr)
-							continue;
-						QPointF targetPos = targetHole->sceneAdjustedTerminalPoint(nullptr);
-
-						double bestNetDistance = std::numeric_limits<double>::max();
-						Q_FOREACH (ConnectorItem *other, connectorsForNet.value(netIndex))
-						{
-							if (other == pin)
-								continue;
-							ConnectorItem *otherTarget = placedTargets.value(other, nullptr);
-							if (otherTarget == nullptr)
-								continue;
-							bestNetDistance = qMin(bestNetDistance, manhattanDistance(targetPos, otherTarget->sceneAdjustedTerminalPoint(nullptr)));
-						}
-
-						if (bestNetDistance == std::numeric_limits<double>::max())
-						{
-							score += manhattanDistance(targetPos, breadboardCenter) * 0.05;
-						}
-						else
-						{
-							score += bestNetDistance;
-						}
+						rejectedSameBus++;
+						continue;
 					}
-
-					if (score < best.score)
-					{
-						best.newLoc = best.oldLoc + offset;
-						best.pinToHole = pinToHole;
-						best.pinToLeg.clear();
-						best.pinToLeg.insert(firstPin, translatedLegForTarget(firstPin, offset, firstHole));
-						best.pinToLeg.insert(secondPin, translatedLegForTarget(secondPin, offset, secondHole));
-						best.score = score;
-						best.usesLegPlacement = true;
-						logAutoroute(QString("bendable placement best update: part=%1 score=%2 offset=(%3,%4) holes=[%5 | %6] legLengths=[%7,%8]")
-										 .arg(itemSummary(part))
-										 .arg(score)
-										 .arg(offset.x())
-										 .arg(offset.y())
-										 .arg(connectorSummary(firstHole))
-										 .arg(connectorSummary(secondHole))
-										 .arg(firstLegLength)
-										 .arg(secondLegLength));
-					}
+					profile.pairCount++;
+					evaluateBendablePair(candidate, profile, best);
 				}
 			}
 		}
+		self->logAutoroute(QString("bendable search profile: %1 elapsedMs=%2 pairs=%3 shiftIterations=%4 postCutoffEvaluations=%5")
+						 .arg(self->itemSummary(part))
+						 .arg(searchTimer.elapsed())
+						 .arg(profile.pairCount)
+						 .arg(profile.shiftIterations)
+						 .arg(profile.postCutoffEvaluations));
+	}
 
-		if (best.pinToHole.isEmpty())
+	// Mirror or rotate the part so swapped-pin candidates land as searched.
+	void emitSwapCommand(ItemBase *part, PinSwap swap)
+	{
+		switch (swap)
 		{
-			logAutoroute(QString("placement no candidate: %1").arg(itemSummary(part)));
-			failedBoardFit++;
-			continue;
+		case PinSwap::FlipHorizontal:
+			new FlipItemCommand(self->m_sketchWidget, part->id(), Qt::Horizontal, parentCommand);
+			self->logAutoroute(QString("placement flip: %1 mirrored horizontally").arg(self->itemSummary(part)));
+			return;
+		case PinSwap::FlipVertical:
+			new FlipItemCommand(self->m_sketchWidget, part->id(), Qt::Vertical, parentCommand);
+			self->logAutoroute(QString("placement flip: %1 mirrored vertically").arg(self->itemSummary(part)));
+			return;
+		case PinSwap::Rotate180:
+			new RotateItemCommand(self->m_sketchWidget, part->id(), &FlipRotationDegrees, parentCommand);
+			self->logAutoroute(QString("placement flip: %1 rotated 180").arg(self->itemSummary(part)));
+			return;
+		default:
+			return;
 		}
+	}
+
+	// The leg command for one placed pin. Bendable placements planned their
+	// leg shape during the search; rigid moves translate the loose sketch's
+	// bent leg shape verbatim, so historical bends would survive placement -
+	// replace the shape with a direct root-to-hole lead instead.
+	void emitLegCommand(ConnectorItem *pin, ConnectorItem *hole, const PlacementCandidate &best)
+	{
+		QPolygonF newLeg = best.pinToLeg.value(pin);
+		if (!best.usesLegPlacement && pin->hasRubberBandLeg())
+		{
+			QPolygonF looseLeg = pin->sceneAdjustedLeg();
+			if (looseLeg.count() >= 2)
+			{
+				newLeg.clear();
+				newLeg << looseLeg.first() + (best.newLoc - best.oldLoc);
+				newLeg << hole->sceneAdjustedTerminalPoint(nullptr);
+			}
+		}
+		if (newLeg.count() < 2)
+			return;
+
+		self->m_componentLeadLength += polylineLength(newLeg);
+		QPolygonF oldLeg = pin->sceneAdjustedLeg();
+		QPolygonF movedOldLeg;
+		QPointF offset = best.newLoc - best.oldLoc;
+		Q_FOREACH (QPointF point, oldLeg)
+		{
+			movedOldLeg << point + offset;
+		}
+		auto *legCommand = new ChangeLegCommand(self->m_sketchWidget,
+												pin->attachedToID(),
+												pin->connectorSharedID(),
+												movedOldLeg,
+												newLeg,
+												false,
+												true,
+												"breadboard autoroute",
+												parentCommand);
+		legCommand->setSimple();
+		self->logAutoroute(QString("placement leg: pin=%1 points=%2")
+						 .arg(self->connectorSummary(pin))
+						 .arg(newLeg.count()));
+	}
+
+	// One pin of the winning candidate: connection command plus all the
+	// planning bookkeeping (hole reservation, net target maps, bus claim -
+	// the prime invariant's placement-side ledger).
+	void connectPinToHole(ConnectorItem *pin, ConnectorItem *hole, const PlacementCandidate &best)
+	{
+		auto *connectionCommand = new ChangeConnectionCommand(self->m_sketchWidget, BaseCommand::CrossView,
+									pin->attachedToID(), pin->connectorSharedID(),
+									hole->attachedToID(), hole->connectorSharedID(),
+									ViewLayer::specFromID(hole->attachedToViewLayerID()),
+									true, parentCommand);
+		// Placement already specifies the exact pin and hole. Geometry-driven
+		// updates while the part and its legs are moving can detach that pair.
+		connectionCommand->setUpdateConnections(false);
+		self->logAutoroute(QString("placement connection: pin=%1 hole=%2 sameBus?=%3")
+						 .arg(self->connectorSummary(pin))
+						 .arg(self->connectorSummary(hole))
+						 .arg(self->connectorsShareBreadboardBus(pin, hole) ? "yes" : "no"));
+		reservedHoles.insert(hole);
+		placedTargets.insert(pin, hole);
+		newlyPlacedTargets.insert(pin, hole);
+		// Claim the hole's bus for the pin's net (or exclusively, for a
+		// no-net pin) so later placements and routing cannot join it.
+		const int placedPinNet = netForConnector.value(pin, -1);
+		self->claimBus(self->busGroupFor(hole), placedPinNet >= 0 ? placedPinNet : self->makeNoNetOwnerKey());
+
+		emitLegCommand(pin, hole, best);
+	}
+
+	// Commit the winning candidate as undo commands (they execute only when
+	// finish() pushes the parent command).
+	void commitBest(ItemBase *part, const PlacementCandidate &best)
+	{
+		// Transform strictly BEFORE the move and before any pins are bound:
+		// transforming a part whose legs are already attached would drag the
+		// leg geometry off its assigned holes.
+		emitSwapCommand(part, best.pinSwap);
 
 		ViewGeometry oldGeometry(part->getViewGeometry());
 		ViewGeometry newGeometry(part->getViewGeometry());
 		newGeometry.setLoc(best.newLoc);
-		new MoveItemCommand(m_sketchWidget, part->id(), oldGeometry, newGeometry, false, parentCommand);
-		logAutoroute(QString("placement accepted: %1 old=(%2,%3) new=(%4,%5) score=%6")
-						 .arg(itemSummary(part))
+		new MoveItemCommand(self->m_sketchWidget, part->id(), oldGeometry, newGeometry, false, parentCommand);
+		self->logAutoroute(QString("placement accepted: %1 old=(%2,%3) new=(%4,%5) score=%6")
+						 .arg(self->itemSummary(part))
 						 .arg(best.oldLoc.x())
 						 .arg(best.oldLoc.y())
 						 .arg(best.newLoc.x())
@@ -1082,47 +1878,9 @@ int BreadboardAutorouter::autoplacePartsOnBreadboard()
 
 		for (auto it = best.pinToHole.constBegin(); it != best.pinToHole.constEnd(); ++it)
 		{
-			ConnectorItem *pin = it.key();
-			ConnectorItem *hole = it.value();
-			if (pin == nullptr || hole == nullptr)
+			if (it.key() == nullptr || it.value() == nullptr)
 				continue;
-			new ChangeConnectionCommand(m_sketchWidget, BaseCommand::CrossView,
-										pin->attachedToID(), pin->connectorSharedID(),
-										hole->attachedToID(), hole->connectorSharedID(),
-										ViewLayer::specFromID(hole->attachedToViewLayerID()),
-										true, parentCommand);
-			logAutoroute(QString("placement connection: pin=%1 hole=%2 sameBus?=%3")
-							 .arg(connectorSummary(pin))
-							 .arg(connectorSummary(hole))
-							 .arg(connectorsShareBreadboardBus(pin, hole) ? "yes" : "no"));
-			reservedHoles.insert(hole);
-			placedTargets.insert(pin, hole);
-
-			QPolygonF newLeg = best.pinToLeg.value(pin);
-			if (best.usesLegPlacement && newLeg.count() >= 2)
-			{
-				m_componentLeadLength += polylineLength(newLeg);
-				QPolygonF oldLeg = pin->sceneAdjustedLeg();
-				QPolygonF movedOldLeg;
-				QPointF offset = best.newLoc - best.oldLoc;
-				Q_FOREACH (QPointF point, oldLeg)
-				{
-					movedOldLeg << point + offset;
-				}
-				auto *legCommand = new ChangeLegCommand(m_sketchWidget,
-														pin->attachedToID(),
-														pin->connectorSharedID(),
-														movedOldLeg,
-														newLeg,
-														false,
-														true,
-														"breadboard autoroute",
-														parentCommand);
-				legCommand->setSimple();
-				logAutoroute(QString("placement leg: pin=%1 points=%2")
-								 .arg(connectorSummary(pin))
-								 .arg(newLeg.count()));
-			}
+			connectPinToHole(it.key(), it.value(), best);
 		}
 
 		occupiedRects.append(part->sceneBoundingRect().translated(best.newLoc - best.oldLoc).adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin));
@@ -1133,60 +1891,207 @@ int BreadboardAutorouter::autoplacePartsOnBreadboard()
 		moved++;
 	}
 
-	if (moved <= 0)
+	// Phase 8, per part: search (bendable-leg for two-pin leg parts, rigid
+	// otherwise), then commit the best candidate. Parts with no placeable
+	// pins are silently left alone.
+	void placePart(ItemBase *part)
 	{
-		delete parentCommand;
-		m_lastPlacementReport = QObject::tr(
-									"Target breadboard(s): %1\n"
-									"Breadboard holes considered: %2\n"
-									"Scene connectors inside target board bounds: %3\n"
-									"Visible parts: %4\n"
-									"Movable parts after filters: %5\n"
-									"Movable parts with placeable pins: %6\n"
-									"Placement candidates tried: %7\n"
-									"Rejected because pins did not line up with free holes: %8\n"
-									"Rejected because one part would be shorted on the same breadboard bus: %9\n"
-									"Rejected because placement was outside target board: %10\n"
-									"Rejected because placement overlapped another part: %11\n"
-									"Accepted candidate placements: %12\n"
-									"Rejected by policy: %13\n"
-									"Left as peripheral: %14\n"
-									"Failed board fit: %15\n\n"
-									"If pin-geometry rejections dominate, the next implementation needs bendable-leg placement instead of whole-SVG pin alignment.")
-									.arg(targetBreadboards.count())
-									.arg(breadboardHoles.count())
-									.arg(targetSceneConnectors)
-									.arg(parts.count())
-									.arg(movableParts.count())
-									.arg(partsWithPlaceablePins)
-									.arg(candidateAttempts)
-									.arg(rejectedPinGeometry)
-									.arg(rejectedSameBus)
-									.arg(rejectedOffBoard)
-									.arg(rejectedOverlap)
-									.arg(acceptedCandidates)
-									.arg(rejectedByPolicy)
-									.arg(leftPeripheral)
-									.arg(failedBoardFit);
-		logAutoroute(QString("autoplace failed:\n%1").arg(m_lastPlacementReport));
+		QList<ConnectorItem *> pins;
+		Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+		{
+			if (connectorItem != nullptr && self->isPlaceablePin(connectorItem))
+				pins.append(connectorItem);
+		}
+		if (pins.isEmpty())
+			return;
+		partsWithPlaceablePins++;
+
+		const bool canUseBendableLegPlacement = pins.count() == 2 && allPinsHaveBendableLegs(pins);
+		self->logAutoroute(QString("placement begin: %1 placeablePins=%2 strategy=%3")
+						 .arg(self->itemSummary(part))
+						 .arg(pins.count())
+						 .arg(canUseBendableLegPlacement ? "rigid-or-bendable-leg" : "rigid"));
+
+		PlacementCandidate best;
+		best.item = part;
+		best.oldLoc = part->getViewGeometry().loc();
+
+		if (canUseBendableLegPlacement)
+			searchBendable(part, pins.at(0), pins.at(1), best);
+		else
+			searchRigid(part, pins, best);
+
+		if (best.pinToHole.isEmpty())
+		{
+			self->logAutoroute(QString("placement no candidate: %1").arg(self->itemSummary(part)));
+			failedBoardFit++;
+			return;
+		}
+		commitBest(part, best);
+	}
+
+	// Why nothing was placed, in user-facing terms; every counter names the
+	// filter that consumed the candidates.
+	QString failureReport() const
+	{
+		return QObject::tr(
+					"Target breadboard(s): %1\n"
+					"Breadboard holes considered: %2\n"
+					"Scene connectors inside target board bounds: %3\n"
+					"Visible parts: %4\n"
+					"Movable parts after filters: %5\n"
+					"Movable parts with placeable pins: %6\n"
+					"Placement candidates tried: %7\n"
+					"Rejected because pins did not line up with free holes: %8\n"
+					"Rejected because one part would be shorted on the same breadboard bus: %9\n"
+					"Rejected because placement was outside target board: %10\n"
+					"Rejected because placement overlapped another part: %11\n"
+					"Accepted candidate placements: %12\n"
+					"Rejected by policy: %13\n"
+					"Left as peripheral: %14\n"
+					"Failed board fit: %15\n\n"
+					"If pin-geometry rejections dominate, the next implementation needs bendable-leg placement instead of whole-SVG pin alignment.")
+					.arg(targetBreadboards.count())
+					.arg(breadboardHoles.count())
+					.arg(targetSceneConnectors)
+					.arg(parts.count())
+					.arg(movableParts.count())
+					.arg(partsWithPlaceablePins)
+					.arg(candidateAttempts)
+					.arg(rejectedPinGeometry)
+					.arg(rejectedSameBus)
+					.arg(rejectedOffBoard)
+					.arg(rejectedOverlap)
+					.arg(acceptedCandidates)
+					.arg(rejectedByPolicy)
+					.arg(leftPeripheral)
+					.arg(failedBoardFit);
+	}
+
+	// Phase 9: push (the commands execute here) and verify every planned pin
+	// actually attached to its assigned hole. Returns the number of parts
+	// moved, 0 when nothing placed (with the failure report set), or -1 when
+	// verification failed.
+	int finish()
+	{
+		if (moved <= 0)
+		{
+			delete parentCommand;
+			self->m_lastPlacementReport = failureReport();
+			self->logAutoroute(QString("autoplace failed:\n%1").arg(self->m_lastPlacementReport));
+			return 0;
+		}
+
+		QElapsedTimer execTimer;
+		execTimer.start();
+		self->m_sketchWidget->undoStack()->push(parentCommand);
+		self->m_phaseStats.placeExecMs = execTimer.elapsed();
+
+		QStringList connectionFailures;
+		if (!self->verifyPlacedConnections(newlyPlacedTargets, connectionFailures))
+		{
+			self->m_lastPlacementReport = QObject::tr("Placed component pins did not attach to their assigned breadboard holes:\n%1")
+									.arg(connectionFailures.join('\n'));
+			self->logAutoroute(QString("autoplace connection verification failed:\n%1").arg(self->m_lastPlacementReport));
+			return -1;
+		}
+		self->logAutoroute(QString("autoplace counters: moved=%1 placedRigid=%2 placedWithLegs=%3 candidateAttempts=%4 acceptedCandidates=%5 rejectedPinGeometry=%6 rejectedSameBus=%7 rejectedOffBoard=%8 rejectedOverlap=%9 rejectedByPolicy=%10 leftPeripheral=%11 failedBoardFit=%12")
+						 .arg(moved)
+						 .arg(placedRigid)
+						 .arg(placedWithLegs)
+						 .arg(candidateAttempts)
+						 .arg(acceptedCandidates)
+						 .arg(rejectedPinGeometry)
+						 .arg(rejectedSameBus)
+						 .arg(rejectedOffBoard)
+						 .arg(rejectedOverlap)
+						 .arg(rejectedByPolicy)
+						 .arg(leftPeripheral)
+						 .arg(failedBoardFit));
+		return moved;
+	}
+};
+
+int BreadboardAutorouter::autoplacePartsOnBreadboard()
+{
+	m_lastPlacementReport.clear();
+
+	PlacementPass pass(this);
+	m_sketchWidget->collectParts(pass.parts);
+	logAutoroute(QString("autoplace: visible parts collected=%1").arg(pass.parts.count()));
+	if (pass.parts.isEmpty())
+	{
+		m_lastPlacementReport = QObject::tr("No breadboard-view parts were found.");
+		logAutoroute("autoplace abort: no parts");
 		return 0;
 	}
 
-	m_sketchWidget->undoStack()->push(parentCommand);
-	logAutoroute(QString("autoplace counters: moved=%1 placedRigid=%2 placedWithLegs=%3 candidateAttempts=%4 acceptedCandidates=%5 rejectedPinGeometry=%6 rejectedSameBus=%7 rejectedOffBoard=%8 rejectedOverlap=%9 rejectedByPolicy=%10 leftPeripheral=%11 failedBoardFit=%12")
-					 .arg(moved)
-					 .arg(placedRigid)
-					 .arg(placedWithLegs)
-					 .arg(candidateAttempts)
-					 .arg(acceptedCandidates)
-					 .arg(rejectedPinGeometry)
-					 .arg(rejectedSameBus)
-					 .arg(rejectedOffBoard)
-					 .arg(rejectedOverlap)
-					 .arg(rejectedByPolicy)
-					 .arg(leftPeripheral)
-					 .arg(failedBoardFit));
-	return moved;
+	pass.indexNets();
+	if (!pass.discoverBoards())
+		return 0;
+	pass.buildHoleCaches();
+	pass.collectMovableParts();
+	pass.collectOccupiedRects();
+	pass.sortByConnectivity();
+	pass.beginCommand();
+	const int movableCount = pass.movableParts.count();
+	int partsDone = 0;
+	Q_FOREACH (ItemBase *part, pass.movableParts)
+	{
+		reportProgress(movableCount > 0 ? (PlacementProgressSpan * partsDone) / movableCount : 0,
+					   QObject::tr("Placing %1 (%2 of %3)...")
+						   .arg(part == nullptr ? QString() : part->title())
+						   .arg(partsDone + 1)
+						   .arg(movableCount));
+		pass.placePart(part);
+		partsDone++;
+	}
+	return pass.finish();
+}
+
+bool BreadboardAutorouter::verifyPlacedConnections(const QHash<ConnectorItem *, ConnectorItem *> &placedTargets,
+													 QStringList &failures) const
+{
+	constexpr double EndpointTolerance = 1.0;
+	for (auto it = placedTargets.constBegin(); it != placedTargets.constEnd(); ++it)
+	{
+		ConnectorItem *pin = it.key();
+		ConnectorItem *hole = it.value();
+		if (pin == nullptr || hole == nullptr)
+		{
+			failures.append(QObject::tr("Null pin or hole in placement result."));
+			continue;
+		}
+
+		const bool pinConnected = pin->connectedToItems().contains(hole);
+		const bool holeConnected = hole->connectedToItems().contains(pin);
+		double endpointDistance = 0.0;
+		if (pin->hasRubberBandLeg())
+		{
+			const QPolygonF leg = pin->sceneAdjustedLeg();
+			endpointDistance = leg.isEmpty()
+				? std::numeric_limits<double>::infinity()
+				: QLineF(leg.last(), hole->sceneAdjustedTerminalPoint(nullptr)).length();
+		}
+
+		if (!pinConnected || !holeConnected || endpointDistance > EndpointTolerance)
+		{
+			failures.append(QObject::tr("%1 -> %2: pinConnected=%3, holeConnected=%4, legEndpointDistance=%5")
+							.arg(connectorSummary(pin))
+							.arg(connectorSummary(hole))
+							.arg(pinConnected ? "yes" : "no")
+							.arg(holeConnected ? "yes" : "no")
+							.arg(endpointDistance));
+		}
+		else
+		{
+			logAutoroute(QString("placement verified: pin=%1 hole=%2 endpointDistance=%3")
+							 .arg(connectorSummary(pin))
+							 .arg(connectorSummary(hole))
+							 .arg(endpointDistance));
+		}
+	}
+	return failures.isEmpty();
 }
 
 int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
@@ -1230,13 +2135,14 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 			reservedHoles.insert(segment.to);
 		}
 	};
-	auto chooseEntry = [&](ConnectorItem *terminal, const QSet<ConnectorItem *> &extraReserved) {
+	auto chooseEntry = [&](ConnectorItem *terminal, const QSet<ConnectorItem *> &extraReserved, int ownerKey) {
 		ConnectorItem *best = nullptr;
 		double bestScore = std::numeric_limits<double>::max();
 		Q_FOREACH (ConnectorItem *hole, routeHoles)
 		{
 			if (hole == nullptr || reservedHoles.contains(hole) || extraReserved.contains(hole)) continue;
 			if (hole->connectionsCount() != 0) continue;
+			if (!busAvailableFor(busGroupFor(hole), ownerKey)) continue;
 			const double score = boardEdgeEntryScore(terminal, hole, holeBounds);
 			if (score < bestScore) {
 				best = hole;
@@ -1247,6 +2153,10 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 	};
 
 	logAutoroute(QString("ratsnest demands: %1").arg(demands.count()));
+	const RouteGraphSession routeSession = RouteGraphSession::build(
+		routeHoles,
+		[this](ConnectorItem *connectorItem) { return busGroupFor(connectorItem); },
+		[this](int busGroup) { return busOwner(busGroup); });
 	Q_FOREACH (Wire *demand, demands)
 	{
 		const int createdBeforeDemand = created;
@@ -1267,15 +2177,28 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 			continue;
 		}
 
+		// The demand's owner key: its schematic net, or a fresh exclusive
+		// sentinel if the endpoints are unexpectedly netless.
+		int demandNet = m_netForConnector.value(fromPart, INT_MIN);
+		if (demandNet == INT_MIN)
+			demandNet = m_netForConnector.value(toPart, INT_MIN);
+		if (demandNet == INT_MIN)
+			demandNet = makeNoNetOwnerKey();
+
 		if (fromHole != nullptr && toHole != nullptr)
 		{
-			BreadboardRouteGraph graph(routeHoles, reservedHoles, routeGraphOptions(plannedSegments));
-			BreadboardRouteGraph::Result route = graph.route(fromHole, toHole);
+			const BreadboardRouteGraphCore::QueryContext routeContext = routeSession.prepare(reservedHoles, plannedSegments, demandNet);
+			BreadboardRouteGraph::Result route = routeSession.route(fromHole, toHole, routeContext);
 			if (!route.found) {
 				failed++;
 				logAutoroute(QString("ratsnest demand failed: no board route from=[%1] to=[%2]")
 							 .arg(connectorSummary(fromPart), connectorSummary(toPart)));
 				continue;
+			}
+			Q_FOREACH (const BreadboardRouteGraph::Segment &segment, route.segments)
+			{
+				claimBus(busGroupFor(segment.from), demandNet);
+				claimBus(busGroupFor(segment.to), demandNet);
 			}
 			applyGraphRoute(route);
 			logAutoroute(QString("ratsnest demand complete: wires=%1").arg(created - createdBeforeDemand));
@@ -1284,8 +2207,10 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 
 		if (fromHole == nullptr && toHole == nullptr)
 		{
-			ConnectorItem *fromEntry = chooseEntry(fromPart, QSet<ConnectorItem *>());
+			ConnectorItem *fromEntry = chooseEntry(fromPart, QSet<ConnectorItem *>(), demandNet);
 			ConnectorItem *toEntry = nearestFreeBusHole(fromEntry);
+			if (toEntry != nullptr && !busAvailableFor(busGroupFor(toEntry), demandNet))
+				toEntry = nullptr;
 			if (fromEntry == nullptr || toEntry == nullptr) {
 				failed++;
 				logAutoroute("ratsnest demand failed: no entries for off-board pair");
@@ -1295,6 +2220,8 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 			addWire(toPart, toEntry);
 			reservedHoles.insert(fromEntry);
 			reservedHoles.insert(toEntry);
+			claimBus(busGroupFor(fromEntry), demandNet);
+			claimBus(busGroupFor(toEntry), demandNet);
 			logAutoroute(QString("ratsnest demand complete: wires=%1").arg(created - createdBeforeDemand));
 			continue;
 		}
@@ -1314,8 +2241,14 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 			logAutoroute(QString("ratsnest demand failed: no peripheral target [%1]").arg(connectorSummary(terminal)));
 			continue;
 		}
+		if (!busAvailableFor(busGroupFor(targetHole), demandNet)) {
+			failed++;
+			logAutoroute(QString("ratsnest demand failed: peripheral target bus owned by another net [%1]").arg(connectorSummary(targetHole)));
+			continue;
+		}
 		addWire(terminal, targetHole);
 		reservedHoles.insert(targetHole);
+		claimBus(busGroupFor(targetHole), demandNet);
 		logAutoroute(QString("ratsnest demand complete: wires=%1").arg(created - createdBeforeDemand));
 	}
 
@@ -1330,84 +2263,123 @@ int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
 	return created;
 }
 
-int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
+// One net-routing pass over the sketch. The pass owns the state every phase
+// shares (route graph session, reserved holes, planned wire segments, score
+// counters); routeCollectedNets() is reduced to building the pass and driving
+// nets through its phases in most-constrained-first order.
+struct BreadboardAutorouter::NetRoutingPass
 {
+	BreadboardAutorouter *self = nullptr;
+	QUndoCommand *parentCommand = nullptr;
+
+	QList<ConnectorItem *> routeHoles;
+	QSet<ConnectorItem *> reservedHoles;
+	HoleBounds holeBounds;
+	RouteGraphSession session;
+	QList<QLineF> plannedSegments;
+	QSet<int> failedNetIndices;
 	int created = 0;
 	int wiredPeripheral = 0;
 	int allocatedPeripheralLanes = 0;
+	double peripheralLeadLength = 0.0;
 
-	BreadboardTopology topology;
-	topology.discover(m_sketchWidget->scene(), m_sketchWidget->scene()->selectedItems());
-	QList<ConnectorItem *> routeHoles = topology.holes();
-	QSet<ConnectorItem *> routeReservedHoles = topology.reservedHoles();
-	const HoleBounds routeHoleBounds = boundsForHoles(routeHoles);
-	QList<QLineF> plannedSegments;
-	QSet<int> failedNetIndices;
-	const BreadboardRouteGraph::Options activeOptions = BreadboardRouteGraph::Options::fromEnvironment();
-	logAutoroute(QString("route options: maxJumperLength=%1 candidatesPerBusPair=%2 crossingPenalty=%3 overlapPenalty=%4")
-				 .arg(activeOptions.maxJumperLength)
-				 .arg(activeOptions.candidatesPerBusPair)
-				 .arg(activeOptions.crossingPenalty)
-				 .arg(activeOptions.overlapPenalty));
+	// Working data for the net currently being routed.
+	int netIndex = -1;
+	QList<ConnectorItem *> breadboardAnchors;
+	QList<ConnectorItem *> offBoardTerminals;
+	QList<QList<ConnectorItem *> > groups;
 
-	QList<int> routeOrder;
-	for (int netIndex = 0; netIndex < m_allPartConnectorItems.count(); netIndex++)
+	NetRoutingPass(BreadboardAutorouter *router, QUndoCommand *command)
+		: self(router)
+		, parentCommand(command)
 	{
-		routeOrder.append(netIndex);
+		BreadboardTopology topology;
+		topology.discover(self->m_sketchWidget->scene(), self->m_sketchWidget->scene()->selectedItems());
+		routeHoles = topology.holes();
+		reservedHoles = topology.reservedHoles();
+		holeBounds = boundsForHoles(routeHoles);
+		session = RouteGraphSession::build(
+			routeHoles,
+			[this](ConnectorItem *connectorItem) { return self->busGroupFor(connectorItem); },
+			[this](int busGroup) { return self->busOwner(busGroup); });
+
+		const BreadboardRouteGraph::Options activeOptions = BreadboardRouteGraph::Options::fromEnvironment();
+		self->logAutoroute(QString("route options: maxJumperLength=%1 candidatesPerBusPair=%2 crossingPenalty=%3 overlapPenalty=%4")
+						   .arg(activeOptions.maxJumperLength)
+						   .arg(activeOptions.candidatesPerBusPair)
+						   .arg(activeOptions.crossingPenalty)
+						   .arg(activeOptions.overlapPenalty));
 	}
-	std::sort(routeOrder.begin(), routeOrder.end(), [this](int firstIndex, int secondIndex) {
-		auto difficulty = [this](QList<ConnectorItem *> *net) {
-			if (net == nullptr) return 0.0;
-			const QList<ConnectorItem *> candidates = routingCandidatesForSubnet(*net);
-			const int groups = collectCandidateGroups(candidates).count();
+
+	// Wire a lead from an off-board terminal to a board hole, with all the
+	// bookkeeping a peripheral lead requires (lead-length accounting so it
+	// is not counted as a board jumper, reservation, bus claim).
+	void addPeripheralLead(ConnectorItem *terminal, ConnectorItem *entry)
+	{
+		self->m_sketchWidget->createWire(terminal, entry, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+		const QLineF lead = connectorLine(terminal, entry);
+		plannedSegments.append(lead);
+		peripheralLeadLength += lead.length();
+		reservedHoles.insert(entry);
+		self->claimBus(self->busGroupFor(entry), netIndex);
+		created++;
+		wiredPeripheral++;
+	}
+
+	// Wire one board jumper segment produced by the route graph, claiming
+	// both end buses for the net (prime invariant bookkeeping).
+	void addGraphWire(const BreadboardRouteGraph::Segment &segment)
+	{
+		self->m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+		plannedSegments.append(connectorLine(segment.from, segment.to));
+		reservedHoles.insert(segment.from);
+		reservedHoles.insert(segment.to);
+		self->claimBus(self->busGroupFor(segment.from), netIndex);
+		self->claimBus(self->busGroupFor(segment.to), netIndex);
+		created++;
+	}
+
+	// Route nets hardest-first so constrained nets grab scarce buses before
+	// easy nets consume them. Difficulty is precomputed: the comparator
+	// would otherwise re-run subnet grouping O(n log n) times.
+	QList<int> netOrderMostConstrainedFirst() const
+	{
+		QList<int> routeOrder;
+		for (int index = 0; index < self->m_allPartConnectorItems.count(); index++)
+			routeOrder.append(index);
+
+		QHash<int, double> difficultyForNet;
+		Q_FOREACH (int index, routeOrder)
+		{
+			QList<ConnectorItem *> *net = self->m_allPartConnectorItems.value(index);
+			if (net == nullptr)
+			{
+				difficultyForNet.insert(index, 0.0);
+				continue;
+			}
+			const QList<ConnectorItem *> candidates = self->routingCandidatesForSubnet(*net);
+			const int groupCount = self->collectCandidateGroups(candidates).count();
 			QRectF bounds;
 			Q_FOREACH (ConnectorItem *candidate, candidates) {
 				if (candidate == nullptr) continue;
 				const QRectF point(candidate->sceneAdjustedTerminalPoint(nullptr), QSizeF(1.0, 1.0));
 				bounds = bounds.isNull() ? point : bounds | point;
 			}
-			return groups * 100000.0 + candidates.count() * 1000.0 + bounds.width() + bounds.height();
-		};
-		return difficulty(m_allPartConnectorItems.value(firstIndex)) > difficulty(m_allPartConnectorItems.value(secondIndex));
-	});
-	QStringList routeOrderText;
-	Q_FOREACH (int netIndex, routeOrder) routeOrderText.append(QString::number(netIndex));
-	logAutoroute(QString("route order (most constrained first): %1").arg(routeOrderText.join(",")));
-
-	for (int orderIndex = 0; orderIndex < routeOrder.count(); orderIndex++)
-	{
-		Q_EMIT setProgressValue(orderIndex);
-		const int i = routeOrder.at(orderIndex);
-
-		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(i);
-		if (net == nullptr)
-			continue;
-
-		QList<ConnectorItem *> candidates = routingCandidatesForSubnet(*net);
-		QList<QList<ConnectorItem *>> groups = collectCandidateGroups(candidates);
-		logAutoroute(QString("route net %1: netConnectors=%2 candidates=%3 groups=%4")
-						 .arg(i)
-						 .arg(net->count())
-						 .arg(candidates.count())
-						 .arg(groups.count()));
-		for (int groupIndex = 0; groupIndex < groups.count(); groupIndex++)
-		{
-			QStringList connectorLines;
-			QList<ConnectorItem *> group = groups.at(groupIndex);
-			for (int connectorIndex = 0; connectorIndex < group.count() && connectorIndex < 6; connectorIndex++)
-			{
-				connectorLines.append(connectorSummary(group.at(connectorIndex)));
-			}
-			logAutoroute(QString("route net %1 group %2 size=%3 sample=[%4]")
-							 .arg(i)
-							 .arg(groupIndex)
-							 .arg(group.count())
-							 .arg(connectorLines.join(" | ")));
+			difficultyForNet.insert(index, groupCount * 100000.0 + candidates.count() * 1000.0 + bounds.width() + bounds.height());
 		}
+		std::sort(routeOrder.begin(), routeOrder.end(), [&difficultyForNet](int firstIndex, int secondIndex) {
+			return difficultyForNet.value(firstIndex) > difficultyForNet.value(secondIndex);
+		});
+		return routeOrder;
+	}
 
-		QList<ConnectorItem *> breadboardAnchors;
-		QList<ConnectorItem *> offBoardTerminals;
-		Q_FOREACH (ConnectorItem *connectorItem, *net)
+	// Split the net's connectors into breadboard anchors (pins already in
+	// holes) and off-board peripheral terminals that need jumper leads.
+	void collectTerminals(const QList<ConnectorItem *> &net)
+	{
+		breadboardAnchors.clear();
+		offBoardTerminals.clear();
+		Q_FOREACH (ConnectorItem *connectorItem, net)
 		{
 			if (connectorItem == nullptr)
 				continue;
@@ -1420,10 +2392,10 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 				continue;
 			if (connectorItem->attachedToItemType() == ModelPart::Wire)
 				continue;
-			if (!isPlaceablePin(connectorItem) && connectorItem->connectorType() != Connector::Female)
+			if (!self->isPlaceablePin(connectorItem) && connectorItem->connectorType() != Connector::Female)
 				continue;
 
-			ConnectorItem *connectedHole = connectedBreadboardHoleFor(connectorItem);
+			ConnectorItem *connectedHole = self->connectedBreadboardHoleFor(connectorItem);
 			if (connectedHole != nullptr)
 			{
 				if (!breadboardAnchors.contains(connectedHole))
@@ -1431,242 +2403,260 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 				continue;
 			}
 
+			// Female sockets on peripheral parts (breakout headers) are
+			// legitimate jumper terminals; only breadboard holes are excluded
+			// (they became anchors above via connectedBreadboardHoleFor).
 			BreadboardPartPolicy::Decision policy = BreadboardPartPolicy::classify(itemBase->layerKinChief());
-			if (policy.classification == BreadboardPartPolicy::Classification::Peripheral && connectorItem->connectorType() != Connector::Female && !offBoardTerminals.contains(connectorItem))
+			if (policy.classification == BreadboardPartPolicy::Classification::Peripheral && !offBoardTerminals.contains(connectorItem))
 			{
 				offBoardTerminals.append(connectorItem);
-				logAutoroute(QString("route peripheral terminal: net=%1 terminal=%2 class=%3 reason=%4")
-								 .arg(i)
-								 .arg(connectorSummary(connectorItem))
-								 .arg(BreadboardPartPolicy::classificationName(policy.classification))
-								 .arg(policy.reason));
+				self->logAutoroute(QString("route peripheral terminal: net=%1 terminal=%2 class=%3 reason=%4")
+								   .arg(netIndex)
+								   .arg(self->connectorSummary(connectorItem))
+								   .arg(BreadboardPartPolicy::classificationName(policy.classification))
+								   .arg(policy.reason));
 			}
 			else if (policy.classification == BreadboardPartPolicy::Classification::BoardPlaceable && connectorItem->connectorType() != Connector::Female)
 			{
-				logAutoroute(QString("route skip board-placeable offboard terminal: net=%1 terminal=%2 reason=not a peripheral")
-								 .arg(i)
-								 .arg(connectorSummary(connectorItem)));
+				self->logAutoroute(QString("route skip board-placeable offboard terminal: net=%1 terminal=%2 reason=not a peripheral")
+								   .arg(netIndex)
+								   .arg(self->connectorSummary(connectorItem)));
 			}
 		}
+	}
 
-		if (breadboardAnchors.isEmpty() && offBoardTerminals.count() > 1)
+	// A net with NO board presence yet (all terminals off-board, e.g. a pot
+	// wired straight to a jack) gets a "lane": one board entry hole per
+	// terminal, chosen near the board edge facing it, plus graph routes
+	// joining those entries into one electrical group. All-or-nothing: the
+	// lane is only wired when every terminal found an entry and every entry
+	// pair found a route.
+	void wirePeripheralLane()
+	{
+		if (!breadboardAnchors.isEmpty() || offBoardTerminals.count() <= 1)
+			return;
+
+		QList<ConnectorItem *> terminalEntries;
+		QSet<ConnectorItem *> usedEntries;
+		QList<QLineF> entryLeadSegments = plannedSegments;
+		bool entriesReady = true;
+
+		Q_FOREACH (ConnectorItem *terminal, offBoardTerminals)
 		{
-			QList<ConnectorItem *> terminalEntries;
-			QSet<ConnectorItem *> usedEntries;
-			QList<QLineF> entryLeadSegments = plannedSegments;
-			bool entriesReady = true;
-
-			Q_FOREACH (ConnectorItem *terminal, offBoardTerminals)
+			ConnectorItem *bestEntry = nullptr;
+			double bestEntryScore = std::numeric_limits<double>::max();
+			Q_FOREACH (ConnectorItem *entry, routeHoles)
 			{
-				ConnectorItem *bestEntry = nullptr;
-				double bestEntryScore = std::numeric_limits<double>::max();
-				Q_FOREACH (ConnectorItem *entry, routeHoles)
+				if (entry == nullptr || reservedHoles.contains(entry) || usedEntries.contains(entry))
+					continue;
+				if (entry->connectionsCount() > 0)
+					continue;
+				if (!self->busAvailableFor(self->busGroupFor(entry), netIndex))
+					continue;
+				const double score = boardEdgeEntryScore(terminal, entry, holeBounds)
+				                   + leadCongestionPenalty(terminal, entry, entryLeadSegments);
+				if (score < bestEntryScore)
 				{
-					if (entry == nullptr || routeReservedHoles.contains(entry) || usedEntries.contains(entry))
+					bestEntry = entry;
+					bestEntryScore = score;
+				}
+			}
+			if (bestEntry == nullptr)
+			{
+				entriesReady = false;
+				failedNetIndices.insert(netIndex);
+				self->logAutoroute(QString("route peripheral entry skipped: net=%1 terminal=%2 no free edge entry")
+								   .arg(netIndex)
+								   .arg(self->connectorSummary(terminal)));
+				break;
+			}
+			terminalEntries.append(bestEntry);
+			usedEntries.insert(bestEntry);
+			entryLeadSegments.append(connectorLine(terminal, bestEntry));
+			self->logAutoroute(QString("route peripheral entry: net=%1 terminal=%2 entry=%3 score=%4")
+							   .arg(netIndex)
+							   .arg(self->connectorSummary(terminal))
+							   .arg(self->connectorSummary(bestEntry))
+							   .arg(bestEntryScore));
+		}
+
+		QList<BreadboardRouteGraph::Result> entryRoutes;
+		if (entriesReady)
+		{
+			QSet<ConnectorItem *> temporaryReserved = reservedHoles;
+			QList<QLineF> entryPlanningSegments = plannedSegments;
+			Q_FOREACH (ConnectorItem *entry, terminalEntries)
+			{
+				temporaryReserved.insert(entry);
+			}
+
+			QList<ConnectorItem *> connectedEntries;
+			if (!terminalEntries.isEmpty())
+				connectedEntries.append(terminalEntries.first());
+
+			for (int targetIndex = 1; targetIndex < terminalEntries.count(); targetIndex++)
+			{
+				ConnectorItem *targetEntry = terminalEntries.at(targetIndex);
+				BreadboardRouteGraph::Result bestRoute;
+				const BreadboardRouteGraphCore::QueryContext entryContext = session.prepare(temporaryReserved, entryPlanningSegments, netIndex);
+				Q_FOREACH (ConnectorItem *connectedEntry, connectedEntries)
+				{
+					BreadboardRouteGraph::Result route = session.route(connectedEntry, targetEntry, entryContext);
+					if (!route.found)
 						continue;
-					if (entry->connectionsCount() > 0)
-						continue;
-					const double score = boardEdgeEntryScore(terminal, entry, routeHoleBounds)
-					                   + leadCongestionPenalty(terminal, entry, entryLeadSegments);
-					if (score < bestEntryScore)
+					if (routeIsBetter(route, bestRoute))
 					{
-						bestEntry = entry;
-						bestEntryScore = score;
+						bestRoute = route;
 					}
 				}
-				if (bestEntry == nullptr)
+				if (!bestRoute.found)
 				{
 					entriesReady = false;
-					failedNetIndices.insert(i);
-					logAutoroute(QString("route peripheral entry skipped: net=%1 terminal=%2 no free edge entry")
-									 .arg(i)
-									 .arg(connectorSummary(terminal)));
+					failedNetIndices.insert(netIndex);
+					self->logAutoroute(QString("route peripheral entries skipped: net=%1 entry=%2 no graph route")
+									   .arg(netIndex)
+									   .arg(self->connectorSummary(targetEntry)));
 					break;
 				}
-				terminalEntries.append(bestEntry);
-				usedEntries.insert(bestEntry);
-				entryLeadSegments.append(connectorLine(terminal, bestEntry));
-				logAutoroute(QString("route peripheral entry: net=%1 terminal=%2 entry=%3 score=%4")
-								 .arg(i)
-								 .arg(connectorSummary(terminal))
-								 .arg(connectorSummary(bestEntry))
-								 .arg(bestEntryScore));
-			}
-
-			QList<BreadboardRouteGraph::Result> entryRoutes;
-			if (entriesReady)
-			{
-				QSet<ConnectorItem *> temporaryReserved = routeReservedHoles;
-				QList<QLineF> entryPlanningSegments = plannedSegments;
-				Q_FOREACH (ConnectorItem *entry, terminalEntries)
-				{
-					temporaryReserved.insert(entry);
+				entryRoutes.append(bestRoute);
+				Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments) {
+					entryPlanningSegments.append(connectorLine(segment.from, segment.to));
+					temporaryReserved.insert(segment.from);
+					temporaryReserved.insert(segment.to);
 				}
-
-				QList<ConnectorItem *> connectedEntries;
-				if (!terminalEntries.isEmpty())
-					connectedEntries.append(terminalEntries.first());
-
-				for (int targetIndex = 1; targetIndex < terminalEntries.count(); targetIndex++)
-				{
-					ConnectorItem *targetEntry = terminalEntries.at(targetIndex);
-					BreadboardRouteGraph::Result bestRoute;
-					BreadboardRouteGraph routeGraph(routeHoles, temporaryReserved, routeGraphOptions(entryPlanningSegments));
-					Q_FOREACH (ConnectorItem *connectedEntry, connectedEntries)
-					{
-						BreadboardRouteGraph::Result route = routeGraph.route(connectedEntry, targetEntry);
-						if (!route.found)
-							continue;
-						if (routeIsBetter(route, bestRoute))
-						{
-							bestRoute = route;
-						}
-					}
-					if (!bestRoute.found)
-					{
-						entriesReady = false;
-						failedNetIndices.insert(i);
-						logAutoroute(QString("route peripheral entries skipped: net=%1 entry=%2 no graph route")
-										 .arg(i)
-										 .arg(connectorSummary(targetEntry)));
-						break;
-					}
-					entryRoutes.append(bestRoute);
-					Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments) {
-						entryPlanningSegments.append(connectorLine(segment.from, segment.to));
-						temporaryReserved.insert(segment.from);
-						temporaryReserved.insert(segment.to);
-					}
-					connectedEntries.append(targetEntry);
-				}
-			}
-
-			if (entriesReady && terminalEntries.count() == offBoardTerminals.count())
-			{
-				allocatedPeripheralLanes++;
-				logAutoroute(QString("route peripheral entries: net=%1 terminals=%2 routes=%3")
-								 .arg(i)
-								 .arg(offBoardTerminals.count())
-								 .arg(entryRoutes.count()));
-				for (int terminalIndex = 0; terminalIndex < offBoardTerminals.count(); terminalIndex++)
-				{
-					ConnectorItem *terminal = offBoardTerminals.at(terminalIndex);
-					ConnectorItem *target = terminalEntries.at(terminalIndex);
-					if (terminal == nullptr || target == nullptr)
-						continue;
-					m_sketchWidget->createWire(terminal, target, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
-					plannedSegments.append(connectorLine(terminal, target));
-					routeReservedHoles.insert(target);
-					created++;
-					wiredPeripheral++;
-				}
-				Q_FOREACH (const BreadboardRouteGraph::Result &route, entryRoutes)
-				{
-					Q_FOREACH (const BreadboardRouteGraph::Segment &segment, route.segments)
-					{
-						if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
-							continue;
-						m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
-						plannedSegments.append(connectorLine(segment.from, segment.to));
-						routeReservedHoles.insert(segment.from);
-						routeReservedHoles.insert(segment.to);
-						created++;
-					}
-				}
-				breadboardAnchors.append(terminalEntries.first());
-				offBoardTerminals.clear();
+				connectedEntries.append(targetEntry);
 			}
 		}
 
-		if (!breadboardAnchors.isEmpty() && !offBoardTerminals.isEmpty())
+		if (entriesReady && terminalEntries.count() == offBoardTerminals.count())
 		{
-			QSet<ConnectorItem *> usedBridgeTargets;
-			Q_FOREACH (ConnectorItem *terminal, offBoardTerminals)
+			allocatedPeripheralLanes++;
+			self->logAutoroute(QString("route peripheral entries: net=%1 terminals=%2 routes=%3")
+							   .arg(netIndex)
+							   .arg(offBoardTerminals.count())
+							   .arg(entryRoutes.count()));
+			for (int terminalIndex = 0; terminalIndex < offBoardTerminals.count(); terminalIndex++)
 			{
-				ConnectorItem *bestAnchor = nullptr;
-				ConnectorItem *bestEntry = nullptr;
-				BreadboardRouteGraph::Result bestRoute;
-				BreadboardRoutingScore bestBridgeScore;
-				bool haveBridgeScore = false;
-				BreadboardRouteGraph routeGraph(routeHoles, routeReservedHoles, routeGraphOptions(plannedSegments));
-
-				Q_FOREACH (ConnectorItem *entry, routeHoles)
-				{
-					if (entry == nullptr || routeReservedHoles.contains(entry) || usedBridgeTargets.contains(entry))
-						continue;
-					if (entry->connectionsCount() > 0)
-						continue;
-					const double entryScore = boardEdgeEntryScore(terminal, entry, routeHoleBounds)
-					                        + leadCongestionPenalty(terminal, entry, plannedSegments);
-					if (entryScore == std::numeric_limits<double>::max())
-						continue;
-
-					Q_FOREACH (ConnectorItem *anchor, breadboardAnchors)
-					{
-						if (anchor == nullptr)
-							continue;
-						BreadboardRouteGraph::Result route = routeGraph.route(entry, anchor);
-						if (!route.found)
-							continue;
-
-						BreadboardRoutingScore score = route.score;
-						score.jumperCount++;
-						score.jumperLength += connectorLine(terminal, entry).length();
-						score.congestion += entryScore;
-						if (!haveBridgeScore || score < bestBridgeScore)
-						{
-							bestAnchor = anchor;
-							bestEntry = entry;
-							bestRoute = route;
-							bestBridgeScore = score;
-							haveBridgeScore = true;
-						}
-					}
-				}
-
-				if (bestEntry == nullptr || !bestRoute.found)
-				{
-					failedNetIndices.insert(i);
-					logAutoroute(QString("route bridge skipped: net=%1 terminal=%2 no breadboard target")
-									 .arg(i)
-									 .arg(connectorSummary(terminal)));
+				ConnectorItem *terminal = offBoardTerminals.at(terminalIndex);
+				ConnectorItem *target = terminalEntries.at(terminalIndex);
+				if (terminal == nullptr || target == nullptr)
 					continue;
-				}
-
-				logAutoroute(QString("route bridge: net=%1 terminal=%2 anchor=%3 entry=%4 segments=%5 score=%6")
-								 .arg(i)
-								 .arg(connectorSummary(terminal))
-								 .arg(connectorSummary(bestAnchor))
-								 .arg(connectorSummary(bestEntry))
-								 .arg(bestRoute.segments.count())
-							 .arg(bestBridgeScore.toString()));
-				m_sketchWidget->createWire(terminal, bestEntry, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
-				plannedSegments.append(connectorLine(terminal, bestEntry));
-				usedBridgeTargets.insert(bestEntry);
-				routeReservedHoles.insert(bestEntry);
-				created++;
-				wiredPeripheral++;
-
-				Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments)
+				addPeripheralLead(terminal, target);
+			}
+			Q_FOREACH (const BreadboardRouteGraph::Result &route, entryRoutes)
+			{
+				Q_FOREACH (const BreadboardRouteGraph::Segment &segment, route.segments)
 				{
 					if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
 						continue;
-					m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
-					plannedSegments.append(connectorLine(segment.from, segment.to));
-					routeReservedHoles.insert(segment.from);
-					routeReservedHoles.insert(segment.to);
-					logAutoroute(QString("route bridge graph wire: net=%1 from=%2 to=%3 cost=%4")
-									 .arg(i)
-									 .arg(connectorSummary(segment.from))
-									 .arg(connectorSummary(segment.to))
-									 .arg(segment.cost));
-					created++;
+					addGraphWire(segment);
 				}
 			}
+			breadboardAnchors.append(terminalEntries.first());
+			offBoardTerminals.clear();
 		}
+	}
 
+	// Bridge each remaining off-board terminal to the net's existing board
+	// presence: pick the (entry hole, anchor) pair with the best combined
+	// lead + graph-route score, wire the lead, then wire the route.
+	void bridgeTerminalsToAnchors()
+	{
+		if (breadboardAnchors.isEmpty() || offBoardTerminals.isEmpty())
+			return;
+
+		QSet<ConnectorItem *> usedBridgeTargets;
+		Q_FOREACH (ConnectorItem *terminal, offBoardTerminals)
+		{
+			ConnectorItem *bestAnchor = nullptr;
+			ConnectorItem *bestEntry = nullptr;
+			BreadboardRouteGraph::Result bestRoute;
+			BreadboardRoutingScore bestBridgeScore;
+			bool haveBridgeScore = false;
+			const BreadboardRouteGraphCore::QueryContext bridgeContext = session.prepare(reservedHoles, plannedSegments, netIndex);
+			// One Dijkstra per anchor; each of the ~holes entries below is
+			// then a constant-time extract instead of its own search.
+			QList<BreadboardRouteGraphCore::MultiResult> anchorRoutes;
+			Q_FOREACH (ConnectorItem *anchor, breadboardAnchors)
+				anchorRoutes.append(session.routeFrom(anchor, bridgeContext));
+
+			Q_FOREACH (ConnectorItem *entry, routeHoles)
+			{
+				if (entry == nullptr || reservedHoles.contains(entry) || usedBridgeTargets.contains(entry))
+					continue;
+				if (entry->connectionsCount() > 0)
+					continue;
+				if (!self->busAvailableFor(self->busGroupFor(entry), netIndex))
+					continue;
+				const double entryScore = boardEdgeEntryScore(terminal, entry, holeBounds)
+				                        + leadCongestionPenalty(terminal, entry, plannedSegments);
+				if (entryScore == std::numeric_limits<double>::max())
+					continue;
+
+				for (int anchorIndex = 0; anchorIndex < breadboardAnchors.count(); anchorIndex++)
+				{
+					ConnectorItem *anchor = breadboardAnchors.at(anchorIndex);
+					if (anchor == nullptr)
+						continue;
+					BreadboardRouteGraph::Result route = session.extract(anchorRoutes.at(anchorIndex), entry);
+					if (!route.found)
+						continue;
+
+					BreadboardRoutingScore score = route.score;
+					score.jumperCount++;
+					score.jumperLength += connectorLine(terminal, entry).length();
+					score.congestion += entryScore;
+					if (!haveBridgeScore || score < bestBridgeScore)
+					{
+						bestAnchor = anchor;
+						bestEntry = entry;
+						bestRoute = route;
+						bestBridgeScore = score;
+						haveBridgeScore = true;
+					}
+				}
+			}
+
+			if (bestEntry == nullptr || !bestRoute.found)
+			{
+				failedNetIndices.insert(netIndex);
+				self->logAutoroute(QString("route bridge skipped: net=%1 terminal=%2 no breadboard target")
+								   .arg(netIndex)
+								   .arg(self->connectorSummary(terminal)));
+				continue;
+			}
+
+			self->logAutoroute(QString("route bridge: net=%1 terminal=%2 anchor=%3 entry=%4 segments=%5 score=%6")
+							   .arg(netIndex)
+							   .arg(self->connectorSummary(terminal))
+							   .arg(self->connectorSummary(bestAnchor))
+							   .arg(self->connectorSummary(bestEntry))
+							   .arg(bestRoute.segments.count())
+							   .arg(bestBridgeScore.toString()));
+			addPeripheralLead(terminal, bestEntry);
+			usedBridgeTargets.insert(bestEntry);
+
+			Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments)
+			{
+				if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
+					continue;
+				addGraphWire(segment);
+				self->logAutoroute(QString("route bridge graph wire: net=%1 from=%2 to=%3 cost=%4")
+								   .arg(netIndex)
+								   .arg(self->connectorSummary(segment.from))
+								   .arg(self->connectorSummary(segment.to))
+								   .arg(segment.cost));
+			}
+		}
+	}
+
+	// Merge the net's electrically separate groups with graph-routed
+	// jumpers, always joining the cheapest available pair first, until one
+	// group remains or no legal route exists.
+	void mergeSubnetGroups()
+	{
 		if (groups.count() < 2)
-			continue;
+			return;
 
 		while (groups.count() > 1)
 		{
@@ -1676,7 +2666,7 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 			BreadboardRoutingScore bestRoutingScore;
 			double bestTieBreak = std::numeric_limits<double>::max();
 			bool haveBestScore = false;
-			BreadboardRouteGraph routeGraph(routeHoles, routeReservedHoles, routeGraphOptions(plannedSegments));
+			const BreadboardRouteGraphCore::QueryContext mergeContext = session.prepare(reservedHoles, plannedSegments, netIndex);
 
 			for (int fromSubnet = 0; fromSubnet < groups.count(); fromSubnet++)
 			{
@@ -1696,10 +2686,10 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 						{
 							if (fromCandidate == nullptr || toCandidate == nullptr || fromCandidate == toCandidate)
 								continue;
-							BreadboardRouteGraph::Result route = routeGraph.route(fromCandidate, toCandidate);
+							BreadboardRouteGraph::Result route = session.route(fromCandidate, toCandidate, mergeContext);
 							if (!route.found)
 								continue;
-							const double tieBreak = routeScore(fromCandidate, toCandidate);
+							const double tieBreak = self->routeScore(fromCandidate, toCandidate);
 							if (!haveBestScore || route.score < bestRoutingScore
 							    || (route.score == bestRoutingScore && tieBreak < bestTieBreak))
 							{
@@ -1717,35 +2707,31 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 
 			if (!bestRoute.found)
 			{
-				failedNetIndices.insert(i);
-				logAutoroute(QString("route graph failed: net=%1 groups=%2 buses=%3 edges=%4")
-								 .arg(i)
-								 .arg(groups.count())
-								 .arg(routeGraph.busCount())
-								 .arg(routeGraph.edgeCount()));
-				break;
+				failedNetIndices.insert(netIndex);
+				self->logAutoroute(QString("route graph failed: net=%1 groups=%2 buses=%3 edges=%4")
+								   .arg(netIndex)
+								   .arg(groups.count())
+								   .arg(session.core->busCount())
+								   .arg(session.core->edgeCount()));
+				return;
 			}
 
-			logAutoroute(QString("route choose: net=%1 fromGroup=%2 toGroup=%3 segments=%4 score=%5")
-							 .arg(i)
-							 .arg(bestFromSubnet)
-							 .arg(bestToSubnet)
-							 .arg(bestRoute.segments.count())
-							 .arg(bestRoutingScore.toString()));
+			self->logAutoroute(QString("route choose: net=%1 fromGroup=%2 toGroup=%3 segments=%4 score=%5")
+							   .arg(netIndex)
+							   .arg(bestFromSubnet)
+							   .arg(bestToSubnet)
+							   .arg(bestRoute.segments.count())
+							   .arg(bestRoutingScore.toString()));
 			Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments)
 			{
 				if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
 					continue;
-				m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
-				plannedSegments.append(connectorLine(segment.from, segment.to));
-				routeReservedHoles.insert(segment.from);
-				routeReservedHoles.insert(segment.to);
-				logAutoroute(QString("route graph wire: net=%1 from=%2 to=%3 cost=%4")
-								 .arg(i)
-								 .arg(connectorSummary(segment.from))
-								 .arg(connectorSummary(segment.to))
-								 .arg(segment.cost));
-				created++;
+				addGraphWire(segment);
+				self->logAutoroute(QString("route graph wire: net=%1 from=%2 to=%3 cost=%4")
+								   .arg(netIndex)
+								   .arg(self->connectorSummary(segment.from))
+								   .arg(self->connectorSummary(segment.to))
+								   .arg(segment.cost));
 			}
 
 			groups[bestFromSubnet].append(groups.at(bestToSubnet));
@@ -1753,50 +2739,154 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 		}
 	}
 
-	double jumperLength = 0.0;
-	Q_FOREACH (const QLineF &segment, plannedSegments) jumperLength += segment.length();
-	m_lastRoutingScore.failedNets = failedNetIndices.count();
-	m_lastRoutingScore.jumperCount = created;
-	m_lastRoutingScore.jumperLength = jumperLength;
-	m_lastRoutingScore.componentLeadLength = m_componentLeadLength;
-	logAutoroute(QString("route counters: wiredPeripheral=%1 allocatedPeripheralLanes=%2 failedNets=%3")
-				 .arg(wiredPeripheral)
-				 .arg(allocatedPeripheralLanes)
-				 .arg(failedNetIndices.count()));
-	return created;
+	// Route one net: log its electrical groups, split terminals into
+	// anchors and off-board peripherals, then run the three wiring phases.
+	void routeNet(int index, QList<ConnectorItem *> *net)
+	{
+		netIndex = index;
+		const QList<ConnectorItem *> candidates = self->routingCandidatesForSubnet(*net);
+		groups = self->collectCandidateGroups(candidates);
+		self->logAutoroute(QString("route net %1: netConnectors=%2 candidates=%3 groups=%4")
+						   .arg(netIndex)
+						   .arg(net->count())
+						   .arg(candidates.count())
+						   .arg(groups.count()));
+		for (int groupIndex = 0; groupIndex < groups.count(); groupIndex++)
+		{
+			QStringList connectorLines;
+			const QList<ConnectorItem *> group = groups.at(groupIndex);
+			for (int connectorIndex = 0; connectorIndex < group.count() && connectorIndex < 6; connectorIndex++)
+				connectorLines.append(self->connectorSummary(group.at(connectorIndex)));
+			self->logAutoroute(QString("route net %1 group %2 size=%3 sample=[%4]")
+							   .arg(netIndex)
+							   .arg(groupIndex)
+							   .arg(group.count())
+							   .arg(connectorLines.join(" | ")));
+		}
+
+		collectTerminals(*net);
+		wirePeripheralLane();
+		bridgeTerminalsToAnchors();
+		mergeSubnetGroups();
+	}
+
+	// Fill in the run's score and counters once every net is done.
+	void finish()
+	{
+		double jumperLength = 0.0;
+		Q_FOREACH (const QLineF &segment, plannedSegments) jumperLength += segment.length();
+		jumperLength = qMax(0.0, jumperLength - peripheralLeadLength);
+		self->m_lastRoutingScore.failedNets = failedNetIndices.count();
+		self->m_lastRoutingScore.jumperCount = created - wiredPeripheral;
+		self->m_lastRoutingScore.jumperLength = jumperLength;
+		self->m_lastRoutingScore.componentLeadLength = self->m_componentLeadLength;
+		self->logAutoroute(QString("route counters: totalWires=%1 boardJumpers=%2 wiredPeripheral=%3 peripheralLeadLength=%4 allocatedPeripheralLanes=%5 failedNets=%6")
+						   .arg(created)
+						   .arg(created - wiredPeripheral)
+						   .arg(wiredPeripheral)
+						   .arg(peripheralLeadLength)
+						   .arg(allocatedPeripheralLanes)
+						   .arg(failedNetIndices.count()));
+	}
+};
+
+int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
+{
+	NetRoutingPass pass(this, parentCommand);
+
+	const QList<int> routeOrder = pass.netOrderMostConstrainedFirst();
+	QStringList routeOrderText;
+	Q_FOREACH (int netIndex, routeOrder) routeOrderText.append(QString::number(netIndex));
+	logAutoroute(QString("route order (most constrained first): %1").arg(routeOrderText.join(",")));
+
+	for (int orderIndex = 0; orderIndex < routeOrder.count(); orderIndex++)
+	{
+		reportProgress(PlacementProgressSpan
+						   + ((RoutingProgressEnd - PlacementProgressSpan) * orderIndex) / qMax(1, routeOrder.count()),
+					   QObject::tr("Routing net %1 of %2...").arg(orderIndex + 1).arg(routeOrder.count()));
+		const int netIndex = routeOrder.at(orderIndex);
+		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
+		if (net == nullptr)
+			continue;
+		pass.routeNet(netIndex, net);
+	}
+
+	pass.finish();
+	return pass.created;
 }
 
 QList<QList<ConnectorItem *>> BreadboardAutorouter::collectCandidateGroups(const QList<ConnectorItem *> &candidates) const
 {
-	QList<QList<ConnectorItem *>> groups;
-	QList<ConnectorItem *> todo = candidates;
-
-	while (!todo.isEmpty())
+	QList<ConnectorItem *> validCandidates;
+	Q_FOREACH (ConnectorItem *candidate, candidates)
 	{
-		ConnectorItem *first = todo.takeFirst();
-		if (first == nullptr)
-			continue;
-
-		QList<ConnectorItem *> equalPotential;
-		equalPotential.append(first);
-		ConnectorItem::collectEqualPotential(equalPotential, false, ViewGeometry::RatsnestFlag);
-
-		QList<ConnectorItem *> group;
-		Q_FOREACH (ConnectorItem *candidate, candidates)
-		{
-			if (candidate == nullptr)
-				continue;
-			if (!equalPotential.contains(candidate))
-				continue;
-			if (!group.contains(candidate))
-				group.append(candidate);
-			todo.removeOne(candidate);
-		}
-
-		if (!group.isEmpty())
-			groups.append(group);
+		if (candidate != nullptr && !validCandidates.contains(candidate))
+			validCandidates.append(candidate);
 	}
 
+	QVector<int> parents(validCandidates.count());
+	for (int i = 0; i < parents.count(); i++) parents[i] = i;
+	auto findRoot = [&parents](int value) {
+		int root = value;
+		while (parents[root] != root) root = parents[root];
+		while (parents[value] != value) {
+			const int next = parents[value];
+			parents[value] = root;
+			value = next;
+		}
+		return root;
+	};
+	auto unite = [&parents, &findRoot](int first, int second) {
+		const int firstRoot = findRoot(first);
+		const int secondRoot = findRoot(second);
+		if (firstRoot != secondRoot) parents[secondRoot] = firstRoot;
+	};
+
+	// Breadboard connectivity is deliberately narrower than Fritzing's global
+	// equal-potential graph. A ratsnest describes intent, not copper. Only a
+	// discovered breadboard bus or a real Breadboard View wire joins groups.
+	for (int first = 0; first < validCandidates.count(); first++)
+	{
+		for (int second = first + 1; second < validCandidates.count(); second++)
+		{
+			if (connectorsShareBreadboardBus(validCandidates.at(first), validCandidates.at(second)))
+				unite(first, second);
+		}
+	}
+
+	using WireEnds = QPair<ConnectorItem *, ConnectorItem *>;
+	Q_FOREACH (const WireEnds &wireEnds, normalBreadboardWireEnds())
+	{
+		ConnectorItem *from = wireEnds.first;
+		ConnectorItem *to = wireEnds.second;
+
+		for (int first = 0; first < validCandidates.count(); first++)
+		{
+			if (!connectorsShareBreadboardBus(validCandidates.at(first), from))
+				continue;
+			for (int second = 0; second < validCandidates.count(); second++)
+			{
+				if (connectorsShareBreadboardBus(validCandidates.at(second), to))
+					unite(first, second);
+			}
+		}
+	}
+
+	// Emit groups ordered by first-member appearance (not QHash::values(),
+	// whose order follows the per-process hash seed): with the candidate
+	// list deterministic, group order - and so routing order - is too.
+	QList<QList<ConnectorItem *>> groups;
+	QHash<int, int> groupIndexByRoot;
+	for (int i = 0; i < validCandidates.count(); i++)
+	{
+		const int root = findRoot(i);
+		if (!groupIndexByRoot.contains(root))
+		{
+			groupIndexByRoot.insert(root, groups.count());
+			groups.append(QList<ConnectorItem *>());
+		}
+		groups[groupIndexByRoot.value(root)].append(validCandidates.at(i));
+	}
 	return groups;
 }
 
@@ -1849,7 +2939,266 @@ bool BreadboardAutorouter::isTargetBreadboardHole(ConnectorItem *connectorItem) 
 
 bool BreadboardAutorouter::connectorsShareBreadboardBus(ConnectorItem *first, ConnectorItem *second) const
 {
-	return BreadboardTopology::connectorsShareBus(first, second);
+	if (first == nullptr || second == nullptr)
+		return false;
+	if (first == second)
+		return true;
+	return busGroupFor(first) == busGroupFor(second);
+}
+
+int BreadboardAutorouter::busGroupFor(ConnectorItem *connectorItem) const
+{
+	auto found = m_busGroupForConnector.constFind(connectorItem);
+	if (found != m_busGroupForConnector.constEnd())
+		return found.value();
+
+	const int groupId = m_busGroupCount++;
+	m_busGroupForConnector.insert(connectorItem, groupId);
+	ItemBase *item = connectorItem->attachedTo();
+	QList<ConnectorItem *> busSiblings;
+	if (item != nullptr && item->busConnectorItems(connectorItem, busSiblings))
+	{
+		Q_FOREACH (ConnectorItem *sibling, busSiblings)
+		{
+			if (sibling != nullptr && !m_busGroupForConnector.contains(sibling))
+				m_busGroupForConnector.insert(sibling, groupId);
+		}
+	}
+	return groupId;
+}
+
+const QList<QPair<ConnectorItem *, ConnectorItem *> > &BreadboardAutorouter::normalBreadboardWireEnds() const
+{
+	if (m_wireEndsCacheValid)
+		return m_normalBreadboardWireEnds;
+
+	m_normalBreadboardWireEnds.clear();
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *wire = dynamic_cast<Wire *>(graphicsItem);
+		if (wire == nullptr || wire->getRatsnest() || !wire->getNormal())
+			continue;
+		if (wire->viewID() != ViewLayer::BreadboardView)
+			continue;
+
+		ConnectorItem *from = routingConnectorFor(wire->connector0());
+		ConnectorItem *to = routingConnectorFor(wire->connector1());
+		if (from == nullptr || to == nullptr)
+			continue;
+		m_normalBreadboardWireEnds.append(qMakePair(from, to));
+	}
+	m_wireEndsCacheValid = true;
+	return m_normalBreadboardWireEnds;
+}
+
+int BreadboardAutorouter::busOwner(int busGroup) const
+{
+	return m_busOwnerForGroup.value(busGroup, -1);
+}
+
+bool BreadboardAutorouter::busAvailableFor(int busGroup, int ownerKey) const
+{
+	const int owner = busOwner(busGroup);
+	return owner == -1 || owner == ownerKey;
+}
+
+void BreadboardAutorouter::claimBus(int busGroup, int ownerKey)
+{
+	if (!m_busOwnerForGroup.contains(busGroup))
+		m_busOwnerForGroup.insert(busGroup, ownerKey);
+}
+
+int BreadboardAutorouter::makeNoNetOwnerKey()
+{
+	return m_nextNoNetOwnerKey--;
+}
+
+int BreadboardAutorouter::ownerKeyForPin(ConnectorItem *pin) const
+{
+	// Netted pins share their net's key; a no-net pin gets no shared key
+	// here - callers claim with a fresh sentinel so nothing may join it.
+	return m_netForConnector.value(pin, INT_MIN);
+}
+
+void BreadboardAutorouter::seedBusOwnership()
+{
+	m_busOwnerForGroup.clear();
+	m_nextNoNetOwnerKey = -2;
+	m_netForConnector.clear();
+	for (int netIndex = 0; netIndex < m_allPartConnectorItems.count(); netIndex++)
+	{
+		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
+		if (net == nullptr)
+			continue;
+		Q_FOREACH (ConnectorItem *connectorItem, *net)
+		{
+			if (connectorItem == nullptr)
+				continue;
+			m_netForConnector.insert(connectorItem, netIndex);
+			// Only a real male PART pin actually plugged into a hole claims a
+			// bus at seed time. Female connectors are breadboard holes/sockets
+			// (they are net members but occupy nothing themselves), and
+			// connectedBreadboardHoleFor returns a female pin as itself - which
+			// would wrongly claim every hosting bus before placement even runs.
+			if (connectorItem->connectorType() == Connector::Female)
+				continue;
+			if (connectorItem->attachedToItemType() == ModelPart::Wire)
+				continue;
+			ConnectorItem *hole = connectedBreadboardHoleFor(connectorItem);
+			if (hole == nullptr || hole->connectorType() != Connector::Female)
+				continue;
+			const int busGroup = busGroupFor(hole);
+			const int owner = busOwner(busGroup);
+			if (owner == -1)
+				claimBus(busGroup, netIndex);
+			else if (owner != netIndex)
+				logAutoroute(QString("bus ownership seed conflict (pre-existing): bus=%1 owner=net%2 also touched by net%3 pin=%4")
+								 .arg(busGroup)
+								 .arg(owner)
+								 .arg(netIndex)
+								 .arg(connectorSummary(connectorItem)));
+		}
+	}
+
+	// Pins with no net already sitting in holes (pre-placed parts) claim
+	// their buses exclusively.
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *connectorItem = dynamic_cast<ConnectorItem *>(graphicsItem);
+		if (connectorItem == nullptr || connectorItem->attachedTo() == nullptr)
+			continue;
+		if (connectorItem->attachedTo()->getRatsnest() || !connectorItem->attachedTo()->isEverVisible())
+			continue;
+		if (connectorItem->connectorType() == Connector::Female)
+			continue;
+		if (connectorItem->attachedToItemType() == ModelPart::Wire)
+			continue;
+		if (m_netForConnector.contains(connectorItem))
+			continue;
+		ConnectorItem *hole = connectedBreadboardHoleFor(connectorItem);
+		if (hole == nullptr)
+			continue;
+		const int busGroup = busGroupFor(hole);
+		if (busOwner(busGroup) == -1)
+			claimBus(busGroup, makeNoNetOwnerKey());
+	}
+	logAutoroute(QString("bus ownership seeded: ownedBuses=%1 nettedPins=%2").arg(m_busOwnerForGroup.count()).arg(m_netForConnector.count()));
+}
+
+bool BreadboardAutorouter::verifySchematicConformance(QStringList &violations, bool recordBaseline)
+{
+	// Independent short detector, breadboard-view only. Union bus groups
+	// that are joined by real breadboard wires, then assert no resulting
+	// component carries pins from two different owners (schematic nets, or a
+	// no-net pin such as an unused DIP output). Deliberately does NOT walk
+	// cross-layer, so it can never mistake the schematic netlist itself for
+	// a short. Pre-existing owner contacts are exempt.
+
+	// Owner key per part pin: its schematic net index, or a unique negative
+	// id for a no-net pin (each no-net pin is its own singleton owner - it
+	// must never share a component with any other owner). Only real MALE
+	// part pins count: m_netForConnector also holds female breadboard holes
+	// (net members that occupy nothing), which would produce phantom shorts.
+	QHash<ConnectorItem *, int> ownerForPin;
+	for (auto it = m_netForConnector.constBegin(); it != m_netForConnector.constEnd(); ++it)
+	{
+		ConnectorItem *pin = it.key();
+		if (pin == nullptr || pin->connectorType() == Connector::Female)
+			continue;
+		if (pin->attachedToItemType() == ModelPart::Wire)
+			continue;
+		ownerForPin.insert(pin, it.value());
+	}
+	int nextNoNetId = -2;
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *pin = dynamic_cast<ConnectorItem *>(graphicsItem);
+		if (pin == nullptr || pin->attachedTo() == nullptr)
+			continue;
+		if (pin->attachedTo()->getRatsnest() || !pin->attachedTo()->isEverVisible())
+			continue;
+		if (pin->connectorType() == Connector::Female || pin->attachedToItemType() == ModelPart::Wire)
+			continue;
+		if (ownerForPin.contains(pin))
+			continue;
+		if (connectedBreadboardHoleFor(pin) != nullptr)
+			ownerForPin.insert(pin, nextNoNetId--);
+	}
+
+	// Union-find over bus groups.
+	QHash<int, int> parent;
+	std::function<int(int)> findRoot = [&](int value) {
+		int root = value;
+		while (parent.value(root, root) != root) root = parent.value(root, root);
+		while (parent.value(value, value) != value) {
+			const int next = parent.value(value, value);
+			parent[value] = root;
+			value = next;
+		}
+		return root;
+	};
+	auto unite = [&](int first, int second) {
+		const int firstRoot = findRoot(first);
+		const int secondRoot = findRoot(second);
+		if (firstRoot != secondRoot) parent[firstRoot] = secondRoot;
+	};
+
+	// Join buses connected by breadboard wires. Component bodies are NOT
+	// wires, so intended part-to-part netlist connections are not unioned -
+	// only breadboard copper is.
+	using WireEnds = QPair<ConnectorItem *, ConnectorItem *>;
+	Q_FOREACH (const WireEnds &ends, normalBreadboardWireEnds())
+	{
+		ConnectorItem *fromHole = connectedBreadboardHoleFor(ends.first);
+		ConnectorItem *toHole = connectedBreadboardHoleFor(ends.second);
+		if (fromHole == nullptr || toHole == nullptr)
+			continue;
+		unite(busGroupFor(fromHole), busGroupFor(toHole));
+	}
+
+	// Collect the distinct owners on each component.
+	QHash<int, QList<QPair<int, ConnectorItem *> > > ownersByComponent;
+	for (auto it = ownerForPin.constBegin(); it != ownerForPin.constEnd(); ++it)
+	{
+		ConnectorItem *hole = connectedBreadboardHoleFor(it.key());
+		if (hole == nullptr)
+			continue;
+		ownersByComponent[findRoot(busGroupFor(hole))].append(qMakePair(it.value(), it.key()));
+	}
+
+	for (auto it = ownersByComponent.constBegin(); it != ownersByComponent.constEnd(); ++it)
+	{
+		const QList<QPair<int, ConnectorItem *> > &pins = it.value();
+		for (int a = 0; a < pins.count(); a++)
+		{
+			for (int b = a + 1; b < pins.count(); b++)
+			{
+				if (pins.at(a).first == pins.at(b).first)
+					continue;
+				const QPair<int, int> contact(qMin(pins.at(a).first, pins.at(b).first),
+											  qMax(pins.at(a).first, pins.at(b).first));
+				if (recordBaseline)
+				{
+					m_preExistingNetContacts.insert(contact);
+					continue;
+				}
+				if (m_preExistingNetContacts.contains(contact))
+					continue;
+				violations.append(QObject::tr("%1 and %2 are joined by breadboard wiring but belong to different schematic nets")
+									  .arg(connectorSummary(pins.at(a).second))
+									  .arg(connectorSummary(pins.at(b).second)));
+			}
+		}
+	}
+	return violations.isEmpty();
+}
+
+void BreadboardAutorouter::invalidateRoutingCaches()
+{
+	m_wireEndsCacheValid = false;
+	m_normalBreadboardWireEnds.clear();
+	m_busGroupForConnector.clear();
+	m_busGroupCount = 0;
 }
 
 QString BreadboardAutorouter::connectorSummary(ConnectorItem *connectorItem) const
@@ -1879,6 +3228,16 @@ QString BreadboardAutorouter::itemSummary(ItemBase *itemBase) const
 		.arg(itemBase->moduleID());
 }
 
+void BreadboardAutorouter::loadTuning()
+{
+	QSettings settings;
+	m_maxLegLength = settings.value("breadboardAutorouter/leadStretchLimit", 120.0).toDouble();
+	m_leadLengthWeight = settings.value("breadboardAutorouter/leadLengthWeight", 1.0).toDouble();
+	m_jumperPenalty = settings.value("breadboardAutorouter/jumperPenalty", 100000.0).toDouble();
+	m_leadAngleWeight = settings.value("breadboardAutorouter/leadAngleWeight", 4.0).toDouble();
+	m_foldbackWeight = settings.value("breadboardAutorouter/foldbackWeight", 6.0).toDouble();
+}
+
 QString BreadboardAutorouter::logFilePath() const
 {
 	QString dir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
@@ -1889,12 +3248,25 @@ QString BreadboardAutorouter::logFilePath() const
 
 void BreadboardAutorouter::logAutoroute(const QString &message) const
 {
+	m_logBuffer.append(QDateTime::currentDateTime().toString(Qt::ISODateWithMs) + " " + message);
+	// Cap memory without losing the tail on a crash mid-phase.
+	if (m_logBuffer.count() >= 512)
+		flushAutorouteLog();
+}
+
+void BreadboardAutorouter::flushAutorouteLog() const
+{
+	if (m_logBuffer.isEmpty())
+		return;
+
 	QFile file(logFilePath());
 	if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text))
 		return;
 
 	QTextStream stream(&file);
-	stream << QDateTime::currentDateTime().toString(Qt::ISODateWithMs) << " " << message << '\n';
+	Q_FOREACH (const QString &line, m_logBuffer)
+		stream << line << '\n';
+	m_logBuffer.clear();
 }
 
 ConnectorItem *BreadboardAutorouter::connectedPartConnector(ConnectorItem *wireConnector) const
@@ -1927,7 +3299,7 @@ ConnectorItem *BreadboardAutorouter::connectedBreadboardHoleFor(ConnectorItem *p
 	if (partConnector == nullptr)
 		return nullptr;
 	if (partConnector->connectorType() == Connector::Female)
-		return partConnector;
+		return isBreadboardHoleConnector(partConnector) ? partConnector : nullptr;
 
 	Q_FOREACH (ConnectorItem *connectorItem, partConnector->connectedToItems())
 	{
@@ -1942,7 +3314,7 @@ ConnectorItem *BreadboardAutorouter::connectedBreadboardHoleFor(ConnectorItem *p
 			continue;
 		if (connectorItem->attachedToItemType() == ModelPart::Wire)
 			continue;
-		if (connectorItem->connectorType() == Connector::Female)
+		if (isBreadboardHoleConnector(connectorItem))
 			return connectorItem;
 	}
 
@@ -1954,11 +3326,7 @@ ConnectorItem *BreadboardAutorouter::breadboardHoleFor(ConnectorItem *partConnec
 	if (partConnector == nullptr)
 		return nullptr;
 	if (partConnector->connectorType() == Connector::Female)
-	{
-		if (partConnector->connectionsCount() == 0)
-			return partConnector;
-		return nearestFreeBusHole(partConnector);
-	}
+		return isBreadboardHoleConnector(partConnector) ? partConnector : nullptr;
 
 	Q_FOREACH (ConnectorItem *connectorItem, partConnector->connectedToItems())
 	{
@@ -1973,7 +3341,7 @@ ConnectorItem *BreadboardAutorouter::breadboardHoleFor(ConnectorItem *partConnec
 			continue;
 		if (connectorItem->attachedToItemType() == ModelPart::Wire)
 			continue;
-		if (connectorItem->connectorType() != Connector::Female)
+		if (!isBreadboardHoleConnector(connectorItem))
 			continue;
 
 		if (connectorItem->connectionsCount() == 0)
@@ -2054,6 +3422,16 @@ QList<QList<ConnectorItem *>> BreadboardAutorouter::collectRoutableSubnets(QList
 		{
 			todo.removeOne(connectorItem);
 		}
+
+		// collectEqualPotential returns members in hash order, which Qt
+		// randomizes per process. Anchor choice (and therefore jumper
+		// layout) follows member order, so sort by stable ids to make
+		// autoroute results reproducible run to run.
+		std::sort(subnet.begin(), subnet.end(), [](ConnectorItem *a, ConnectorItem *b)
+				  {
+			if (a == nullptr || b == nullptr) return b == nullptr && a != nullptr;
+			if (a->attachedToID() != b->attachedToID()) return a->attachedToID() < b->attachedToID();
+			return a->connectorSharedID() < b->connectorSharedID(); });
 
 		ConnectorItem *representative = chooseRepresentative(subnet);
 		if (representative != nullptr)
@@ -2167,4 +3545,72 @@ void BreadboardAutorouter::clearCollectedNets()
 {
 	qDeleteAll(m_allPartConnectorItems);
 	m_allPartConnectorItems.clear();
+}
+
+// Update the progress dialog and (rate-limited) let it repaint. The router
+// runs synchronously on the GUI thread, so nothing paints unless events are
+// pumped - but pumping unconditionally per part or per net would thrash the
+// GUI engine with repaints. ~5 pumps per second keeps the bar live for free.
+void BreadboardAutorouter::reportProgress(int percent, const QString &detail)
+{
+	Q_EMIT setProgressValue(percent);
+	if (!detail.isEmpty())
+		Q_EMIT setProgressMessage2(detail);
+	if (m_progressPumpTimer.isValid() && m_progressPumpTimer.elapsed() < 200)
+		return;
+	m_progressPumpTimer.restart();
+	ProcessEventBlocker::processEvents();
+}
+
+// collectAllNets walks hash-ordered structures, so both net order and member
+// order vary with Qt's per-process hash seed. Anchor selection, group order
+// and difficulty tie-breaks all follow list order, so sort by stable ids to
+// make autoroute results reproducible run to run.
+void BreadboardAutorouter::sortCollectedNets()
+{
+	auto connectorLess = [](ConnectorItem *a, ConnectorItem *b) {
+		if (a == nullptr || b == nullptr)
+			return b == nullptr && a != nullptr;
+		if (a->attachedToID() != b->attachedToID())
+			return a->attachedToID() < b->attachedToID();
+		return a->connectorSharedID() < b->connectorSharedID();
+	};
+
+	Q_FOREACH (QList<ConnectorItem *> *net, m_allPartConnectorItems)
+	{
+		if (net != nullptr)
+			std::sort(net->begin(), net->end(), connectorLess);
+	}
+
+	// Net indices double as bus-ownership keys, and nets are re-collected
+	// after placement (holes join the equal-potential groups). The net sort
+	// key must therefore ignore members that placement adds: key on the
+	// smallest real part pin, which is invariant across both collections,
+	// so index i names the same schematic net before and after placement.
+	auto netSortKey = [&connectorLess](QList<ConnectorItem *> *net) -> ConnectorItem * {
+		if (net == nullptr)
+			return nullptr;
+		ConnectorItem *best = nullptr;
+		Q_FOREACH (ConnectorItem *connectorItem, *net)
+		{
+			if (connectorItem == nullptr)
+				continue;
+			if (connectorItem->connectorType() == Connector::Female)
+				continue;
+			if (connectorItem->attachedToItemType() == ModelPart::Wire)
+				continue;
+			if (best == nullptr || connectorLess(connectorItem, best))
+				best = connectorItem;
+		}
+		return best;
+	};
+
+	std::sort(m_allPartConnectorItems.begin(), m_allPartConnectorItems.end(),
+			  [&connectorLess, &netSortKey](QList<ConnectorItem *> *a, QList<ConnectorItem *> *b) {
+		ConnectorItem *aKey = netSortKey(a);
+		ConnectorItem *bKey = netSortKey(b);
+		if (aKey == nullptr || bKey == nullptr)
+			return bKey == nullptr && aKey != nullptr;
+		return connectorLess(aKey, bKey);
+	});
 }

--- a/src/autoroute/breadboardautorouter.cpp
+++ b/src/autoroute/breadboardautorouter.cpp
@@ -1,0 +1,2170 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#include "breadboardautorouter.h"
+#include "breadboardpartpolicy.h"
+#include "breadboardroutegraph.h"
+#include "breadboardtopology.h"
+
+#include <QHash>
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QGraphicsScene>
+#include <QGraphicsItem>
+#include <QSet>
+#include <QStandardPaths>
+#include <QTextStream>
+#include <QtMath>
+#include <QMessageBox>
+#include <QElapsedTimer>
+#include <QUndoCommand>
+#include <algorithm>
+#include <limits>
+
+#include "../commands.h"
+#include "../items/itembase.h"
+#include "../items/wire.h"
+#include "../sketch/breadboardsketchwidget.h"
+#include "../waitpushundostack.h"
+
+namespace
+{
+	struct PlacementCandidate
+	{
+		ItemBase *item = nullptr;
+		QPointF oldLoc;
+		QPointF newLoc;
+		QHash<ConnectorItem *, ConnectorItem *> pinToHole;
+		QHash<ConnectorItem *, QPolygonF> pinToLeg;
+		double score = std::numeric_limits<double>::max();
+		bool usesLegPlacement = false;
+	};
+
+	constexpr double HoleMatchTolerance = 12.0;
+	constexpr double PlacementKeepoutMargin = 8.0;
+	constexpr double BendablePlacementKeepoutMargin = 1.0;
+	constexpr double MaxBendableLegLength = 120.0;
+
+	ViewGeometry::WireFlags generatedWireFlags()
+	{
+		return ViewGeometry::NormalFlag | ViewGeometry::AutoroutableFlag;
+	}
+
+	QLineF connectorLine(ConnectorItem *from, ConnectorItem *to)
+	{
+		if (from == nullptr || to == nullptr) return QLineF();
+		return QLineF(from->sceneAdjustedTerminalPoint(nullptr), to->sceneAdjustedTerminalPoint(nullptr));
+	}
+
+	BreadboardRouteGraph::Options routeGraphOptions(const QList<QLineF> &plannedSegments)
+	{
+		BreadboardRouteGraph::Options options = BreadboardRouteGraph::Options::fromEnvironment();
+		options.existingSegments = plannedSegments;
+		return options;
+	}
+
+	double leadCongestionPenalty(ConnectorItem *from, ConnectorItem *to, const QList<QLineF> &plannedSegments)
+	{
+		const BreadboardRouteGraph::Options options = BreadboardRouteGraph::Options::fromEnvironment();
+		return BreadboardRouteGraph::congestionPenalty(connectorLine(from, to),
+		                                                   plannedSegments,
+		                                                   options.crossingPenalty,
+		                                                   options.overlapPenalty);
+	}
+
+	struct HoleBounds
+	{
+		bool valid = false;
+		double minX = 0.0;
+		double maxX = 0.0;
+		double minY = 0.0;
+		double maxY = 0.0;
+	};
+
+	double manhattanDistance(const QPointF &a, const QPointF &b)
+	{
+		return qAbs(a.x() - b.x()) + qAbs(a.y() - b.y());
+	}
+
+	double polylineLength(const QPolygonF &polygon)
+	{
+		double length = 0.0;
+		for (int i = 1; i < polygon.count(); i++) length += QLineF(polygon.at(i - 1), polygon.at(i)).length();
+		return length;
+	}
+
+	bool routeIsBetter(const BreadboardRouteGraph::Result &candidate,
+	                   const BreadboardRouteGraph::Result &current)
+	{
+		return candidate.found && (!current.found || candidate.score < current.score);
+	}
+
+	HoleBounds boundsForHoles(const QList<ConnectorItem *> &holes)
+	{
+		HoleBounds bounds;
+		Q_FOREACH (ConnectorItem *hole, holes)
+		{
+			if (hole == nullptr)
+				continue;
+			const QPointF point = hole->sceneAdjustedTerminalPoint(nullptr);
+			if (!bounds.valid)
+			{
+				bounds.valid = true;
+				bounds.minX = bounds.maxX = point.x();
+				bounds.minY = bounds.maxY = point.y();
+				continue;
+			}
+			bounds.minX = qMin(bounds.minX, point.x());
+			bounds.maxX = qMax(bounds.maxX, point.x());
+			bounds.minY = qMin(bounds.minY, point.y());
+			bounds.maxY = qMax(bounds.maxY, point.y());
+		}
+		return bounds;
+	}
+
+	double boardEdgeEntryScore(ConnectorItem *terminal, ConnectorItem *entry, const HoleBounds &bounds)
+	{
+		if (terminal == nullptr || entry == nullptr || !bounds.valid)
+		{
+			return std::numeric_limits<double>::max();
+		}
+
+		const QPointF terminalPoint = terminal->sceneAdjustedTerminalPoint(nullptr);
+		const QPointF entryPoint = entry->sceneAdjustedTerminalPoint(nullptr);
+		const double centerX = (bounds.minX + bounds.maxX) * 0.5;
+		const double centerY = (bounds.minY + bounds.maxY) * 0.5;
+
+		// Peripheral wires should enter at the breadboard edge facing the part.
+		// This keeps long off-board leads out of the middle of the board and lets
+		// the bus graph handle board-local jumpers from that entry point.
+		double edgeDistance = 0.0;
+		double perpendicularDistance = 0.0;
+		if (terminalPoint.x() < bounds.minX)
+		{
+			edgeDistance = qAbs(entryPoint.x() - bounds.minX);
+			perpendicularDistance = qAbs(entryPoint.y() - terminalPoint.y()) * 0.35;
+		}
+		else if (terminalPoint.x() > bounds.maxX)
+		{
+			edgeDistance = qAbs(entryPoint.x() - bounds.maxX);
+			perpendicularDistance = qAbs(entryPoint.y() - terminalPoint.y()) * 0.35;
+		}
+		else if (terminalPoint.y() < bounds.minY)
+		{
+			edgeDistance = qAbs(entryPoint.y() - bounds.minY);
+			perpendicularDistance = qAbs(entryPoint.x() - terminalPoint.x()) * 0.35;
+		}
+		else if (terminalPoint.y() > bounds.maxY)
+		{
+			edgeDistance = qAbs(entryPoint.y() - bounds.maxY);
+			perpendicularDistance = qAbs(entryPoint.x() - terminalPoint.x()) * 0.35;
+		}
+		else
+		{
+			const double left = qAbs(entryPoint.x() - bounds.minX);
+			const double right = qAbs(entryPoint.x() - bounds.maxX);
+			const double top = qAbs(entryPoint.y() - bounds.minY);
+			const double bottom = qAbs(entryPoint.y() - bounds.maxY);
+			edgeDistance = qMin(qMin(left, right), qMin(top, bottom));
+			perpendicularDistance = manhattanDistance(entryPoint, QPointF(centerX, centerY)) * 0.1;
+		}
+
+		return edgeDistance * 8.0 + perpendicularDistance + manhattanDistance(terminalPoint, entryPoint) * 0.1;
+	}
+
+	QPolygonF translatedLegForTarget(ConnectorItem *pin, const QPointF &offset, ConnectorItem *hole)
+	{
+		QPolygonF translated;
+		if (pin == nullptr || hole == nullptr)
+			return translated;
+
+		QPolygonF oldLeg = pin->sceneAdjustedLeg();
+		if (oldLeg.count() < 2)
+		{
+			translated << pin->sceneAdjustedTerminalPoint(nullptr) + offset;
+			translated << hole->sceneAdjustedTerminalPoint(nullptr);
+			return translated;
+		}
+
+		Q_FOREACH (QPointF point, oldLeg)
+		{
+			translated << point + offset;
+		}
+		translated.replace(translated.count() - 1, hole->sceneAdjustedTerminalPoint(nullptr));
+		return translated;
+	}
+
+	bool allPinsHaveBendableLegs(const QList<ConnectorItem *> &pins)
+	{
+		if (pins.isEmpty())
+			return false;
+		Q_FOREACH (ConnectorItem *pin, pins)
+		{
+			if (pin == nullptr || !pin->hasRubberBandLeg())
+				return false;
+		}
+		return true;
+	}
+
+	QList<ConnectorItem *> freeBusHoles(ConnectorItem *breadboardHole, const QList<ConnectorItem *> &allowedHoles, const QSet<ConnectorItem *> &reservedHoles)
+	{
+		QList<ConnectorItem *> result;
+		if (breadboardHole == nullptr)
+			return result;
+
+		ItemBase *breadboard = breadboardHole->attachedTo();
+		if (breadboard == nullptr)
+			return result;
+
+		QList<ConnectorItem *> busHoles;
+		if (!breadboard->busConnectorItems(breadboardHole, busHoles))
+			return result;
+
+		Q_FOREACH (ConnectorItem *candidate, busHoles)
+		{
+			if (candidate == nullptr)
+				continue;
+			if (!allowedHoles.contains(candidate))
+				continue;
+			if (reservedHoles.contains(candidate))
+				continue;
+			if (candidate->connectorType() != Connector::Female)
+				continue;
+			if (candidate->connectionsCount() != 0)
+				continue;
+			if (!candidate->attachedTo()->isEverVisible())
+				continue;
+			if (!result.contains(candidate))
+				result.append(candidate);
+		}
+
+		std::sort(result.begin(), result.end(), [breadboardHole](ConnectorItem *a, ConnectorItem *b)
+				  {
+		QPointF origin = breadboardHole->sceneAdjustedTerminalPoint(nullptr);
+		double ad = QLineF(origin, a->sceneAdjustedTerminalPoint(nullptr)).length();
+		double bd = QLineF(origin, b->sceneAdjustedTerminalPoint(nullptr)).length();
+		return ad < bd; });
+
+		return result;
+	}
+}
+
+BreadboardAutorouter::BreadboardAutorouter(BreadboardSketchWidget *sketchWidget)
+	: m_sketchWidget(sketchWidget)
+{
+}
+
+BreadboardAutorouter::~BreadboardAutorouter()
+{
+	clearCollectedNets();
+}
+
+void BreadboardAutorouter::start()
+{
+	if (m_sketchWidget == nullptr)
+		return;
+	QElapsedTimer elapsed;
+	elapsed.start();
+	m_componentLeadLength = 0.0;
+	m_lastRoutingScore = BreadboardRoutingScore();
+
+	QFile::remove(logFilePath());
+	logAutoroute("========== breadboard autoroute start ==========");
+	logAutoroute(QString("log file: %1").arg(logFilePath()));
+
+	const int cleared = clearPreviousAutorouteWires();
+	if (cleared > 0)
+	{
+		Q_EMIT setMaximumProgress(1);
+		Q_EMIT setProgressValue(1);
+		Q_EMIT setProgressMessage(QObject::tr("Breadboard routes cleared."));
+		Q_EMIT setProgressMessage2(QObject::tr("Removed %1 generated breadboard wire(s).").arg(cleared));
+		logAutoroute(QString("clear complete: removedWires=%1").arg(cleared));
+		logAutoroute("========== breadboard autoroute end ==========");
+		return;
+	}
+
+	clearCollectedNets();
+
+	QHash<ConnectorItem *, int> indexer;
+	m_sketchWidget->collectAllNets(indexer, m_allPartConnectorItems, false, false, false);
+	logAutoroute(QString("collectAllNets: nets=%1 indexer=%2").arg(m_allPartConnectorItems.count()).arg(indexer.count()));
+
+	if (m_allPartConnectorItems.isEmpty())
+	{
+		logAutoroute("abort: no breadboard connections to route");
+		QMessageBox::information(nullptr, QObject::tr("Fritzing"), QObject::tr("No breadboard connections to route."));
+		return;
+	}
+
+	Q_EMIT setMaximumProgress(m_allPartConnectorItems.count());
+	Q_EMIT setProgressValue(0);
+	Q_EMIT setProgressMessage(QObject::tr("Placing breadboard parts..."));
+	Q_EMIT setProgressMessage2(QString());
+
+	auto *undoStack = m_sketchWidget->undoStack();
+	const int undoCountBefore = undoStack->count();
+	const int undoIndexBefore = undoStack->index();
+	logAutoroute(QString("undo transaction begin: count=%1 index=%2")
+				 .arg(undoCountBefore)
+				 .arg(undoIndexBefore));
+	undoStack->beginMacro(QObject::tr("Breadboard autoroute"));
+	int placed = autoplacePartsOnBreadboard();
+	logAutoroute(QString("undo transaction after placement: count=%1 index=%2")
+				 .arg(undoStack->count())
+				 .arg(undoStack->index()));
+	logAutoroute(QString("autoplace complete: placed=%1").arg(placed));
+	if (placed > 0)
+	{
+		clearCollectedNets();
+		indexer.clear();
+		m_sketchWidget->collectAllNets(indexer, m_allPartConnectorItems, false, false, false);
+		logAutoroute(QString("collectAllNets after placement: nets=%1 indexer=%2").arg(m_allPartConnectorItems.count()).arg(indexer.count()));
+		Q_EMIT setMaximumProgress(m_allPartConnectorItems.count());
+	}
+
+	Q_EMIT setProgressMessage(QObject::tr("Routing breadboard jumpers..."));
+
+	auto *parentCommand = new QUndoCommand(QObject::tr("Route breadboard jumpers"));
+
+	int created = routeCollectedNets(parentCommand);
+	logAutoroute(QString("route complete: createdWires=%1").arg(created));
+
+	Q_EMIT setProgressValue(m_allPartConnectorItems.count());
+
+	if (placed <= 0 && created <= 0)
+	{
+		delete parentCommand;
+		undoStack->endMacro();
+		logAutoroute(QString("undo transaction empty end: count=%1 index=%2 delta=%3")
+					 .arg(undoStack->count())
+					 .arg(undoStack->index())
+					 .arg(undoStack->count() - undoCountBefore));
+		logAutoroute("abort: no valid placement or route");
+		if (!m_lastPlacementReport.isEmpty())
+			logAutoroute(QString("placement report:\n%1").arg(m_lastPlacementReport));
+		QMessageBox messageBox(QMessageBox::Information,
+							   QObject::tr("Fritzing"),
+							   QObject::tr("Breadboard autoroute did not find a valid placement or route."));
+		if (!m_lastPlacementReport.isEmpty())
+		{
+			messageBox.setDetailedText(m_lastPlacementReport);
+		}
+		messageBox.exec();
+		return;
+	}
+
+	new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, parentCommand);
+	new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, parentCommand);
+	undoStack->push(parentCommand);
+	logAutoroute(QString("undo transaction after routing: count=%1 index=%2")
+				 .arg(undoStack->count())
+				 .arg(undoStack->index()));
+	undoStack->endMacro();
+	logAutoroute(QString("undo transaction end: count=%1 index=%2 delta=%3")
+				 .arg(undoStack->count())
+				 .arg(undoStack->index())
+				 .arg(undoStack->count() - undoCountBefore));
+	m_lastRoutingScore.failedNets = countUnresolvedNets();
+	logAutoroute(QString("benchmark: %1 elapsedMs=%2")
+				 .arg(m_lastRoutingScore.toString())
+				 .arg(elapsed.elapsed()));
+
+	Q_EMIT setProgressMessage2(QObject::tr("Placed %1 part(s), created %2 breadboard jumper wire(s).").arg(placed).arg(created));
+	logAutoroute(QString("success: placed=%1 createdWires=%2").arg(placed).arg(created));
+	logAutoroute("========== breadboard autoroute end ==========");
+}
+
+int BreadboardAutorouter::clearPreviousAutorouteWires()
+{
+	QList<Wire *> generatedWires;
+	QList<Wire *> normalBreadboardWires;
+	int ratsnestCount = 0;
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *wire = dynamic_cast<Wire *>(graphicsItem);
+		if (wire == nullptr)
+			continue;
+
+		if (wire->getRatsnest())
+		{
+			ratsnestCount++;
+			continue;
+		}
+		if (!wire->getNormal())
+			continue;
+		if (wire->viewID() != ViewLayer::BreadboardView)
+			continue;
+
+		ConnectorItem *from = wire->connector0() == nullptr ? nullptr : wire->connector0()->firstConnectedToIsh();
+		ConnectorItem *to = wire->connector1() == nullptr ? nullptr : wire->connector1()->firstConnectedToIsh();
+		const bool touchesBreadboard = connectedBreadboardHoleFor(from) != nullptr
+		                            || connectedBreadboardHoleFor(to) != nullptr
+		                            || isTargetBreadboardHole(from)
+		                            || isTargetBreadboardHole(to);
+		if (!touchesBreadboard)
+			continue;
+
+		normalBreadboardWires.append(wire);
+		if (wire->getAutoroutable() || wire->hasFlag(ViewGeometry::AutoroutableFlag))
+			generatedWires.append(wire);
+	}
+
+	if (generatedWires.isEmpty() && ratsnestCount == 0)
+	{
+		generatedWires = normalBreadboardWires;
+	}
+	else if (!generatedWires.isEmpty() && ratsnestCount == 0)
+	{
+		Q_FOREACH (Wire *wire, normalBreadboardWires)
+		{
+			if (!generatedWires.contains(wire))
+				generatedWires.append(wire);
+		}
+	}
+
+	QSet<Wire *> unique;
+	QList<Wire *> uniqueGeneratedWires;
+	Q_FOREACH (Wire *wire, generatedWires)
+	{
+		if (wire == nullptr || unique.contains(wire))
+			continue;
+		unique.insert(wire);
+		uniqueGeneratedWires.append(wire);
+	}
+	generatedWires = uniqueGeneratedWires;
+
+	if (generatedWires.isEmpty())
+	{
+		logAutoroute(QString("clear previous: none ratsnests=%1 normalBreadboardWires=%2")
+		             .arg(ratsnestCount)
+		             .arg(normalBreadboardWires.count()));
+		return 0;
+	}
+
+	auto *parentCommand = new QUndoCommand(QObject::tr("Clear breadboard autoroute"));
+	new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
+	new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
+	m_sketchWidget->makeWiresChangeConnectionCommands(generatedWires, parentCommand);
+	Q_FOREACH (Wire *wire, generatedWires)
+	{
+		m_sketchWidget->makeDeleteItemCommand(wire, BaseCommand::SingleView, parentCommand);
+	}
+	new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, parentCommand);
+	new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::RedoOnly, parentCommand);
+	m_sketchWidget->undoStack()->push(parentCommand);
+
+	logAutoroute(QString("clear previous: removed=%1 ratsnests=%2 normalBreadboardWires=%3")
+	             .arg(generatedWires.count())
+	             .arg(ratsnestCount)
+	             .arg(normalBreadboardWires.count()));
+	return generatedWires.count();
+}
+
+int BreadboardAutorouter::autoplacePartsOnBreadboard()
+{
+	m_lastPlacementReport.clear();
+
+	QList<ItemBase *> parts;
+	m_sketchWidget->collectParts(parts);
+	logAutoroute(QString("autoplace: visible parts collected=%1").arg(parts.count()));
+	if (parts.isEmpty())
+	{
+		m_lastPlacementReport = QObject::tr("No breadboard-view parts were found.");
+		logAutoroute("autoplace abort: no parts");
+		return 0;
+	}
+
+	QList<ConnectorItem *> breadboardHoles;
+	QList<ItemBase *> targetBreadboards;
+	QSet<ConnectorItem *> reservedHoles;
+	QList<QRectF> occupiedRects;
+	QHash<ConnectorItem *, int> netForConnector;
+	QHash<int, QList<ConnectorItem *>> connectorsForNet;
+	QHash<ConnectorItem *, ConnectorItem *> placedTargets;
+	int candidateAttempts = 0;
+	int rejectedPinGeometry = 0;
+	int rejectedSameBus = 0;
+	int rejectedOffBoard = 0;
+	int rejectedOverlap = 0;
+	int acceptedCandidates = 0;
+	int partsWithPlaceablePins = 0;
+	int rejectedByPolicy = 0;
+	int leftPeripheral = 0;
+	int failedBoardFit = 0;
+	int placedRigid = 0;
+	int placedWithLegs = 0;
+
+	for (int netIndex = 0; netIndex < m_allPartConnectorItems.count(); netIndex++)
+	{
+		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
+		if (net == nullptr)
+			continue;
+		Q_FOREACH (ConnectorItem *connectorItem, *net)
+		{
+			if (connectorItem == nullptr)
+				continue;
+			netForConnector.insert(connectorItem, netIndex);
+			connectorsForNet[netIndex].append(connectorItem);
+			ConnectorItem *breadboardHole = breadboardHoleFor(connectorItem);
+			if (breadboardHole != nullptr && breadboardHole->connectorType() == Connector::Female)
+			{
+				placedTargets.insert(connectorItem, breadboardHole);
+			}
+		}
+	}
+
+	BreadboardTopology topology;
+	topology.discover(m_sketchWidget->scene(), m_sketchWidget->scene()->selectedItems());
+	Q_FOREACH (const QString &line, topology.diagnosticLines())
+	{
+		logAutoroute(line);
+	}
+
+	breadboardHoles = topology.holes();
+	targetBreadboards = topology.boardItems();
+	reservedHoles = topology.reservedHoles();
+	QRectF targetBoardBounds = topology.bounds();
+	int targetBoardConnectors = topology.itemConnectorCount();
+	int targetSceneConnectors = topology.sceneConnectorCount();
+
+	if (breadboardHoles.isEmpty())
+	{
+		m_lastPlacementReport = QObject::tr(
+									"No target breadboard holes were found.\n"
+									"Target breadboard(s): %1\n"
+									"Connectors on target breadboard item(s): %2\n"
+									"Scene connectors inside target board bounds: %3\n\n"
+									"If both connector counts are zero, no scene item owns enough breadboard holes.")
+									.arg(targetBreadboards.count())
+									.arg(targetBoardConnectors)
+									.arg(targetSceneConnectors);
+		logAutoroute(QString("autoplace abort: no holes\n%1").arg(m_lastPlacementReport));
+		return 0;
+	}
+
+	QRectF targetKeepoutBounds = targetBoardBounds.adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
+
+	std::sort(breadboardHoles.begin(), breadboardHoles.end(), [](ConnectorItem *a, ConnectorItem *b)
+			  {
+		QPointF ap = a->sceneAdjustedTerminalPoint(nullptr);
+		QPointF bp = b->sceneAdjustedTerminalPoint(nullptr);
+		if (!qFuzzyCompare(ap.y(), bp.y())) return ap.y() < bp.y();
+		return ap.x() < bp.x(); });
+
+	QPointF breadboardCenter;
+	Q_FOREACH (ConnectorItem *hole, breadboardHoles)
+	{
+		breadboardCenter += hole->sceneAdjustedTerminalPoint(nullptr);
+	}
+	breadboardCenter /= breadboardHoles.count();
+
+	QList<ItemBase *> movableParts;
+	int skippedNull = 0;
+	int skippedInvisible = 0;
+	int skippedRatsnest = 0;
+	int skippedBreadboard = 0;
+	int skippedWire = 0;
+	int skippedLocked = 0;
+	int skippedAlreadyOnBreadboard = 0;
+	Q_FOREACH (ItemBase *part, parts)
+	{
+		BreadboardPartPolicy::Decision policy = BreadboardPartPolicy::classify(part);
+		QString skipReason;
+		if (part == nullptr)
+		{
+			skippedNull++;
+			skipReason = "null";
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "not visible")
+		{
+			skippedInvisible++;
+			skipReason = policy.reason;
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "ratsnest")
+		{
+			skippedRatsnest++;
+			skipReason = policy.reason;
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "breadboard")
+		{
+			skippedBreadboard++;
+			skipReason = policy.reason;
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "breadboard decoration")
+		{
+			skippedBreadboard++;
+			skipReason = policy.reason;
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "wire")
+		{
+			skippedWire++;
+			skipReason = policy.reason;
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Ignore && policy.reason == "move locked")
+		{
+			skippedLocked++;
+			skipReason = policy.reason;
+		}
+		else if (policy.classification == BreadboardPartPolicy::Classification::Peripheral)
+		{
+			leftPeripheral++;
+			skipReason = QString("peripheral: %1").arg(policy.reason);
+		}
+		else if (policy.classification != BreadboardPartPolicy::Classification::BoardPlaceable)
+		{
+			rejectedByPolicy++;
+			skipReason = policy.reason;
+		}
+		else
+		{
+			bool alreadyOnBreadboard = false;
+			Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+			{
+				if (connectorItem == nullptr)
+					continue;
+				if (!isPlaceablePin(connectorItem))
+					continue;
+				Q_FOREACH (ConnectorItem *connected, connectorItem->connectedToItems())
+				{
+					if (connected != nullptr && connected->connectorType() == Connector::Female)
+					{
+						alreadyOnBreadboard = true;
+						break;
+					}
+				}
+				if (alreadyOnBreadboard)
+					break;
+			}
+			if (alreadyOnBreadboard)
+			{
+				skippedAlreadyOnBreadboard++;
+				skipReason = "already connected to female connector";
+			}
+		}
+
+		logAutoroute(QString("part policy: class=%1 reason=%2 pins=%3 bendableLegs=%4 family='%5' taxonomy='%6' package='%7' module=%8 title='%9'")
+						 .arg(BreadboardPartPolicy::classificationName(policy.classification))
+						 .arg(policy.reason)
+						 .arg(policy.placeablePins)
+						 .arg(policy.hasBendableLegs ? "yes" : "no")
+						 .arg(policy.family)
+						 .arg(policy.taxonomy)
+						 .arg(policy.package)
+						 .arg(policy.moduleID)
+						 .arg(policy.title));
+
+		if (skipReason.isEmpty())
+		{
+			movableParts.append(part);
+			logAutoroute(QString("movable part: %1 connectors=%2 placeablePins=%3 bendableLegs=%4 bounds=[%5,%6 %7x%8]")
+							 .arg(itemSummary(part))
+							 .arg(part->cachedConnectorItems().count())
+							 .arg(policy.placeablePins)
+							 .arg(policy.hasBendableLegs ? "yes" : "no")
+							 .arg(part->sceneBoundingRect().x())
+							 .arg(part->sceneBoundingRect().y())
+							 .arg(part->sceneBoundingRect().width())
+							 .arg(part->sceneBoundingRect().height()));
+		}
+		else
+		{
+			logAutoroute(QString("skip part: reason=%1 item=%2").arg(skipReason).arg(itemSummary(part)));
+		}
+	}
+	logAutoroute(QString("movable filter summary: movable=%1 null=%2 invisible=%3 ratsnest=%4 breadboard=%5 wire=%6 locked=%7 alreadyFemale=%8 rejectedByPolicy=%9 leftPeripheral=%10")
+					 .arg(movableParts.count())
+					 .arg(skippedNull)
+					 .arg(skippedInvisible)
+					 .arg(skippedRatsnest)
+					 .arg(skippedBreadboard)
+					 .arg(skippedWire)
+					 .arg(skippedLocked)
+					 .arg(skippedAlreadyOnBreadboard)
+					 .arg(rejectedByPolicy)
+					 .arg(leftPeripheral));
+
+	Q_FOREACH (ItemBase *part, parts)
+	{
+		if (part == nullptr)
+			continue;
+		if (!part->isEverVisible())
+			continue;
+		ItemBase *chief = part->layerKinChief();
+		if (isBreadboardItem(part) || isBreadboardItem(chief))
+			continue;
+		if (isBreadboardDecorationItem(part) || isBreadboardDecorationItem(chief))
+			continue;
+		if (targetBreadboards.contains(part) || targetBreadboards.contains(chief))
+			continue;
+		if (movableParts.contains(part))
+			continue;
+
+		QRectF partBounds = part->sceneBoundingRect().adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
+		if (partBounds.intersects(targetKeepoutBounds))
+		{
+			occupiedRects.append(partBounds);
+			logAutoroute(QString("occupied rect: item=%1 bounds=[%2,%3 %4x%5]")
+							 .arg(itemSummary(part))
+							 .arg(partBounds.x())
+							 .arg(partBounds.y())
+							 .arg(partBounds.width())
+							 .arg(partBounds.height()));
+		}
+	}
+	logAutoroute(QString("occupied rects considered=%1").arg(occupiedRects.count()));
+
+	std::sort(movableParts.begin(), movableParts.end(), [this, &netForConnector, &connectorsForNet](ItemBase *a, ItemBase *b)
+			  {
+		double aScore = partConnectivityScore(a, netForConnector, connectorsForNet);
+		double bScore = partConnectivityScore(b, netForConnector, connectorsForNet);
+		if (!qFuzzyCompare(aScore, bScore)) return aScore > bScore;
+
+		double aArea = a == nullptr ? 0 : a->sceneBoundingRect().width() * a->sceneBoundingRect().height();
+		double bArea = b == nullptr ? 0 : b->sceneBoundingRect().width() * b->sceneBoundingRect().height();
+		if (!qFuzzyCompare(aArea, bArea)) return aArea > bArea;
+
+		QPointF ap = a == nullptr ? QPointF() : a->sceneBoundingRect().center();
+		QPointF bp = b == nullptr ? QPointF() : b->sceneBoundingRect().center();
+		if (!qFuzzyCompare(ap.x(), bp.x())) return ap.x() < bp.x();
+		return ap.y() < bp.y(); });
+
+	QStringList placementOrder;
+	Q_FOREACH (ItemBase *part, movableParts)
+	{
+		placementOrder.append(QString("%1 score=%2")
+								  .arg(itemSummary(part))
+								  .arg(partConnectivityScore(part, netForConnector, connectorsForNet)));
+	}
+	logAutoroute(QString("placement order: %1").arg(placementOrder.join(" || ")));
+
+	auto *parentCommand = new QUndoCommand(QObject::tr("Autoplace breadboard parts"));
+	// This command is the first child of the outer autoroute macro, so its
+	// undo-only cleanup runs after both generated wires and placement
+	// connections have been undone. Cleaning inside the routing child leaves
+	// stale ratsnests because placement is undone later.
+	new CleanUpWiresCommand(m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
+	new CleanUpRatsnestsCommand(m_sketchWidget, CleanUpWiresCommand::UndoOnly, parentCommand);
+	int moved = 0;
+
+	Q_FOREACH (ItemBase *part, movableParts)
+	{
+		QList<ConnectorItem *> pins;
+		Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+		{
+			if (connectorItem == nullptr)
+				continue;
+			if (isPlaceablePin(connectorItem))
+				pins.append(connectorItem);
+		}
+		if (pins.isEmpty())
+			continue;
+		partsWithPlaceablePins++;
+		bool canUseBendableLegPlacement = pins.count() == 2 && allPinsHaveBendableLegs(pins);
+		logAutoroute(QString("placement begin: %1 placeablePins=%2 strategy=%3")
+						 .arg(itemSummary(part))
+						 .arg(pins.count())
+						 .arg(canUseBendableLegPlacement ? "rigid-or-bendable-leg" : "rigid"));
+
+		PlacementCandidate best;
+		best.item = part;
+		best.oldLoc = part->getViewGeometry().loc();
+
+		if (!canUseBendableLegPlacement)
+		{
+			Q_FOREACH (ConnectorItem *anchorPin, pins)
+			{
+				QPointF anchorPinPos = anchorPin->sceneAdjustedTerminalPoint(nullptr);
+				Q_FOREACH (ConnectorItem *anchorHole, breadboardHoles)
+				{
+					if (reservedHoles.contains(anchorHole))
+						continue;
+					candidateAttempts++;
+
+					QPointF offset = anchorHole->sceneAdjustedTerminalPoint(nullptr) - anchorPinPos;
+					QSet<ConnectorItem *> candidateReserved;
+					QHash<ConnectorItem *, ConnectorItem *> pinToHole;
+					bool fits = true;
+
+					Q_FOREACH (ConnectorItem *pin, pins)
+					{
+						QPointF target = pin->sceneAdjustedTerminalPoint(nullptr) + offset;
+						ConnectorItem *nearestHole = nullptr;
+						double nearestDistance = HoleMatchTolerance;
+
+						Q_FOREACH (ConnectorItem *hole, breadboardHoles)
+						{
+							if (reservedHoles.contains(hole) || candidateReserved.contains(hole))
+								continue;
+							double distance = QLineF(target, hole->sceneAdjustedTerminalPoint(nullptr)).length();
+							if (distance <= nearestDistance)
+							{
+								nearestHole = hole;
+								nearestDistance = distance;
+							}
+						}
+
+						if (nearestHole == nullptr)
+						{
+							fits = false;
+							break;
+						}
+
+						candidateReserved.insert(nearestHole);
+						pinToHole.insert(pin, nearestHole);
+					}
+
+					if (!fits)
+					{
+						rejectedPinGeometry++;
+						continue;
+					}
+
+					bool shortsPart = false;
+					QList<ConnectorItem *> mappedHoles = pinToHole.values();
+					for (int fromIndex = 0; fromIndex < mappedHoles.count(); fromIndex++)
+					{
+						for (int toIndex = fromIndex + 1; toIndex < mappedHoles.count(); toIndex++)
+						{
+							if (connectorsShareBreadboardBus(mappedHoles.at(fromIndex), mappedHoles.at(toIndex)))
+							{
+								shortsPart = true;
+								break;
+							}
+						}
+						if (shortsPart)
+							break;
+					}
+					if (shortsPart)
+					{
+						rejectedSameBus++;
+						continue;
+					}
+
+					QRectF movedBounds = part->sceneBoundingRect().translated(offset);
+					QRectF movedKeepout = movedBounds.adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin);
+					if (!targetBoardBounds.contains(movedBounds))
+					{
+						rejectedOffBoard++;
+						continue;
+					}
+
+					bool overlaps = false;
+					Q_FOREACH (const QRectF &occupied, occupiedRects)
+					{
+						if (movedKeepout.intersects(occupied))
+						{
+							overlaps = true;
+							break;
+						}
+					}
+					if (overlaps)
+					{
+						rejectedOverlap++;
+						continue;
+					}
+
+					acceptedCandidates++;
+					double score = manhattanDistance(movedBounds.center(), breadboardCenter) * 0.15;
+
+					Q_FOREACH (ConnectorItem *pin, pins)
+					{
+						int netIndex = netForConnector.value(pin, -1);
+						if (netIndex < 0)
+							continue;
+
+						ConnectorItem *targetHole = pinToHole.value(pin, nullptr);
+						if (targetHole == nullptr)
+							continue;
+						QPointF targetPos = targetHole->sceneAdjustedTerminalPoint(nullptr);
+
+						double bestNetDistance = std::numeric_limits<double>::max();
+						Q_FOREACH (ConnectorItem *other, connectorsForNet.value(netIndex))
+						{
+							if (other == pin)
+								continue;
+							ConnectorItem *otherTarget = placedTargets.value(other, nullptr);
+							if (otherTarget == nullptr)
+								continue;
+							bestNetDistance = qMin(bestNetDistance, manhattanDistance(targetPos, otherTarget->sceneAdjustedTerminalPoint(nullptr)));
+						}
+
+						if (bestNetDistance == std::numeric_limits<double>::max())
+						{
+							score += manhattanDistance(targetPos, breadboardCenter) * 0.05;
+						}
+						else
+						{
+							score += bestNetDistance;
+						}
+					}
+
+					if (score < best.score)
+					{
+						best.newLoc = best.oldLoc + offset;
+						best.pinToHole = pinToHole;
+						best.pinToLeg.clear();
+						best.score = score;
+						best.usesLegPlacement = false;
+						logAutoroute(QString("placement best update: part=%1 score=%2 offset=(%3,%4) anchorHole=%5")
+										 .arg(itemSummary(part))
+										 .arg(score)
+										 .arg(offset.x())
+										 .arg(offset.y())
+										 .arg(connectorSummary(anchorHole)));
+					}
+				}
+			}
+		}
+
+		if (canUseBendableLegPlacement)
+		{
+			ConnectorItem *firstPin = pins.at(0);
+			ConnectorItem *secondPin = pins.at(1);
+			logAutoroute(QString("bendable placement search: %1 pins=[%2 | %3]")
+							 .arg(itemSummary(part))
+							 .arg(connectorSummary(firstPin))
+							 .arg(connectorSummary(secondPin)));
+
+			Q_FOREACH (ConnectorItem *firstHole, breadboardHoles)
+			{
+				if (reservedHoles.contains(firstHole))
+					continue;
+				QPointF firstHolePos = firstHole->sceneAdjustedTerminalPoint(nullptr);
+				Q_FOREACH (ConnectorItem *secondHole, breadboardHoles)
+				{
+					if (firstHole == secondHole)
+						continue;
+					if (reservedHoles.contains(secondHole))
+						continue;
+					candidateAttempts++;
+
+					if (connectorsShareBreadboardBus(firstHole, secondHole))
+					{
+						rejectedSameBus++;
+						continue;
+					}
+
+					QPointF secondHolePos = secondHole->sceneAdjustedTerminalPoint(nullptr);
+					QPointF desiredCenter = (firstHolePos + secondHolePos) / 2.0;
+					QPointF offset = desiredCenter - part->sceneBoundingRect().center();
+					QRectF movedBounds = part->sceneBoundingRect().translated(offset);
+					QRectF movedKeepout = movedBounds.adjusted(-BendablePlacementKeepoutMargin, -BendablePlacementKeepoutMargin, BendablePlacementKeepoutMargin, BendablePlacementKeepoutMargin);
+
+					if (!targetBoardBounds.contains(movedBounds))
+					{
+						rejectedOffBoard++;
+						continue;
+					}
+
+					bool overlaps = false;
+					Q_FOREACH (const QRectF &occupied, occupiedRects)
+					{
+						if (movedKeepout.intersects(occupied))
+						{
+							overlaps = true;
+							break;
+						}
+					}
+					if (overlaps)
+					{
+						rejectedOverlap++;
+						continue;
+					}
+
+					QPointF movedFirstPin = firstPin->sceneAdjustedTerminalPoint(nullptr) + offset;
+					QPointF movedSecondPin = secondPin->sceneAdjustedTerminalPoint(nullptr) + offset;
+					double firstLegLength = QLineF(movedFirstPin, firstHolePos).length();
+					double secondLegLength = QLineF(movedSecondPin, secondHolePos).length();
+					if (firstLegLength > MaxBendableLegLength || secondLegLength > MaxBendableLegLength)
+					{
+						rejectedPinGeometry++;
+						continue;
+					}
+
+					acceptedCandidates++;
+					double score = manhattanDistance(movedBounds.center(), breadboardCenter) * 0.15 + firstLegLength + secondLegLength;
+					QHash<ConnectorItem *, ConnectorItem *> pinToHole;
+					pinToHole.insert(firstPin, firstHole);
+					pinToHole.insert(secondPin, secondHole);
+
+					Q_FOREACH (ConnectorItem *pin, pins)
+					{
+						int netIndex = netForConnector.value(pin, -1);
+						if (netIndex < 0)
+							continue;
+
+						ConnectorItem *targetHole = pinToHole.value(pin, nullptr);
+						if (targetHole == nullptr)
+							continue;
+						QPointF targetPos = targetHole->sceneAdjustedTerminalPoint(nullptr);
+
+						double bestNetDistance = std::numeric_limits<double>::max();
+						Q_FOREACH (ConnectorItem *other, connectorsForNet.value(netIndex))
+						{
+							if (other == pin)
+								continue;
+							ConnectorItem *otherTarget = placedTargets.value(other, nullptr);
+							if (otherTarget == nullptr)
+								continue;
+							bestNetDistance = qMin(bestNetDistance, manhattanDistance(targetPos, otherTarget->sceneAdjustedTerminalPoint(nullptr)));
+						}
+
+						if (bestNetDistance == std::numeric_limits<double>::max())
+						{
+							score += manhattanDistance(targetPos, breadboardCenter) * 0.05;
+						}
+						else
+						{
+							score += bestNetDistance;
+						}
+					}
+
+					if (score < best.score)
+					{
+						best.newLoc = best.oldLoc + offset;
+						best.pinToHole = pinToHole;
+						best.pinToLeg.clear();
+						best.pinToLeg.insert(firstPin, translatedLegForTarget(firstPin, offset, firstHole));
+						best.pinToLeg.insert(secondPin, translatedLegForTarget(secondPin, offset, secondHole));
+						best.score = score;
+						best.usesLegPlacement = true;
+						logAutoroute(QString("bendable placement best update: part=%1 score=%2 offset=(%3,%4) holes=[%5 | %6] legLengths=[%7,%8]")
+										 .arg(itemSummary(part))
+										 .arg(score)
+										 .arg(offset.x())
+										 .arg(offset.y())
+										 .arg(connectorSummary(firstHole))
+										 .arg(connectorSummary(secondHole))
+										 .arg(firstLegLength)
+										 .arg(secondLegLength));
+					}
+				}
+			}
+		}
+
+		if (best.pinToHole.isEmpty())
+		{
+			logAutoroute(QString("placement no candidate: %1").arg(itemSummary(part)));
+			failedBoardFit++;
+			continue;
+		}
+
+		ViewGeometry oldGeometry(part->getViewGeometry());
+		ViewGeometry newGeometry(part->getViewGeometry());
+		newGeometry.setLoc(best.newLoc);
+		new MoveItemCommand(m_sketchWidget, part->id(), oldGeometry, newGeometry, false, parentCommand);
+		logAutoroute(QString("placement accepted: %1 old=(%2,%3) new=(%4,%5) score=%6")
+						 .arg(itemSummary(part))
+						 .arg(best.oldLoc.x())
+						 .arg(best.oldLoc.y())
+						 .arg(best.newLoc.x())
+						 .arg(best.newLoc.y())
+						 .arg(best.score));
+
+		for (auto it = best.pinToHole.constBegin(); it != best.pinToHole.constEnd(); ++it)
+		{
+			ConnectorItem *pin = it.key();
+			ConnectorItem *hole = it.value();
+			if (pin == nullptr || hole == nullptr)
+				continue;
+			new ChangeConnectionCommand(m_sketchWidget, BaseCommand::CrossView,
+										pin->attachedToID(), pin->connectorSharedID(),
+										hole->attachedToID(), hole->connectorSharedID(),
+										ViewLayer::specFromID(hole->attachedToViewLayerID()),
+										true, parentCommand);
+			logAutoroute(QString("placement connection: pin=%1 hole=%2 sameBus?=%3")
+							 .arg(connectorSummary(pin))
+							 .arg(connectorSummary(hole))
+							 .arg(connectorsShareBreadboardBus(pin, hole) ? "yes" : "no"));
+			reservedHoles.insert(hole);
+			placedTargets.insert(pin, hole);
+
+			QPolygonF newLeg = best.pinToLeg.value(pin);
+			if (best.usesLegPlacement && newLeg.count() >= 2)
+			{
+				m_componentLeadLength += polylineLength(newLeg);
+				QPolygonF oldLeg = pin->sceneAdjustedLeg();
+				QPolygonF movedOldLeg;
+				QPointF offset = best.newLoc - best.oldLoc;
+				Q_FOREACH (QPointF point, oldLeg)
+				{
+					movedOldLeg << point + offset;
+				}
+				auto *legCommand = new ChangeLegCommand(m_sketchWidget,
+														pin->attachedToID(),
+														pin->connectorSharedID(),
+														movedOldLeg,
+														newLeg,
+														false,
+														true,
+														"breadboard autoroute",
+														parentCommand);
+				legCommand->setSimple();
+				logAutoroute(QString("placement leg: pin=%1 points=%2")
+								 .arg(connectorSummary(pin))
+								 .arg(newLeg.count()));
+			}
+		}
+
+		occupiedRects.append(part->sceneBoundingRect().translated(best.newLoc - best.oldLoc).adjusted(-PlacementKeepoutMargin, -PlacementKeepoutMargin, PlacementKeepoutMargin, PlacementKeepoutMargin));
+		if (best.usesLegPlacement)
+			placedWithLegs++;
+		else
+			placedRigid++;
+		moved++;
+	}
+
+	if (moved <= 0)
+	{
+		delete parentCommand;
+		m_lastPlacementReport = QObject::tr(
+									"Target breadboard(s): %1\n"
+									"Breadboard holes considered: %2\n"
+									"Scene connectors inside target board bounds: %3\n"
+									"Visible parts: %4\n"
+									"Movable parts after filters: %5\n"
+									"Movable parts with placeable pins: %6\n"
+									"Placement candidates tried: %7\n"
+									"Rejected because pins did not line up with free holes: %8\n"
+									"Rejected because one part would be shorted on the same breadboard bus: %9\n"
+									"Rejected because placement was outside target board: %10\n"
+									"Rejected because placement overlapped another part: %11\n"
+									"Accepted candidate placements: %12\n"
+									"Rejected by policy: %13\n"
+									"Left as peripheral: %14\n"
+									"Failed board fit: %15\n\n"
+									"If pin-geometry rejections dominate, the next implementation needs bendable-leg placement instead of whole-SVG pin alignment.")
+									.arg(targetBreadboards.count())
+									.arg(breadboardHoles.count())
+									.arg(targetSceneConnectors)
+									.arg(parts.count())
+									.arg(movableParts.count())
+									.arg(partsWithPlaceablePins)
+									.arg(candidateAttempts)
+									.arg(rejectedPinGeometry)
+									.arg(rejectedSameBus)
+									.arg(rejectedOffBoard)
+									.arg(rejectedOverlap)
+									.arg(acceptedCandidates)
+									.arg(rejectedByPolicy)
+									.arg(leftPeripheral)
+									.arg(failedBoardFit);
+		logAutoroute(QString("autoplace failed:\n%1").arg(m_lastPlacementReport));
+		return 0;
+	}
+
+	m_sketchWidget->undoStack()->push(parentCommand);
+	logAutoroute(QString("autoplace counters: moved=%1 placedRigid=%2 placedWithLegs=%3 candidateAttempts=%4 acceptedCandidates=%5 rejectedPinGeometry=%6 rejectedSameBus=%7 rejectedOffBoard=%8 rejectedOverlap=%9 rejectedByPolicy=%10 leftPeripheral=%11 failedBoardFit=%12")
+					 .arg(moved)
+					 .arg(placedRigid)
+					 .arg(placedWithLegs)
+					 .arg(candidateAttempts)
+					 .arg(acceptedCandidates)
+					 .arg(rejectedPinGeometry)
+					 .arg(rejectedSameBus)
+					 .arg(rejectedOffBoard)
+					 .arg(rejectedOverlap)
+					 .arg(rejectedByPolicy)
+					 .arg(leftPeripheral)
+					 .arg(failedBoardFit));
+	return moved;
+}
+
+int BreadboardAutorouter::routeRatsnestDemands(QUndoCommand *parentCommand)
+{
+	BreadboardTopology topology;
+	topology.discover(m_sketchWidget->scene(), m_sketchWidget->scene()->selectedItems());
+	const QList<ConnectorItem *> routeHoles = topology.holes();
+	QSet<ConnectorItem *> reservedHoles = topology.reservedHoles();
+	const HoleBounds holeBounds = boundsForHoles(routeHoles);
+	QList<QLineF> plannedSegments;
+	QList<Wire *> demands;
+
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *wire = dynamic_cast<Wire *>(graphicsItem);
+		if (wire != nullptr && wire->getRatsnest()) demands.append(wire);
+	}
+
+	std::sort(demands.begin(), demands.end(), [](Wire *first, Wire *second) {
+		if (first == nullptr || second == nullptr) return first != nullptr;
+		const double firstLength = QLineF(first->connector0()->sceneAdjustedTerminalPoint(nullptr),
+		                                  first->connector1()->sceneAdjustedTerminalPoint(nullptr)).length();
+		const double secondLength = QLineF(second->connector0()->sceneAdjustedTerminalPoint(nullptr),
+		                                   second->connector1()->sceneAdjustedTerminalPoint(nullptr)).length();
+		return firstLength < secondLength;
+	});
+
+	int created = 0;
+	int failed = 0;
+	auto addWire = [&](ConnectorItem *from, ConnectorItem *to) {
+		if (from == nullptr || to == nullptr || from == to) return;
+		m_sketchWidget->createWire(from, to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+		plannedSegments.append(connectorLine(from, to));
+		created++;
+	};
+	auto applyGraphRoute = [&](const BreadboardRouteGraph::Result &route) {
+		Q_FOREACH (const BreadboardRouteGraph::Segment &segment, route.segments)
+		{
+			addWire(segment.from, segment.to);
+			reservedHoles.insert(segment.from);
+			reservedHoles.insert(segment.to);
+		}
+	};
+	auto chooseEntry = [&](ConnectorItem *terminal, const QSet<ConnectorItem *> &extraReserved) {
+		ConnectorItem *best = nullptr;
+		double bestScore = std::numeric_limits<double>::max();
+		Q_FOREACH (ConnectorItem *hole, routeHoles)
+		{
+			if (hole == nullptr || reservedHoles.contains(hole) || extraReserved.contains(hole)) continue;
+			if (hole->connectionsCount() != 0) continue;
+			const double score = boardEdgeEntryScore(terminal, hole, holeBounds);
+			if (score < bestScore) {
+				best = hole;
+				bestScore = score;
+			}
+		}
+		return best;
+	};
+
+	logAutoroute(QString("ratsnest demands: %1").arg(demands.count()));
+	Q_FOREACH (Wire *demand, demands)
+	{
+		const int createdBeforeDemand = created;
+		ConnectorItem *fromPart = demand->connector0() == nullptr ? nullptr : demand->connector0()->firstConnectedToIsh();
+		ConnectorItem *toPart = demand->connector1() == nullptr ? nullptr : demand->connector1()->firstConnectedToIsh();
+		ConnectorItem *fromHole = breadboardHoleFor(fromPart);
+		ConnectorItem *toHole = breadboardHoleFor(toPart);
+		logAutoroute(QString("ratsnest demand begin: from=[%1] fromHole=[%2] to=[%3] toHole=[%4]")
+					 .arg(connectorSummary(fromPart))
+					 .arg(connectorSummary(fromHole))
+					 .arg(connectorSummary(toPart))
+					 .arg(connectorSummary(toHole)));
+
+		if (fromPart == nullptr || toPart == nullptr)
+		{
+			failed++;
+			logAutoroute("ratsnest demand failed: missing endpoint");
+			continue;
+		}
+
+		if (fromHole != nullptr && toHole != nullptr)
+		{
+			BreadboardRouteGraph graph(routeHoles, reservedHoles, routeGraphOptions(plannedSegments));
+			BreadboardRouteGraph::Result route = graph.route(fromHole, toHole);
+			if (!route.found) {
+				failed++;
+				logAutoroute(QString("ratsnest demand failed: no board route from=[%1] to=[%2]")
+							 .arg(connectorSummary(fromPart), connectorSummary(toPart)));
+				continue;
+			}
+			applyGraphRoute(route);
+			logAutoroute(QString("ratsnest demand complete: wires=%1").arg(created - createdBeforeDemand));
+			continue;
+		}
+
+		if (fromHole == nullptr && toHole == nullptr)
+		{
+			ConnectorItem *fromEntry = chooseEntry(fromPart, QSet<ConnectorItem *>());
+			ConnectorItem *toEntry = nearestFreeBusHole(fromEntry);
+			if (fromEntry == nullptr || toEntry == nullptr) {
+				failed++;
+				logAutoroute("ratsnest demand failed: no entries for off-board pair");
+				continue;
+			}
+			addWire(fromPart, fromEntry);
+			addWire(toPart, toEntry);
+			reservedHoles.insert(fromEntry);
+			reservedHoles.insert(toEntry);
+			logAutoroute(QString("ratsnest demand complete: wires=%1").arg(created - createdBeforeDemand));
+			continue;
+		}
+
+		ConnectorItem *terminal = fromHole == nullptr ? fromPart : toPart;
+		ConnectorItem *targetHole = fromHole == nullptr ? toHole : fromHole;
+		BreadboardPartPolicy::Decision terminalPolicy = BreadboardPartPolicy::classify(terminal->attachedTo()->layerKinChief());
+		if (terminalPolicy.classification != BreadboardPartPolicy::Classification::Peripheral) {
+			failed++;
+			logAutoroute(QString("ratsnest demand failed: board-placeable endpoint has no hole [%1]")
+						 .arg(connectorSummary(terminal)));
+			continue;
+		}
+
+		if (targetHole == nullptr) {
+			failed++;
+			logAutoroute(QString("ratsnest demand failed: no peripheral target [%1]").arg(connectorSummary(terminal)));
+			continue;
+		}
+		addWire(terminal, targetHole);
+		reservedHoles.insert(targetHole);
+		logAutoroute(QString("ratsnest demand complete: wires=%1").arg(created - createdBeforeDemand));
+	}
+
+	double jumperLength = 0.0;
+	Q_FOREACH (const QLineF &segment, plannedSegments) jumperLength += segment.length();
+	m_lastRoutingScore.failedNets = failed;
+	m_lastRoutingScore.jumperCount = created;
+	m_lastRoutingScore.jumperLength = jumperLength;
+	m_lastRoutingScore.componentLeadLength = m_componentLeadLength;
+	logAutoroute(QString("ratsnest route result: demands=%1 failed=%2 created=%3 length=%4")
+				 .arg(demands.count()).arg(failed).arg(created).arg(jumperLength));
+	return created;
+}
+
+int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
+{
+	int created = 0;
+	int wiredPeripheral = 0;
+	int allocatedPeripheralLanes = 0;
+
+	BreadboardTopology topology;
+	topology.discover(m_sketchWidget->scene(), m_sketchWidget->scene()->selectedItems());
+	QList<ConnectorItem *> routeHoles = topology.holes();
+	QSet<ConnectorItem *> routeReservedHoles = topology.reservedHoles();
+	const HoleBounds routeHoleBounds = boundsForHoles(routeHoles);
+	QList<QLineF> plannedSegments;
+	QSet<int> failedNetIndices;
+	const BreadboardRouteGraph::Options activeOptions = BreadboardRouteGraph::Options::fromEnvironment();
+	logAutoroute(QString("route options: maxJumperLength=%1 candidatesPerBusPair=%2 crossingPenalty=%3 overlapPenalty=%4")
+				 .arg(activeOptions.maxJumperLength)
+				 .arg(activeOptions.candidatesPerBusPair)
+				 .arg(activeOptions.crossingPenalty)
+				 .arg(activeOptions.overlapPenalty));
+
+	QList<int> routeOrder;
+	for (int netIndex = 0; netIndex < m_allPartConnectorItems.count(); netIndex++)
+	{
+		routeOrder.append(netIndex);
+	}
+	std::sort(routeOrder.begin(), routeOrder.end(), [this](int firstIndex, int secondIndex) {
+		auto difficulty = [this](QList<ConnectorItem *> *net) {
+			if (net == nullptr) return 0.0;
+			const QList<ConnectorItem *> candidates = routingCandidatesForSubnet(*net);
+			const int groups = collectCandidateGroups(candidates).count();
+			QRectF bounds;
+			Q_FOREACH (ConnectorItem *candidate, candidates) {
+				if (candidate == nullptr) continue;
+				const QRectF point(candidate->sceneAdjustedTerminalPoint(nullptr), QSizeF(1.0, 1.0));
+				bounds = bounds.isNull() ? point : bounds | point;
+			}
+			return groups * 100000.0 + candidates.count() * 1000.0 + bounds.width() + bounds.height();
+		};
+		return difficulty(m_allPartConnectorItems.value(firstIndex)) > difficulty(m_allPartConnectorItems.value(secondIndex));
+	});
+	QStringList routeOrderText;
+	Q_FOREACH (int netIndex, routeOrder) routeOrderText.append(QString::number(netIndex));
+	logAutoroute(QString("route order (most constrained first): %1").arg(routeOrderText.join(",")));
+
+	for (int orderIndex = 0; orderIndex < routeOrder.count(); orderIndex++)
+	{
+		Q_EMIT setProgressValue(orderIndex);
+		const int i = routeOrder.at(orderIndex);
+
+		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(i);
+		if (net == nullptr)
+			continue;
+
+		QList<ConnectorItem *> candidates = routingCandidatesForSubnet(*net);
+		QList<QList<ConnectorItem *>> groups = collectCandidateGroups(candidates);
+		logAutoroute(QString("route net %1: netConnectors=%2 candidates=%3 groups=%4")
+						 .arg(i)
+						 .arg(net->count())
+						 .arg(candidates.count())
+						 .arg(groups.count()));
+		for (int groupIndex = 0; groupIndex < groups.count(); groupIndex++)
+		{
+			QStringList connectorLines;
+			QList<ConnectorItem *> group = groups.at(groupIndex);
+			for (int connectorIndex = 0; connectorIndex < group.count() && connectorIndex < 6; connectorIndex++)
+			{
+				connectorLines.append(connectorSummary(group.at(connectorIndex)));
+			}
+			logAutoroute(QString("route net %1 group %2 size=%3 sample=[%4]")
+							 .arg(i)
+							 .arg(groupIndex)
+							 .arg(group.count())
+							 .arg(connectorLines.join(" | ")));
+		}
+
+		QList<ConnectorItem *> breadboardAnchors;
+		QList<ConnectorItem *> offBoardTerminals;
+		Q_FOREACH (ConnectorItem *connectorItem, *net)
+		{
+			if (connectorItem == nullptr)
+				continue;
+			ItemBase *itemBase = connectorItem->attachedTo();
+			if (itemBase == nullptr)
+				continue;
+			if (!itemBase->isEverVisible())
+				continue;
+			if (itemBase->getRatsnest())
+				continue;
+			if (connectorItem->attachedToItemType() == ModelPart::Wire)
+				continue;
+			if (!isPlaceablePin(connectorItem) && connectorItem->connectorType() != Connector::Female)
+				continue;
+
+			ConnectorItem *connectedHole = connectedBreadboardHoleFor(connectorItem);
+			if (connectedHole != nullptr)
+			{
+				if (!breadboardAnchors.contains(connectedHole))
+					breadboardAnchors.append(connectedHole);
+				continue;
+			}
+
+			BreadboardPartPolicy::Decision policy = BreadboardPartPolicy::classify(itemBase->layerKinChief());
+			if (policy.classification == BreadboardPartPolicy::Classification::Peripheral && connectorItem->connectorType() != Connector::Female && !offBoardTerminals.contains(connectorItem))
+			{
+				offBoardTerminals.append(connectorItem);
+				logAutoroute(QString("route peripheral terminal: net=%1 terminal=%2 class=%3 reason=%4")
+								 .arg(i)
+								 .arg(connectorSummary(connectorItem))
+								 .arg(BreadboardPartPolicy::classificationName(policy.classification))
+								 .arg(policy.reason));
+			}
+			else if (policy.classification == BreadboardPartPolicy::Classification::BoardPlaceable && connectorItem->connectorType() != Connector::Female)
+			{
+				logAutoroute(QString("route skip board-placeable offboard terminal: net=%1 terminal=%2 reason=not a peripheral")
+								 .arg(i)
+								 .arg(connectorSummary(connectorItem)));
+			}
+		}
+
+		if (breadboardAnchors.isEmpty() && offBoardTerminals.count() > 1)
+		{
+			QList<ConnectorItem *> terminalEntries;
+			QSet<ConnectorItem *> usedEntries;
+			QList<QLineF> entryLeadSegments = plannedSegments;
+			bool entriesReady = true;
+
+			Q_FOREACH (ConnectorItem *terminal, offBoardTerminals)
+			{
+				ConnectorItem *bestEntry = nullptr;
+				double bestEntryScore = std::numeric_limits<double>::max();
+				Q_FOREACH (ConnectorItem *entry, routeHoles)
+				{
+					if (entry == nullptr || routeReservedHoles.contains(entry) || usedEntries.contains(entry))
+						continue;
+					if (entry->connectionsCount() > 0)
+						continue;
+					const double score = boardEdgeEntryScore(terminal, entry, routeHoleBounds)
+					                   + leadCongestionPenalty(terminal, entry, entryLeadSegments);
+					if (score < bestEntryScore)
+					{
+						bestEntry = entry;
+						bestEntryScore = score;
+					}
+				}
+				if (bestEntry == nullptr)
+				{
+					entriesReady = false;
+					failedNetIndices.insert(i);
+					logAutoroute(QString("route peripheral entry skipped: net=%1 terminal=%2 no free edge entry")
+									 .arg(i)
+									 .arg(connectorSummary(terminal)));
+					break;
+				}
+				terminalEntries.append(bestEntry);
+				usedEntries.insert(bestEntry);
+				entryLeadSegments.append(connectorLine(terminal, bestEntry));
+				logAutoroute(QString("route peripheral entry: net=%1 terminal=%2 entry=%3 score=%4")
+								 .arg(i)
+								 .arg(connectorSummary(terminal))
+								 .arg(connectorSummary(bestEntry))
+								 .arg(bestEntryScore));
+			}
+
+			QList<BreadboardRouteGraph::Result> entryRoutes;
+			if (entriesReady)
+			{
+				QSet<ConnectorItem *> temporaryReserved = routeReservedHoles;
+				QList<QLineF> entryPlanningSegments = plannedSegments;
+				Q_FOREACH (ConnectorItem *entry, terminalEntries)
+				{
+					temporaryReserved.insert(entry);
+				}
+
+				QList<ConnectorItem *> connectedEntries;
+				if (!terminalEntries.isEmpty())
+					connectedEntries.append(terminalEntries.first());
+
+				for (int targetIndex = 1; targetIndex < terminalEntries.count(); targetIndex++)
+				{
+					ConnectorItem *targetEntry = terminalEntries.at(targetIndex);
+					BreadboardRouteGraph::Result bestRoute;
+					BreadboardRouteGraph routeGraph(routeHoles, temporaryReserved, routeGraphOptions(entryPlanningSegments));
+					Q_FOREACH (ConnectorItem *connectedEntry, connectedEntries)
+					{
+						BreadboardRouteGraph::Result route = routeGraph.route(connectedEntry, targetEntry);
+						if (!route.found)
+							continue;
+						if (routeIsBetter(route, bestRoute))
+						{
+							bestRoute = route;
+						}
+					}
+					if (!bestRoute.found)
+					{
+						entriesReady = false;
+						failedNetIndices.insert(i);
+						logAutoroute(QString("route peripheral entries skipped: net=%1 entry=%2 no graph route")
+										 .arg(i)
+										 .arg(connectorSummary(targetEntry)));
+						break;
+					}
+					entryRoutes.append(bestRoute);
+					Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments) {
+						entryPlanningSegments.append(connectorLine(segment.from, segment.to));
+						temporaryReserved.insert(segment.from);
+						temporaryReserved.insert(segment.to);
+					}
+					connectedEntries.append(targetEntry);
+				}
+			}
+
+			if (entriesReady && terminalEntries.count() == offBoardTerminals.count())
+			{
+				allocatedPeripheralLanes++;
+				logAutoroute(QString("route peripheral entries: net=%1 terminals=%2 routes=%3")
+								 .arg(i)
+								 .arg(offBoardTerminals.count())
+								 .arg(entryRoutes.count()));
+				for (int terminalIndex = 0; terminalIndex < offBoardTerminals.count(); terminalIndex++)
+				{
+					ConnectorItem *terminal = offBoardTerminals.at(terminalIndex);
+					ConnectorItem *target = terminalEntries.at(terminalIndex);
+					if (terminal == nullptr || target == nullptr)
+						continue;
+					m_sketchWidget->createWire(terminal, target, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+					plannedSegments.append(connectorLine(terminal, target));
+					routeReservedHoles.insert(target);
+					created++;
+					wiredPeripheral++;
+				}
+				Q_FOREACH (const BreadboardRouteGraph::Result &route, entryRoutes)
+				{
+					Q_FOREACH (const BreadboardRouteGraph::Segment &segment, route.segments)
+					{
+						if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
+							continue;
+						m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+						plannedSegments.append(connectorLine(segment.from, segment.to));
+						routeReservedHoles.insert(segment.from);
+						routeReservedHoles.insert(segment.to);
+						created++;
+					}
+				}
+				breadboardAnchors.append(terminalEntries.first());
+				offBoardTerminals.clear();
+			}
+		}
+
+		if (!breadboardAnchors.isEmpty() && !offBoardTerminals.isEmpty())
+		{
+			QSet<ConnectorItem *> usedBridgeTargets;
+			Q_FOREACH (ConnectorItem *terminal, offBoardTerminals)
+			{
+				ConnectorItem *bestAnchor = nullptr;
+				ConnectorItem *bestEntry = nullptr;
+				BreadboardRouteGraph::Result bestRoute;
+				BreadboardRoutingScore bestBridgeScore;
+				bool haveBridgeScore = false;
+				BreadboardRouteGraph routeGraph(routeHoles, routeReservedHoles, routeGraphOptions(plannedSegments));
+
+				Q_FOREACH (ConnectorItem *entry, routeHoles)
+				{
+					if (entry == nullptr || routeReservedHoles.contains(entry) || usedBridgeTargets.contains(entry))
+						continue;
+					if (entry->connectionsCount() > 0)
+						continue;
+					const double entryScore = boardEdgeEntryScore(terminal, entry, routeHoleBounds)
+					                        + leadCongestionPenalty(terminal, entry, plannedSegments);
+					if (entryScore == std::numeric_limits<double>::max())
+						continue;
+
+					Q_FOREACH (ConnectorItem *anchor, breadboardAnchors)
+					{
+						if (anchor == nullptr)
+							continue;
+						BreadboardRouteGraph::Result route = routeGraph.route(entry, anchor);
+						if (!route.found)
+							continue;
+
+						BreadboardRoutingScore score = route.score;
+						score.jumperCount++;
+						score.jumperLength += connectorLine(terminal, entry).length();
+						score.congestion += entryScore;
+						if (!haveBridgeScore || score < bestBridgeScore)
+						{
+							bestAnchor = anchor;
+							bestEntry = entry;
+							bestRoute = route;
+							bestBridgeScore = score;
+							haveBridgeScore = true;
+						}
+					}
+				}
+
+				if (bestEntry == nullptr || !bestRoute.found)
+				{
+					failedNetIndices.insert(i);
+					logAutoroute(QString("route bridge skipped: net=%1 terminal=%2 no breadboard target")
+									 .arg(i)
+									 .arg(connectorSummary(terminal)));
+					continue;
+				}
+
+				logAutoroute(QString("route bridge: net=%1 terminal=%2 anchor=%3 entry=%4 segments=%5 score=%6")
+								 .arg(i)
+								 .arg(connectorSummary(terminal))
+								 .arg(connectorSummary(bestAnchor))
+								 .arg(connectorSummary(bestEntry))
+								 .arg(bestRoute.segments.count())
+							 .arg(bestBridgeScore.toString()));
+				m_sketchWidget->createWire(terminal, bestEntry, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+				plannedSegments.append(connectorLine(terminal, bestEntry));
+				usedBridgeTargets.insert(bestEntry);
+				routeReservedHoles.insert(bestEntry);
+				created++;
+				wiredPeripheral++;
+
+				Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments)
+				{
+					if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
+						continue;
+					m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+					plannedSegments.append(connectorLine(segment.from, segment.to));
+					routeReservedHoles.insert(segment.from);
+					routeReservedHoles.insert(segment.to);
+					logAutoroute(QString("route bridge graph wire: net=%1 from=%2 to=%3 cost=%4")
+									 .arg(i)
+									 .arg(connectorSummary(segment.from))
+									 .arg(connectorSummary(segment.to))
+									 .arg(segment.cost));
+					created++;
+				}
+			}
+		}
+
+		if (groups.count() < 2)
+			continue;
+
+		while (groups.count() > 1)
+		{
+			int bestFromSubnet = -1;
+			int bestToSubnet = -1;
+			BreadboardRouteGraph::Result bestRoute;
+			BreadboardRoutingScore bestRoutingScore;
+			double bestTieBreak = std::numeric_limits<double>::max();
+			bool haveBestScore = false;
+			BreadboardRouteGraph routeGraph(routeHoles, routeReservedHoles, routeGraphOptions(plannedSegments));
+
+			for (int fromSubnet = 0; fromSubnet < groups.count(); fromSubnet++)
+			{
+				QList<ConnectorItem *> fromCandidates = groups.at(fromSubnet);
+				if (fromCandidates.isEmpty())
+					continue;
+
+				for (int toSubnet = fromSubnet + 1; toSubnet < groups.count(); toSubnet++)
+				{
+					QList<ConnectorItem *> toCandidates = groups.at(toSubnet);
+					if (toCandidates.isEmpty())
+						continue;
+
+					Q_FOREACH (ConnectorItem *fromCandidate, fromCandidates)
+					{
+						Q_FOREACH (ConnectorItem *toCandidate, toCandidates)
+						{
+							if (fromCandidate == nullptr || toCandidate == nullptr || fromCandidate == toCandidate)
+								continue;
+							BreadboardRouteGraph::Result route = routeGraph.route(fromCandidate, toCandidate);
+							if (!route.found)
+								continue;
+							const double tieBreak = routeScore(fromCandidate, toCandidate);
+							if (!haveBestScore || route.score < bestRoutingScore
+							    || (route.score == bestRoutingScore && tieBreak < bestTieBreak))
+							{
+								bestRoute = route;
+								bestRoutingScore = route.score;
+								bestTieBreak = tieBreak;
+								haveBestScore = true;
+								bestFromSubnet = fromSubnet;
+								bestToSubnet = toSubnet;
+							}
+						}
+					}
+				}
+			}
+
+			if (!bestRoute.found)
+			{
+				failedNetIndices.insert(i);
+				logAutoroute(QString("route graph failed: net=%1 groups=%2 buses=%3 edges=%4")
+								 .arg(i)
+								 .arg(groups.count())
+								 .arg(routeGraph.busCount())
+								 .arg(routeGraph.edgeCount()));
+				break;
+			}
+
+			logAutoroute(QString("route choose: net=%1 fromGroup=%2 toGroup=%3 segments=%4 score=%5")
+							 .arg(i)
+							 .arg(bestFromSubnet)
+							 .arg(bestToSubnet)
+							 .arg(bestRoute.segments.count())
+							 .arg(bestRoutingScore.toString()));
+			Q_FOREACH (const BreadboardRouteGraph::Segment &segment, bestRoute.segments)
+			{
+				if (segment.from == nullptr || segment.to == nullptr || segment.from == segment.to)
+					continue;
+				m_sketchWidget->createWire(segment.from, segment.to, generatedWireFlags(), false, BaseCommand::SingleView, parentCommand);
+				plannedSegments.append(connectorLine(segment.from, segment.to));
+				routeReservedHoles.insert(segment.from);
+				routeReservedHoles.insert(segment.to);
+				logAutoroute(QString("route graph wire: net=%1 from=%2 to=%3 cost=%4")
+								 .arg(i)
+								 .arg(connectorSummary(segment.from))
+								 .arg(connectorSummary(segment.to))
+								 .arg(segment.cost));
+				created++;
+			}
+
+			groups[bestFromSubnet].append(groups.at(bestToSubnet));
+			groups.removeAt(bestToSubnet);
+		}
+	}
+
+	double jumperLength = 0.0;
+	Q_FOREACH (const QLineF &segment, plannedSegments) jumperLength += segment.length();
+	m_lastRoutingScore.failedNets = failedNetIndices.count();
+	m_lastRoutingScore.jumperCount = created;
+	m_lastRoutingScore.jumperLength = jumperLength;
+	m_lastRoutingScore.componentLeadLength = m_componentLeadLength;
+	logAutoroute(QString("route counters: wiredPeripheral=%1 allocatedPeripheralLanes=%2 failedNets=%3")
+				 .arg(wiredPeripheral)
+				 .arg(allocatedPeripheralLanes)
+				 .arg(failedNetIndices.count()));
+	return created;
+}
+
+QList<QList<ConnectorItem *>> BreadboardAutorouter::collectCandidateGroups(const QList<ConnectorItem *> &candidates) const
+{
+	QList<QList<ConnectorItem *>> groups;
+	QList<ConnectorItem *> todo = candidates;
+
+	while (!todo.isEmpty())
+	{
+		ConnectorItem *first = todo.takeFirst();
+		if (first == nullptr)
+			continue;
+
+		QList<ConnectorItem *> equalPotential;
+		equalPotential.append(first);
+		ConnectorItem::collectEqualPotential(equalPotential, false, ViewGeometry::RatsnestFlag);
+
+		QList<ConnectorItem *> group;
+		Q_FOREACH (ConnectorItem *candidate, candidates)
+		{
+			if (candidate == nullptr)
+				continue;
+			if (!equalPotential.contains(candidate))
+				continue;
+			if (!group.contains(candidate))
+				group.append(candidate);
+			todo.removeOne(candidate);
+		}
+
+		if (!group.isEmpty())
+			groups.append(group);
+	}
+
+	return groups;
+}
+
+int BreadboardAutorouter::countUnresolvedNets() const
+{
+	int residualRatsnests = 0;
+	Q_FOREACH (QGraphicsItem *graphicsItem, m_sketchWidget->scene()->items())
+	{
+		auto *wire = dynamic_cast<Wire *>(graphicsItem);
+		if (wire == nullptr || !wire->getRatsnest()) continue;
+		residualRatsnests++;
+		ConnectorItem *from = wire->connector0() == nullptr ? nullptr : wire->connector0()->firstConnectedToIsh();
+		ConnectorItem *to = wire->connector1() == nullptr ? nullptr : wire->connector1()->firstConnectedToIsh();
+		logAutoroute(QString("validation residual ratsnest: %1 from=[%2] to=[%3]")
+					 .arg(itemSummary(wire))
+					 .arg(connectorSummary(from))
+					 .arg(connectorSummary(to)));
+	}
+	return residualRatsnests;
+}
+
+bool BreadboardAutorouter::isBreadboardItem(ItemBase *itemBase) const
+{
+	return BreadboardTopology::isBreadboardItem(itemBase);
+}
+
+bool BreadboardAutorouter::isBreadboardDecorationItem(ItemBase *itemBase) const
+{
+	return BreadboardTopology::isBreadboardDecorationItem(itemBase);
+}
+
+bool BreadboardAutorouter::isMovableBreadboardPart(ItemBase *itemBase) const
+{
+	BreadboardPartPolicy::Decision policy = BreadboardPartPolicy::classify(itemBase);
+	return policy.classification == BreadboardPartPolicy::Classification::BoardPlaceable;
+}
+
+bool BreadboardAutorouter::isPlaceablePin(ConnectorItem *connectorItem) const
+{
+	if (connectorItem == nullptr)
+		return false;
+	Connector::ConnectorType connectorType = connectorItem->connectorType();
+	return connectorType == Connector::Male || connectorType == Connector::Pad || connectorItem->isHybrid();
+}
+
+bool BreadboardAutorouter::isTargetBreadboardHole(ConnectorItem *connectorItem) const
+{
+	return BreadboardTopology::isTargetBreadboardHole(connectorItem);
+}
+
+bool BreadboardAutorouter::connectorsShareBreadboardBus(ConnectorItem *first, ConnectorItem *second) const
+{
+	return BreadboardTopology::connectorsShareBus(first, second);
+}
+
+QString BreadboardAutorouter::connectorSummary(ConnectorItem *connectorItem) const
+{
+	if (connectorItem == nullptr)
+		return QString("<null connector>");
+
+	QPointF p = connectorItem->sceneAdjustedTerminalPoint(nullptr);
+	return QString("%1:%2 type=%3 bus=%4 at=(%5,%6) conns=%7")
+		.arg(connectorItem->attachedToTitle())
+		.arg(connectorItem->connectorSharedID())
+		.arg(connectorItem->connectorType())
+		.arg(connectorItem->busID())
+		.arg(p.x())
+		.arg(p.y())
+		.arg(connectorItem->connectionsCount());
+}
+
+QString BreadboardAutorouter::itemSummary(ItemBase *itemBase) const
+{
+	if (itemBase == nullptr)
+		return QString("<null item>");
+
+	return QString("%1 id=%2 module=%3")
+		.arg(itemBase->title())
+		.arg(itemBase->id())
+		.arg(itemBase->moduleID());
+}
+
+QString BreadboardAutorouter::logFilePath() const
+{
+	QString dir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+	if (dir.isEmpty())
+		dir = QDir::tempPath();
+	return QDir(dir).filePath("fritzing-breadboard-autorouter.log");
+}
+
+void BreadboardAutorouter::logAutoroute(const QString &message) const
+{
+	QFile file(logFilePath());
+	if (!file.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text))
+		return;
+
+	QTextStream stream(&file);
+	stream << QDateTime::currentDateTime().toString(Qt::ISODateWithMs) << " " << message << '\n';
+}
+
+ConnectorItem *BreadboardAutorouter::connectedPartConnector(ConnectorItem *wireConnector) const
+{
+	if (wireConnector == nullptr)
+		return nullptr;
+
+	Q_FOREACH (ConnectorItem *connectorItem, wireConnector->connectedToItems())
+	{
+		if (connectorItem == nullptr)
+			continue;
+		ItemBase *itemBase = connectorItem->attachedTo();
+		if (itemBase == nullptr)
+			continue;
+		if (!itemBase->isEverVisible())
+			continue;
+		if (itemBase->getRatsnest())
+			continue;
+		if (connectorItem->attachedToItemType() == ModelPart::Wire)
+			continue;
+
+		return connectorItem;
+	}
+
+	return nullptr;
+}
+
+ConnectorItem *BreadboardAutorouter::connectedBreadboardHoleFor(ConnectorItem *partConnector) const
+{
+	if (partConnector == nullptr)
+		return nullptr;
+	if (partConnector->connectorType() == Connector::Female)
+		return partConnector;
+
+	Q_FOREACH (ConnectorItem *connectorItem, partConnector->connectedToItems())
+	{
+		if (connectorItem == nullptr)
+			continue;
+		ItemBase *itemBase = connectorItem->attachedTo();
+		if (itemBase == nullptr)
+			continue;
+		if (!itemBase->isEverVisible())
+			continue;
+		if (itemBase->getRatsnest())
+			continue;
+		if (connectorItem->attachedToItemType() == ModelPart::Wire)
+			continue;
+		if (connectorItem->connectorType() == Connector::Female)
+			return connectorItem;
+	}
+
+	return nullptr;
+}
+
+ConnectorItem *BreadboardAutorouter::breadboardHoleFor(ConnectorItem *partConnector) const
+{
+	if (partConnector == nullptr)
+		return nullptr;
+	if (partConnector->connectorType() == Connector::Female)
+	{
+		if (partConnector->connectionsCount() == 0)
+			return partConnector;
+		return nearestFreeBusHole(partConnector);
+	}
+
+	Q_FOREACH (ConnectorItem *connectorItem, partConnector->connectedToItems())
+	{
+		if (connectorItem == nullptr)
+			continue;
+		ItemBase *itemBase = connectorItem->attachedTo();
+		if (itemBase == nullptr)
+			continue;
+		if (!itemBase->isEverVisible())
+			continue;
+		if (itemBase->getRatsnest())
+			continue;
+		if (connectorItem->attachedToItemType() == ModelPart::Wire)
+			continue;
+		if (connectorItem->connectorType() != Connector::Female)
+			continue;
+
+		if (connectorItem->connectionsCount() == 0)
+			return connectorItem;
+
+		ConnectorItem *freeHole = nearestFreeBusHole(connectorItem);
+		if (freeHole != nullptr)
+			return freeHole;
+	}
+
+	return nullptr;
+}
+
+ConnectorItem *BreadboardAutorouter::nearestFreeBusHole(ConnectorItem *breadboardHole) const
+{
+	if (breadboardHole == nullptr)
+		return nullptr;
+
+	ItemBase *breadboard = breadboardHole->attachedTo();
+	if (breadboard == nullptr)
+		return nullptr;
+
+	QList<ConnectorItem *> busHoles;
+	if (!breadboard->busConnectorItems(breadboardHole, busHoles))
+		return nullptr;
+
+	ConnectorItem *nearest = nullptr;
+	double nearestDistance = 0;
+	QPointF from = breadboardHole->sceneAdjustedTerminalPoint(nullptr);
+
+	Q_FOREACH (ConnectorItem *candidate, busHoles)
+	{
+		if (candidate == nullptr)
+			continue;
+		if (candidate == breadboardHole)
+			continue;
+		if (candidate->connectorType() != Connector::Female)
+			continue;
+		if (candidate->connectionsCount() != 0)
+			continue;
+		if (!candidate->attachedTo()->isEverVisible())
+			continue;
+
+		QPointF to = candidate->sceneAdjustedTerminalPoint(nullptr);
+		double distance = QLineF(from, to).length();
+		if (nearest == nullptr || distance < nearestDistance)
+		{
+			nearest = candidate;
+			nearestDistance = distance;
+		}
+	}
+
+	return nearest;
+}
+
+ConnectorItem *BreadboardAutorouter::routingConnectorFor(ConnectorItem *wireConnector) const
+{
+	ConnectorItem *partConnector = connectedPartConnector(wireConnector);
+	ConnectorItem *breadboardHole = breadboardHoleFor(partConnector);
+	return breadboardHole == nullptr ? partConnector : breadboardHole;
+}
+
+QList<QList<ConnectorItem *>> BreadboardAutorouter::collectRoutableSubnets(QList<ConnectorItem *> *net) const
+{
+	QList<QList<ConnectorItem *>> subnets;
+	if (net == nullptr)
+		return subnets;
+
+	QList<ConnectorItem *> todo = *net;
+	while (!todo.isEmpty())
+	{
+		ConnectorItem *first = todo.takeFirst();
+		QList<ConnectorItem *> subnet;
+		subnet.append(first);
+
+		ConnectorItem::collectEqualPotential(subnet, false, ViewGeometry::RatsnestFlag);
+		Q_FOREACH (ConnectorItem *connectorItem, subnet)
+		{
+			todo.removeOne(connectorItem);
+		}
+
+		ConnectorItem *representative = chooseRepresentative(subnet);
+		if (representative != nullptr)
+		{
+			subnets.append(subnet);
+		}
+	}
+
+	return subnets;
+}
+
+QList<ConnectorItem *> BreadboardAutorouter::routingCandidatesForSubnet(const QList<ConnectorItem *> &subnet) const
+{
+	QList<ConnectorItem *> candidates;
+
+	Q_FOREACH (ConnectorItem *connectorItem, subnet)
+	{
+		if (connectorItem == nullptr)
+			continue;
+		ItemBase *itemBase = connectorItem->attachedTo();
+		if (itemBase == nullptr)
+			continue;
+		if (!itemBase->isEverVisible())
+			continue;
+		if (itemBase->getRatsnest())
+			continue;
+		if (connectorItem->attachedToItemType() == ModelPart::Wire)
+			continue;
+
+		ConnectorItem *breadboardHole = breadboardHoleFor(connectorItem);
+		if (breadboardHole == nullptr)
+		{
+			logAutoroute(QString("route candidate skipped off-board terminal: %1").arg(connectorSummary(connectorItem)));
+			continue;
+		}
+		if (!candidates.contains(breadboardHole))
+			candidates.append(breadboardHole);
+	}
+
+	return candidates;
+}
+
+ConnectorItem *BreadboardAutorouter::chooseRepresentative(const QList<ConnectorItem *> &subnet) const
+{
+	QList<ConnectorItem *> candidates = routingCandidatesForSubnet(subnet);
+	return candidates.isEmpty() ? nullptr : candidates.first();
+}
+
+double BreadboardAutorouter::partConnectivityScore(ItemBase *part, const QHash<ConnectorItem *, int> &netForConnector, const QHash<int, QList<ConnectorItem *>> &connectorsForNet) const
+{
+	if (part == nullptr)
+		return 0;
+
+	QSet<int> seenNets;
+	double score = 0;
+	Q_FOREACH (ConnectorItem *connectorItem, part->cachedConnectorItems())
+	{
+		if (connectorItem == nullptr)
+			continue;
+		if (!isPlaceablePin(connectorItem))
+			continue;
+
+		int netIndex = netForConnector.value(connectorItem, -1);
+		if (netIndex < 0 || seenNets.contains(netIndex))
+			continue;
+		seenNets.insert(netIndex);
+
+		int visiblePinsInNet = 0;
+		Q_FOREACH (ConnectorItem *netConnector, connectorsForNet.value(netIndex))
+		{
+			if (netConnector == nullptr)
+				continue;
+			ItemBase *itemBase = netConnector->attachedTo();
+			if (itemBase == nullptr)
+				continue;
+			if (!itemBase->isEverVisible())
+				continue;
+			if (itemBase->getRatsnest())
+				continue;
+			if (netConnector->attachedToItemType() == ModelPart::Wire)
+				continue;
+			visiblePinsInNet++;
+		}
+
+		score += qMax(1, visiblePinsInNet);
+	}
+
+	return score;
+}
+
+double BreadboardAutorouter::routeScore(ConnectorItem *from, ConnectorItem *to) const
+{
+	if (from == nullptr || to == nullptr)
+		return std::numeric_limits<double>::max();
+
+	QPointF fromPos = from->sceneAdjustedTerminalPoint(nullptr);
+	QPointF toPos = to->sceneAdjustedTerminalPoint(nullptr);
+	double score = qAbs(fromPos.x() - toPos.x()) + qAbs(fromPos.y() - toPos.y());
+
+	bool fromBreadboard = from->connectorType() == Connector::Female;
+	bool toBreadboard = to->connectorType() == Connector::Female;
+	if (fromBreadboard && toBreadboard)
+		score *= 0.5;
+	else if (!fromBreadboard && !toBreadboard)
+		score *= 4.0;
+
+	return score;
+}
+
+void BreadboardAutorouter::clearCollectedNets()
+{
+	qDeleteAll(m_allPartConnectorItems);
+	m_allPartConnectorItems.clear();
+}

--- a/src/autoroute/breadboardautorouter.cpp
+++ b/src/autoroute/breadboardautorouter.cpp
@@ -44,7 +44,9 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QElapsedTimer>
 #include <QUndoCommand>
 #include <algorithm>
+#include <array>
 #include <limits>
+#include <numeric>
 
 #include "../commands.h"
 #include "../items/itembase.h"
@@ -330,8 +332,10 @@ namespace
 			if (!bounds.valid)
 			{
 				bounds.valid = true;
-				bounds.minX = bounds.maxX = point.x();
-				bounds.minY = bounds.maxY = point.y();
+				bounds.minX = point.x();
+				bounds.maxX = point.x();
+				bounds.minY = point.y();
+				bounds.maxY = point.y();
 				continue;
 			}
 			bounds.minX = qMin(bounds.minX, point.x());
@@ -944,7 +948,7 @@ struct BreadboardAutorouter::PlacementPass
 	{
 		for (int netIndex = 0; netIndex < self->m_allPartConnectorItems.count(); netIndex++)
 		{
-			QList<ConnectorItem *> *net = self->m_allPartConnectorItems.at(netIndex);
+			const QList<ConnectorItem *> *net = self->m_allPartConnectorItems.at(netIndex);
 			if (net == nullptr)
 				continue;
 			Q_FOREACH (ConnectorItem *connectorItem, *net)
@@ -1657,7 +1661,7 @@ struct BreadboardAutorouter::PlacementPass
 								+ (candidate.firstHolePos.y() - baseFirstPin.y()) * candidate.pinAxisDir.y();
 		const double secondAxial = (candidate.secondHolePos.x() - baseSecondPin.x()) * candidate.pinAxisDir.x()
 								 + (candidate.secondHolePos.y() - baseSecondPin.y()) * candidate.pinAxisDir.y();
-		const double axialShifts[] = {(firstAxial + secondAxial) / 2.0, firstAxial, secondAxial};
+		const std::array<double, 3> axialShifts = {(firstAxial + secondAxial) / 2.0, firstAxial, secondAxial};
 		for (double axialShift : axialShifts)
 		{
 			profile.shiftIterations++;
@@ -1703,9 +1707,9 @@ struct BreadboardAutorouter::PlacementPass
 			qAbs(unflippedSecondPinPos.x() - unflippedFirstPinPos.x())
 			>= qAbs(unflippedSecondPinPos.y() - unflippedFirstPinPos.y());
 		const Qt::Orientations flipOrientation = axisMostlyHorizontal ? Qt::Horizontal : Qt::Vertical;
-		const PinSwap swapMode = part->canFlip(flipOrientation)
-			? (axisMostlyHorizontal ? PinSwap::FlipHorizontal : PinSwap::FlipVertical)
-			: PinSwap::Rotate180;
+		PinSwap swapMode = PinSwap::Rotate180;
+		if (part->canFlip(flipOrientation))
+			swapMode = axisMostlyHorizontal ? PinSwap::FlipHorizontal : PinSwap::FlipVertical;
 
 		for (int flip = 0; flip <= 1; flip++)
 		{
@@ -2351,7 +2355,7 @@ struct BreadboardAutorouter::NetRoutingPass
 		QHash<int, double> difficultyForNet;
 		Q_FOREACH (int index, routeOrder)
 		{
-			QList<ConnectorItem *> *net = self->m_allPartConnectorItems.value(index);
+			const QList<ConnectorItem *> *net = self->m_allPartConnectorItems.value(index);
 			if (net == nullptr)
 			{
 				difficultyForNet.insert(index, 0.0);
@@ -2395,8 +2399,7 @@ struct BreadboardAutorouter::NetRoutingPass
 			if (!self->isPlaceablePin(connectorItem) && connectorItem->connectorType() != Connector::Female)
 				continue;
 
-			ConnectorItem *connectedHole = self->connectedBreadboardHoleFor(connectorItem);
-			if (connectedHole != nullptr)
+			if (ConnectorItem *connectedHole = self->connectedBreadboardHoleFor(connectorItem); connectedHole != nullptr)
 			{
 				if (!breadboardAnchors.contains(connectedHole))
 					breadboardAnchors.append(connectedHole);
@@ -2741,7 +2744,7 @@ struct BreadboardAutorouter::NetRoutingPass
 
 	// Route one net: log its electrical groups, split terminals into
 	// anchors and off-board peripherals, then run the three wiring phases.
-	void routeNet(int index, QList<ConnectorItem *> *net)
+	void routeNet(int index, const QList<ConnectorItem *> *net)
 	{
 		netIndex = index;
 		const QList<ConnectorItem *> candidates = self->routingCandidatesForSubnet(*net);
@@ -2805,7 +2808,7 @@ int BreadboardAutorouter::routeCollectedNets(QUndoCommand *parentCommand)
 						   + ((RoutingProgressEnd - PlacementProgressSpan) * orderIndex) / qMax(1, routeOrder.count()),
 					   QObject::tr("Routing net %1 of %2...").arg(orderIndex + 1).arg(routeOrder.count()));
 		const int netIndex = routeOrder.at(orderIndex);
-		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
+		const QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
 		if (net == nullptr)
 			continue;
 		pass.routeNet(netIndex, net);
@@ -2825,7 +2828,7 @@ QList<QList<ConnectorItem *>> BreadboardAutorouter::collectCandidateGroups(const
 	}
 
 	QVector<int> parents(validCandidates.count());
-	for (int i = 0; i < parents.count(); i++) parents[i] = i;
+	std::iota(parents.begin(), parents.end(), 0);
 	auto findRoot = [&parents](int value) {
 		int root = value;
 		while (parents[root] != root) root = parents[root];
@@ -2948,15 +2951,13 @@ bool BreadboardAutorouter::connectorsShareBreadboardBus(ConnectorItem *first, Co
 
 int BreadboardAutorouter::busGroupFor(ConnectorItem *connectorItem) const
 {
-	auto found = m_busGroupForConnector.constFind(connectorItem);
-	if (found != m_busGroupForConnector.constEnd())
+	if (auto found = m_busGroupForConnector.constFind(connectorItem); found != m_busGroupForConnector.constEnd())
 		return found.value();
 
 	const int groupId = m_busGroupCount++;
 	m_busGroupForConnector.insert(connectorItem, groupId);
 	ItemBase *item = connectorItem->attachedTo();
-	QList<ConnectorItem *> busSiblings;
-	if (item != nullptr && item->busConnectorItems(connectorItem, busSiblings))
+	if (QList<ConnectorItem *> busSiblings; item != nullptr && item->busConnectorItems(connectorItem, busSiblings))
 	{
 		Q_FOREACH (ConnectorItem *sibling, busSiblings)
 		{
@@ -3027,7 +3028,7 @@ void BreadboardAutorouter::seedBusOwnership()
 	m_netForConnector.clear();
 	for (int netIndex = 0; netIndex < m_allPartConnectorItems.count(); netIndex++)
 	{
-		QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
+		const QList<ConnectorItem *> *net = m_allPartConnectorItems.at(netIndex);
 		if (net == nullptr)
 			continue;
 		Q_FOREACH (ConnectorItem *connectorItem, *net)
@@ -3404,7 +3405,7 @@ ConnectorItem *BreadboardAutorouter::routingConnectorFor(ConnectorItem *wireConn
 	return breadboardHole == nullptr ? partConnector : breadboardHole;
 }
 
-QList<QList<ConnectorItem *>> BreadboardAutorouter::collectRoutableSubnets(QList<ConnectorItem *> *net) const
+QList<QList<ConnectorItem *>> BreadboardAutorouter::collectRoutableSubnets(const QList<ConnectorItem *> *net) const
 {
 	QList<QList<ConnectorItem *>> subnets;
 	if (net == nullptr)
@@ -3531,9 +3532,8 @@ double BreadboardAutorouter::routeScore(ConnectorItem *from, ConnectorItem *to) 
 	QPointF toPos = to->sceneAdjustedTerminalPoint(nullptr);
 	double score = qAbs(fromPos.x() - toPos.x()) + qAbs(fromPos.y() - toPos.y());
 
-	bool fromBreadboard = from->connectorType() == Connector::Female;
-	bool toBreadboard = to->connectorType() == Connector::Female;
-	if (fromBreadboard && toBreadboard)
+	const bool fromBreadboard = from->connectorType() == Connector::Female;
+	if (const bool toBreadboard = to->connectorType() == Connector::Female; fromBreadboard && toBreadboard)
 		score *= 0.5;
 	else if (!fromBreadboard && !toBreadboard)
 		score *= 4.0;

--- a/src/autoroute/breadboardautorouter.h
+++ b/src/autoroute/breadboardautorouter.h
@@ -1,0 +1,88 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#ifndef BREADBOARDAUTOROUTER_H
+#define BREADBOARDAUTOROUTER_H
+
+#include <QObject>
+#include <QList>
+
+#include "../viewgeometry.h"
+#include "../connectors/connectoritem.h"
+#include "breadboardroutingscore.h"
+
+class BreadboardSketchWidget;
+class ItemBase;
+class QUndoCommand;
+
+class BreadboardAutorouter : public QObject
+{
+	Q_OBJECT
+
+public:
+	explicit BreadboardAutorouter(BreadboardSketchWidget * sketchWidget);
+	~BreadboardAutorouter() override;
+
+	void start();
+
+Q_SIGNALS:
+	void setMaximumProgress(int);
+	void setProgressValue(int);
+	void setProgressMessage(const QString &);
+	void setProgressMessage2(const QString &);
+
+private:
+	int clearPreviousAutorouteWires();
+	int autoplacePartsOnBreadboard();
+	int routeCollectedNets(QUndoCommand * parentCommand);
+	int routeRatsnestDemands(QUndoCommand * parentCommand);
+	QList< QList<ConnectorItem *> > collectCandidateGroups(const QList<ConnectorItem *> & candidates) const;
+	bool isBreadboardItem(ItemBase * itemBase) const;
+	bool isBreadboardDecorationItem(ItemBase * itemBase) const;
+	bool isMovableBreadboardPart(ItemBase * itemBase) const;
+	bool isPlaceablePin(ConnectorItem * connectorItem) const;
+	bool isTargetBreadboardHole(ConnectorItem * connectorItem) const;
+	bool connectorsShareBreadboardBus(ConnectorItem * first, ConnectorItem * second) const;
+	QString connectorSummary(ConnectorItem * connectorItem) const;
+	QString itemSummary(ItemBase * itemBase) const;
+	QString logFilePath() const;
+	void logAutoroute(const QString & message) const;
+	ConnectorItem * connectedPartConnector(ConnectorItem * wireConnector) const;
+	ConnectorItem * connectedBreadboardHoleFor(ConnectorItem * partConnector) const;
+	ConnectorItem * breadboardHoleFor(ConnectorItem * partConnector) const;
+	ConnectorItem * nearestFreeBusHole(ConnectorItem * breadboardHole) const;
+	ConnectorItem * routingConnectorFor(ConnectorItem * wireConnector) const;
+	QList< QList<ConnectorItem *> > collectRoutableSubnets(QList<ConnectorItem *> * net) const;
+	QList<ConnectorItem *> routingCandidatesForSubnet(const QList<ConnectorItem *> & subnet) const;
+	ConnectorItem * chooseRepresentative(const QList<ConnectorItem *> & subnet) const;
+	double partConnectivityScore(ItemBase * part, const QHash<ConnectorItem *, int> & netForConnector, const QHash<int, QList<ConnectorItem *> > & connectorsForNet) const;
+	double routeScore(ConnectorItem * from, ConnectorItem * to) const;
+	int countUnresolvedNets() const;
+	void clearCollectedNets();
+
+private:
+	BreadboardSketchWidget * m_sketchWidget = nullptr;
+	QList< QList<ConnectorItem *> * > m_allPartConnectorItems;
+	QString m_lastPlacementReport;
+	BreadboardRoutingScore m_lastRoutingScore;
+	double m_componentLeadLength = 0.0;
+};
+
+#endif

--- a/src/autoroute/breadboardautorouter.h
+++ b/src/autoroute/breadboardautorouter.h
@@ -22,7 +22,11 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #define BREADBOARDAUTOROUTER_H
 
 #include <QObject>
+#include <QElapsedTimer>
+#include <QHash>
 #include <QList>
+#include <QPair>
+#include <QStringList>
 
 #include "../viewgeometry.h"
 #include "../connectors/connectoritem.h"
@@ -49,8 +53,19 @@ Q_SIGNALS:
 	void setProgressMessage2(const QString &);
 
 private:
+	// Defined in the .cpp: carries the state shared across one net-routing
+	// pass so the per-net phases can live in named functions instead of one
+	// monolithic loop body. Nested so it can use the router's private
+	// helpers without widening the public surface.
+	struct NetRoutingPass;
+	// Same pattern for part placement: board topology, hole caches, planning
+	// state and rejection counters shared by the placement phases (movable
+	// part collection, rigid/bendable candidate search, commit, verify).
+	struct PlacementPass;
+
 	int clearPreviousAutorouteWires();
 	int autoplacePartsOnBreadboard();
+	bool verifyPlacedConnections(const QHash<ConnectorItem *, ConnectorItem *> &placedTargets, QStringList &failures) const;
 	int routeCollectedNets(QUndoCommand * parentCommand);
 	int routeRatsnestDemands(QUndoCommand * parentCommand);
 	QList< QList<ConnectorItem *> > collectCandidateGroups(const QList<ConnectorItem *> & candidates) const;
@@ -60,10 +75,26 @@ private:
 	bool isPlaceablePin(ConnectorItem * connectorItem) const;
 	bool isTargetBreadboardHole(ConnectorItem * connectorItem) const;
 	bool connectorsShareBreadboardBus(ConnectorItem * first, ConnectorItem * second) const;
+	int busGroupFor(ConnectorItem * connectorItem) const;
+	const QList<QPair<ConnectorItem *, ConnectorItem *> > & normalBreadboardWireEnds() const;
+	void invalidateRoutingCaches();
+
+	// Bus ownership: the mechanism behind the prime invariant. Every bus is
+	// free (-1) or owned by exactly one key; keys are net indices (>= 0) or
+	// unique negative sentinels claimed by no-net pins (e.g. unused DIP
+	// outputs, which are still real outputs and must never join a net).
+	int busOwner(int busGroup) const;
+	bool busAvailableFor(int busGroup, int ownerKey) const;
+	void claimBus(int busGroup, int ownerKey);
+	int makeNoNetOwnerKey();
+	int ownerKeyForPin(ConnectorItem * pin) const;
+	void seedBusOwnership();
+	bool verifySchematicConformance(QStringList & violations, bool recordBaseline = false);
 	QString connectorSummary(ConnectorItem * connectorItem) const;
 	QString itemSummary(ItemBase * itemBase) const;
 	QString logFilePath() const;
 	void logAutoroute(const QString & message) const;
+	void flushAutorouteLog() const;
 	ConnectorItem * connectedPartConnector(ConnectorItem * wireConnector) const;
 	ConnectorItem * connectedBreadboardHoleFor(ConnectorItem * partConnector) const;
 	ConnectorItem * breadboardHoleFor(ConnectorItem * partConnector) const;
@@ -76,6 +107,25 @@ private:
 	double routeScore(ConnectorItem * from, ConnectorItem * to) const;
 	int countUnresolvedNets() const;
 	void clearCollectedNets();
+	void sortCollectedNets();
+	void reportProgress(int percent, const QString & detail);
+	void loadTuning();
+
+	// Wall-clock per pipeline phase, reset each start(); logged as one
+	// greppable phase-summary line so critical paths are comparable per
+	// sketch and across builds.
+	struct PhaseStats
+	{
+		qint64 clearMs = 0;
+		qint64 collectMs = 0;
+		qint64 placeSearchMs = 0;
+		qint64 placeExecMs = 0;
+		qint64 routeSearchMs = 0;
+		qint64 routeExecMs = 0;
+		qint64 completionMs = 0;
+		qint64 cleanupMs = 0;
+		QString toString() const;
+	};
 
 private:
 	BreadboardSketchWidget * m_sketchWidget = nullptr;
@@ -83,6 +133,33 @@ private:
 	QString m_lastPlacementReport;
 	BreadboardRoutingScore m_lastRoutingScore;
 	double m_componentLeadLength = 0.0;
+
+	// Placement tuning weights, read from QSettings at every start() so the
+	// toolbar sliders take effect without restarting. Defaults live here.
+	PhaseStats m_phaseStats;
+
+	// Per-run memoization: bus membership never changes during an autoroute,
+	// and BreadboardTopology::connectorsShareBus rebuilds bus lists per call
+	// (dominant cost of route search pre-Stage-1). Cleared in start() and
+	// whenever pushed commands change scene wires.
+	mutable QHash<ConnectorItem *, int> m_busGroupForConnector;
+	mutable int m_busGroupCount = 0;
+	QHash<int, int> m_busOwnerForGroup;      // busGroup -> ownerKey, absent = free
+	QHash<ConnectorItem *, int> m_netForConnector;   // schematic net index per part pin
+	int m_nextNoNetOwnerKey = -2;
+	QSet<QPair<int, int> > m_preExistingNetContacts; // net pairs already touching before we run
+	// Log lines are buffered and flushed at phase boundaries: opening and
+	// closing the file per line dominated route-search time on large boards.
+	mutable QStringList m_logBuffer;
+	QElapsedTimer m_progressPumpTimer;
+	mutable bool m_wireEndsCacheValid = false;
+	mutable QList<QPair<ConnectorItem *, ConnectorItem *> > m_normalBreadboardWireEnds;
+
+	double m_maxLegLength = 120.0;
+	double m_leadLengthWeight = 1.0;
+	double m_jumperPenalty = 100000.0;
+	double m_leadAngleWeight = 4.0;
+	double m_foldbackWeight = 6.0;
 };
 
 #endif

--- a/src/autoroute/breadboardautorouter.h
+++ b/src/autoroute/breadboardautorouter.h
@@ -100,7 +100,7 @@ private:
 	ConnectorItem * breadboardHoleFor(ConnectorItem * partConnector) const;
 	ConnectorItem * nearestFreeBusHole(ConnectorItem * breadboardHole) const;
 	ConnectorItem * routingConnectorFor(ConnectorItem * wireConnector) const;
-	QList< QList<ConnectorItem *> > collectRoutableSubnets(QList<ConnectorItem *> * net) const;
+	QList< QList<ConnectorItem *> > collectRoutableSubnets(const QList<ConnectorItem *> * net) const;
 	QList<ConnectorItem *> routingCandidatesForSubnet(const QList<ConnectorItem *> & subnet) const;
 	ConnectorItem * chooseRepresentative(const QList<ConnectorItem *> & subnet) const;
 	double partConnectivityScore(ItemBase * part, const QHash<ConnectorItem *, int> & netForConnector, const QHash<int, QList<ConnectorItem *> > & connectorsForNet) const;

--- a/src/autoroute/breadboardpartpolicy.cpp
+++ b/src/autoroute/breadboardpartpolicy.cpp
@@ -86,8 +86,13 @@ BreadboardPartPolicy::Decision BreadboardPartPolicy::classify(ItemBase * itemBas
 		return decision;
 	}
 
+	int femaleSockets = 0;
 	Q_FOREACH (ConnectorItem * connectorItem, itemBase->cachedConnectorItems()) {
 		if (connectorItem == nullptr) continue;
+		if (connectorItem->connectorType() == Connector::Female) {
+			femaleSockets++;
+			continue;
+		}
 		if (!isPlaceablePin(connectorItem)) continue;
 		decision.placeablePins++;
 		if (connectorItem->hasRubberBandLeg() || !connectorItem->legID(itemBase->viewID(), itemBase->viewLayerID()).isEmpty()) {
@@ -96,6 +101,17 @@ BreadboardPartPolicy::Decision BreadboardPartPolicy::classify(ItemBase * itemBas
 	}
 
 	if (decision.placeablePins <= 0) {
+		if (femaleSockets > 0) {
+			// Breakout boards and socketed modules with female headers: never
+			// seated into a breadboard, but their sockets are legitimate wire
+			// terminals - jumper them from off-board, like all breakouts.
+			// (Future exception per user: dual-row male headers at breadboard
+			// pitch could seat like a DIP; that variant has placeable pins
+			// and does not reach this branch.)
+			decision.classification = Classification::Peripheral;
+			decision.reason = "female-socket breakout (jumper wiring only)";
+			return decision;
+		}
 		decision.reason = "no placeable pins";
 		return decision;
 	}

--- a/src/autoroute/breadboardpartpolicy.cpp
+++ b/src/autoroute/breadboardpartpolicy.cpp
@@ -1,0 +1,153 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#include "breadboardpartpolicy.h"
+#include "breadboardtopology.h"
+
+#include "../connectors/connectoritem.h"
+#include "../items/itembase.h"
+#include "../model/modelpart.h"
+
+#include <QStringList>
+
+namespace {
+bool containsAny(const QString & text, const QStringList & needles)
+{
+	Q_FOREACH (const QString & needle, needles) {
+		if (text.contains(needle, Qt::CaseInsensitive)) return true;
+	}
+	return false;
+}
+
+bool isPlaceablePin(ConnectorItem * connectorItem)
+{
+	if (connectorItem == nullptr) return false;
+	Connector::ConnectorType connectorType = connectorItem->connectorType();
+	return connectorType == Connector::Male || connectorType == Connector::Pad || connectorItem->isHybrid();
+}
+}
+
+BreadboardPartPolicy::Decision BreadboardPartPolicy::classify(ItemBase * itemBase)
+{
+	Decision decision;
+	if (itemBase == nullptr) {
+		decision.reason = "null item";
+		return decision;
+	}
+
+	ModelPart * modelPart = itemBase->modelPart();
+	decision.title = itemBase->title();
+	decision.moduleID = itemBase->moduleID();
+	if (modelPart != nullptr) {
+		decision.family = modelPart->family();
+		decision.taxonomy = modelPart->taxonomy();
+		decision.package = modelPart->properties().value("package");
+	}
+
+	if (!itemBase->isEverVisible()) {
+		decision.reason = "not visible";
+		return decision;
+	}
+	if (itemBase->getRatsnest()) {
+		decision.reason = "ratsnest";
+		return decision;
+	}
+	if (BreadboardTopology::isBreadboardItem(itemBase)) {
+		decision.reason = "breadboard";
+		return decision;
+	}
+	if (BreadboardTopology::isBreadboardDecorationItem(itemBase)) {
+		decision.reason = "breadboard decoration";
+		return decision;
+	}
+	if (itemBase->itemType() == ModelPart::Wire) {
+		decision.reason = "wire";
+		return decision;
+	}
+	if (itemBase->moveLock()) {
+		decision.reason = "move locked";
+		return decision;
+	}
+
+	Q_FOREACH (ConnectorItem * connectorItem, itemBase->cachedConnectorItems()) {
+		if (connectorItem == nullptr) continue;
+		if (!isPlaceablePin(connectorItem)) continue;
+		decision.placeablePins++;
+		if (connectorItem->hasRubberBandLeg() || !connectorItem->legID(itemBase->viewID(), itemBase->viewLayerID()).isEmpty()) {
+			decision.hasBendableLegs = true;
+		}
+	}
+
+	if (decision.placeablePins <= 0) {
+		decision.reason = "no placeable pins";
+		return decision;
+	}
+
+	const QString descriptiveText = QString("%1 %2 %3 %4")
+	        .arg(decision.title)
+	        .arg(decision.family)
+	        .arg(decision.taxonomy)
+	        .arg(decision.package);
+	const QString searchable = QString("%1 %2").arg(descriptiveText).arg(decision.moduleID);
+
+	const bool looksLikeTrimpot = containsAny(searchable, {"trimpot", "trim pot", "trimmer", "preset"});
+	if (descriptiveText.contains("potentiometer", Qt::CaseInsensitive) && !looksLikeTrimpot) {
+		decision.classification = Classification::Peripheral;
+		decision.reason = "panel/control potentiometer";
+		return decision;
+	}
+
+	if (containsAny(descriptiveText, {"audio jack", " jack", "connector", "terminal", "switch", "button", "keypad"})) {
+		decision.classification = Classification::Peripheral;
+		decision.reason = "interface/control part";
+		return decision;
+	}
+
+	if (containsAny(descriptiveText, {"power", "battery", "supply", "module", "breakout", "board", "sensor", "arduino"})) {
+		decision.classification = Classification::Peripheral;
+		decision.reason = "module/power/peripheral part";
+		return decision;
+	}
+
+	if (containsAny(searchable, {"resistor", "capacitor", "diode", "led", "transistor", "ic", "dip", "header"})
+	    || decision.hasBendableLegs
+	    || looksLikeTrimpot) {
+		decision.classification = Classification::BoardPlaceable;
+		decision.reason = "breadboard-suitable component";
+		return decision;
+	}
+
+	decision.classification = Classification::Peripheral;
+	decision.reason = "not known breadboard-placeable";
+	return decision;
+}
+
+QString BreadboardPartPolicy::classificationName(Classification classification)
+{
+	switch (classification) {
+	case Classification::BoardPlaceable:
+		return "BoardPlaceable";
+	case Classification::Peripheral:
+		return "Peripheral";
+	case Classification::Ignore:
+	default:
+		return "Ignore";
+	}
+}

--- a/src/autoroute/breadboardpartpolicy.h
+++ b/src/autoroute/breadboardpartpolicy.h
@@ -1,0 +1,53 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#ifndef BREADBOARDPARTPOLICY_H
+#define BREADBOARDPARTPOLICY_H
+
+#include <QString>
+
+class ItemBase;
+
+class BreadboardPartPolicy
+{
+public:
+	enum class Classification {
+		BoardPlaceable,
+		Peripheral,
+		Ignore
+	};
+
+	struct Decision {
+		Classification classification = Classification::Ignore;
+		QString reason;
+		QString family;
+		QString taxonomy;
+		QString package;
+		QString moduleID;
+		QString title;
+		int placeablePins = 0;
+		bool hasBendableLegs = false;
+	};
+
+	static Decision classify(ItemBase * itemBase);
+	static QString classificationName(Classification classification);
+};
+
+#endif

--- a/src/autoroute/breadboardplacementkernel.cpp
+++ b/src/autoroute/breadboardplacementkernel.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2026 Fritzing contributors
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+********************************************************************/
+
+#include "breadboardplacementkernel.h"
+
+#include <QtMath>
+#include <algorithm>
+
+namespace BreadboardPlacementKernel
+{
+
+HoleSpatialIndex::HoleSpatialIndex(const QVector<QPointF> &positions, const QVector<int> &boardIds, double cellSize)
+	: m_positions(positions),
+	  m_boardIds(boardIds),
+	  m_cellSize(qMax(1.0, cellSize))
+{
+	if (m_boardIds.count() != m_positions.count())
+		m_boardIds.fill(-1, m_positions.count());
+
+	for (int index = 0; index < m_positions.count(); index++)
+	{
+		const QPointF &position = m_positions.at(index);
+		m_cells[cellKey(cellCoordinate(position.x()), cellCoordinate(position.y()))].append(index);
+	}
+}
+
+QVector<int> HoleSpatialIndex::withinRadius(const QPointF &center, double radius, int boardId) const
+{
+	QVector<int> result;
+	if (radius < 0.0 || m_positions.isEmpty())
+		return result;
+
+	const int minX = cellCoordinate(center.x() - radius);
+	const int maxX = cellCoordinate(center.x() + radius);
+	const int minY = cellCoordinate(center.y() - radius);
+	const int maxY = cellCoordinate(center.y() + radius);
+	const double radiusSquared = radius * radius;
+
+	for (int cellY = minY; cellY <= maxY; cellY++)
+	{
+		for (int cellX = minX; cellX <= maxX; cellX++)
+		{
+			const auto found = m_cells.constFind(cellKey(cellX, cellY));
+			if (found == m_cells.constEnd())
+				continue;
+			for (int index : found.value())
+			{
+				if (boardId >= 0 && m_boardIds.at(index) != boardId)
+					continue;
+				const QPointF delta = m_positions.at(index) - center;
+				if (delta.x() * delta.x() + delta.y() * delta.y() <= radiusSquared)
+					result.append(index);
+			}
+		}
+	}
+
+	std::sort(result.begin(), result.end());
+	return result;
+}
+
+bool HoleSpatialIndex::isEmpty() const
+{
+	return m_positions.isEmpty();
+}
+
+quint64 HoleSpatialIndex::cellKey(int x, int y)
+{
+	return (quint64(quint32(x)) << 32) | quint32(y);
+}
+
+int HoleSpatialIndex::cellCoordinate(double coordinate) const
+{
+	return qFloor(coordinate / m_cellSize);
+}
+
+}

--- a/src/autoroute/breadboardplacementkernel.h
+++ b/src/autoroute/breadboardplacementkernel.h
@@ -1,0 +1,47 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2026 Fritzing contributors
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+********************************************************************/
+
+#ifndef BREADBOARDPLACEMENTKERNEL_H
+#define BREADBOARDPLACEMENTKERNEL_H
+
+#include <QHash>
+#include <QPointF>
+#include <QVector>
+
+namespace BreadboardPlacementKernel
+{
+
+// Uniform-grid index over immutable breadboard-hole positions. Queries return
+// original indices in ascending order, so replacing a brute-force scan cannot
+// change candidate tie-breaking or make results depend on hash iteration.
+class HoleSpatialIndex
+{
+public:
+	HoleSpatialIndex() = default;
+	HoleSpatialIndex(const QVector<QPointF> &positions, const QVector<int> &boardIds, double cellSize);
+
+	QVector<int> withinRadius(const QPointF &center, double radius, int boardId = -1) const;
+	bool isEmpty() const;
+
+private:
+	static quint64 cellKey(int x, int y);
+	int cellCoordinate(double coordinate) const;
+
+	QVector<QPointF> m_positions;
+	QVector<int> m_boardIds;
+	QHash<quint64, QVector<int>> m_cells;
+	double m_cellSize = 1.0;
+};
+
+}
+
+#endif

--- a/src/autoroute/breadboardroutegraph.cpp
+++ b/src/autoroute/breadboardroutegraph.cpp
@@ -92,8 +92,7 @@ BreadboardRouteGraph::Result BreadboardRouteGraph::route(ConnectorItem * start, 
 			}
 		}
 
-		if (currentBus.isEmpty()) break;
-		if (currentBus == targetBus) break;
+		if (currentBus.isEmpty() || currentBus == targetBus) break;
 		settled.insert(currentBus);
 
 		Q_FOREACH (const Edge & edge, m_edgesByBus.value(currentBus)) {
@@ -139,8 +138,7 @@ BreadboardRouteGraph::Result BreadboardRouteGraph::route(ConnectorItem * start, 
 QString BreadboardRouteGraph::busId(ConnectorItem * connectorItem) const
 {
 	if (connectorItem == nullptr) return QString();
-	QString id = connectorItem->busID();
-	if (!id.isEmpty()) return id;
+	if (QString id = connectorItem->busID(); !id.isEmpty()) return id;
 	return fallbackBusId(connectorItem);
 }
 
@@ -227,7 +225,7 @@ bool BreadboardRouteGraph::edgeAvailable(const Edge & edge, ConnectorItem * star
 	    && holeAvailable(edge.toHole, start, target);
 }
 
-bool BreadboardRouteGraph::holeAvailable(ConnectorItem * hole, ConnectorItem * start, ConnectorItem * target) const
+bool BreadboardRouteGraph::holeAvailable(ConnectorItem * hole, const ConnectorItem * start, const ConnectorItem * target) const
 {
 	if (hole == nullptr) return false;
 	if (hole == start || hole == target) return true;
@@ -286,8 +284,7 @@ bool BreadboardRouteGraph::collinearOverlap(const QLineF & first, const QLineF &
 	const QPointF b = second.p1() - first.p1();
 	const QPointF c = second.p2() - first.p1();
 	const double crossB = a.x() * b.y() - a.y() * b.x();
-	const double crossC = a.x() * c.y() - a.y() * c.x();
-	if (qAbs(crossB) > 0.5 || qAbs(crossC) > 0.5) return false;
+	if (const double crossC = a.x() * c.y() - a.y() * c.x(); qAbs(crossB) > 0.5 || qAbs(crossC) > 0.5) return false;
 	const QRectF firstBounds = QRectF(first.p1(), first.p2()).normalized().adjusted(-0.5, -0.5, 0.5, 0.5);
 	const QRectF secondBounds = QRectF(second.p1(), second.p2()).normalized();
 	return firstBounds.intersects(secondBounds);

--- a/src/autoroute/breadboardroutegraph.cpp
+++ b/src/autoroute/breadboardroutegraph.cpp
@@ -1,0 +1,302 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#include "breadboardroutegraph.h"
+
+#include <QLineF>
+#include <QPointF>
+#include <QStringList>
+#include <QtMath>
+#include <algorithm>
+#include <limits>
+
+#include "../connectors/connectoritem.h"
+
+BreadboardRouteGraph::Options BreadboardRouteGraph::Options::fromEnvironment()
+{
+	Options options;
+	bool ok = false;
+	const double maxLength = qEnvironmentVariable("FRITZING_BB_MAX_JUMPER_LENGTH").toDouble(&ok);
+	if (ok && maxLength > 0.0) options.maxJumperLength = maxLength;
+	const int candidates = qEnvironmentVariable("FRITZING_BB_CANDIDATES_PER_BUS_PAIR").toInt(&ok);
+	if (ok && candidates > 0) options.candidatesPerBusPair = candidates;
+	const double crossing = qEnvironmentVariable("FRITZING_BB_CROSSING_PENALTY").toDouble(&ok);
+	if (ok && crossing >= 0.0) options.crossingPenalty = crossing;
+	const double overlap = qEnvironmentVariable("FRITZING_BB_OVERLAP_PENALTY").toDouble(&ok);
+	if (ok && overlap >= 0.0) options.overlapPenalty = overlap;
+	return options;
+}
+
+BreadboardRouteGraph::BreadboardRouteGraph(const QList<ConnectorItem *> & holes,
+                                           const QSet<ConnectorItem *> & reservedHoles,
+                                           const Options & options)
+	: m_holes(holes)
+	, m_reservedHoles(reservedHoles)
+	, m_options(options)
+{
+	buildBusIndex();
+	buildStaticEdges();
+}
+
+BreadboardRouteGraph::Result BreadboardRouteGraph::route(ConnectorItem * start, ConnectorItem * target) const
+{
+	Result result;
+	if (start == nullptr || target == nullptr) {
+		result.reason = "null endpoint";
+		return result;
+	}
+
+	const QString startBus = busId(start);
+	const QString targetBus = busId(target);
+	if (startBus.isEmpty() || targetBus.isEmpty()) {
+		result.reason = "endpoint has no breadboard bus";
+		return result;
+	}
+	if (startBus == targetBus) {
+		result.found = true;
+		return result;
+	}
+
+	QSet<QString> settled;
+	QHash<QString, BreadboardRoutingScore> best;
+	QHash<QString, Edge> cameFrom;
+	best.insert(startBus, BreadboardRoutingScore());
+
+	while (true) {
+		QString currentBus;
+		BreadboardRoutingScore currentScore;
+		bool foundCurrent = false;
+		for (auto it = best.constBegin(); it != best.constEnd(); ++it) {
+			if (settled.contains(it.key())) continue;
+			if (!foundCurrent || it.value() < currentScore) {
+				currentBus = it.key();
+				currentScore = it.value();
+				foundCurrent = true;
+			}
+		}
+
+		if (currentBus.isEmpty()) break;
+		if (currentBus == targetBus) break;
+		settled.insert(currentBus);
+
+		Q_FOREACH (const Edge & edge, m_edgesByBus.value(currentBus)) {
+			if (!edgeAvailable(edge, start, target)) continue;
+			BreadboardRoutingScore nextScore = currentScore;
+			nextScore.jumperCount++;
+			nextScore.jumperLength += edge.length;
+			nextScore.congestion += edge.congestion;
+			if (best.contains(edge.toBus) && !(nextScore < best.value(edge.toBus))) continue;
+			best.insert(edge.toBus, nextScore);
+			cameFrom.insert(edge.toBus, edge);
+		}
+	}
+
+	if (!cameFrom.contains(targetBus)) {
+		result.reason = QString("no route %1 -> %2").arg(startBus, targetBus);
+		return result;
+	}
+
+	QString bus = targetBus;
+	while (bus != startBus) {
+		const Edge edge = cameFrom.value(bus);
+		if (edge.fromBus.isEmpty()) {
+			result.reason = QString("broken route backtrace at %1").arg(bus);
+			result.segments.clear();
+			return result;
+		}
+		Segment segment;
+		segment.from = edge.fromHole;
+		segment.to = edge.toHole;
+		segment.cost = edge.cost;
+		result.segments.prepend(segment);
+		result.cost += edge.cost;
+		bus = edge.fromBus;
+	}
+
+	result.found = true;
+	result.score = best.value(targetBus);
+	result.cost = result.score.jumperLength + result.score.congestion;
+	return result;
+}
+
+QString BreadboardRouteGraph::busId(ConnectorItem * connectorItem) const
+{
+	if (connectorItem == nullptr) return QString();
+	QString id = connectorItem->busID();
+	if (!id.isEmpty()) return id;
+	return fallbackBusId(connectorItem);
+}
+
+int BreadboardRouteGraph::busCount() const
+{
+	return m_holesByBus.count();
+}
+
+int BreadboardRouteGraph::edgeCount() const
+{
+	int count = 0;
+	for (auto it = m_edgesByBus.constBegin(); it != m_edgesByBus.constEnd(); ++it) {
+		count += it.value().count();
+	}
+	return count;
+}
+
+void BreadboardRouteGraph::buildBusIndex()
+{
+	Q_FOREACH (ConnectorItem * hole, m_holes) {
+		if (hole == nullptr) continue;
+		const QString id = busId(hole);
+		if (id.isEmpty()) continue;
+		if (!m_holesByBus[id].contains(hole)) m_holesByBus[id].append(hole);
+	}
+}
+
+void BreadboardRouteGraph::buildStaticEdges()
+{
+	const QStringList buses = m_holesByBus.keys();
+	Q_FOREACH (const QString & bus, buses) {
+		m_edgesByBus.insert(bus, QList<Edge>());
+	}
+
+	for (int i = 0; i < buses.count(); i++) {
+		for (int j = i + 1; j < buses.count(); j++) {
+			Q_FOREACH (const Edge & edge, bestStaticJumpers(buses.at(i), buses.at(j))) {
+				m_edgesByBus[edge.fromBus].append(edge);
+
+				Edge reverse = edge;
+				reverse.fromBus = edge.toBus;
+				reverse.toBus = edge.fromBus;
+				reverse.fromHole = edge.toHole;
+				reverse.toHole = edge.fromHole;
+				m_edgesByBus[reverse.fromBus].append(reverse);
+			}
+		}
+	}
+}
+
+QList<BreadboardRouteGraph::Edge> BreadboardRouteGraph::bestStaticJumpers(const QString & fromBus, const QString & toBus) const
+{
+	QList<Edge> candidates;
+	Q_FOREACH (ConnectorItem * fromHole, m_holesByBus.value(fromBus)) {
+		Q_FOREACH (ConnectorItem * toHole, m_holesByBus.value(toBus)) {
+			const double length = manhattan(fromHole, toHole);
+			if (length > m_options.maxJumperLength) continue;
+
+			Edge edge;
+			edge.fromBus = fromBus;
+			edge.toBus = toBus;
+			edge.fromHole = fromHole;
+			edge.toHole = toHole;
+			edge.length = length;
+			edge.congestion = segmentPenalty(fromHole, toHole);
+			edge.cost = length + m_options.jumperPenalty + edge.congestion;
+			candidates.append(edge);
+		}
+	}
+
+	std::sort(candidates.begin(), candidates.end(), [](const Edge & a, const Edge & b) {
+		if (!qFuzzyCompare(a.length + 1.0, b.length + 1.0)) return a.length < b.length;
+		return a.congestion < b.congestion;
+	});
+	while (candidates.count() > m_options.candidatesPerBusPair) {
+		candidates.removeLast();
+	}
+	return candidates;
+}
+
+bool BreadboardRouteGraph::edgeAvailable(const Edge & edge, ConnectorItem * start, ConnectorItem * target) const
+{
+	return holeAvailable(edge.fromHole, start, target)
+	    && holeAvailable(edge.toHole, start, target);
+}
+
+bool BreadboardRouteGraph::holeAvailable(ConnectorItem * hole, ConnectorItem * start, ConnectorItem * target) const
+{
+	if (hole == nullptr) return false;
+	if (hole == start || hole == target) return true;
+	if (m_reservedHoles.contains(hole)) return false;
+	if (hole->connectionsCount() != 0) return false;
+	return true;
+}
+
+double BreadboardRouteGraph::manhattan(ConnectorItem * first, ConnectorItem * second)
+{
+	if (first == nullptr || second == nullptr) return std::numeric_limits<double>::max();
+	const QPointF a = first->sceneAdjustedTerminalPoint(nullptr);
+	const QPointF b = second->sceneAdjustedTerminalPoint(nullptr);
+	return qAbs(a.x() - b.x()) + qAbs(a.y() - b.y());
+}
+
+double BreadboardRouteGraph::segmentPenalty(ConnectorItem * first, ConnectorItem * second) const
+{
+	if (first == nullptr || second == nullptr) return 0.0;
+	const QLineF candidate(first->sceneAdjustedTerminalPoint(nullptr), second->sceneAdjustedTerminalPoint(nullptr));
+	return congestionPenalty(candidate, m_options.existingSegments, m_options.crossingPenalty, m_options.overlapPenalty);
+}
+
+double BreadboardRouteGraph::congestionPenalty(const QLineF & candidate,
+                                               const QList<QLineF> & existingSegments,
+                                               double crossingPenalty,
+                                               double overlapPenalty)
+{
+	double penalty = 0.0;
+	Q_FOREACH (const QLineF & existing, existingSegments) {
+		if (sharesEndpoint(candidate, existing)) continue;
+		if (collinearOverlap(candidate, existing)) {
+			penalty += overlapPenalty;
+			continue;
+		}
+		QPointF intersection;
+		if (candidate.intersects(existing, &intersection) == QLineF::BoundedIntersection) {
+			penalty += crossingPenalty;
+		}
+	}
+	return penalty;
+}
+
+bool BreadboardRouteGraph::sharesEndpoint(const QLineF & first, const QLineF & second)
+{
+	constexpr double tolerance = 0.5;
+	return QLineF(first.p1(), second.p1()).length() <= tolerance
+	    || QLineF(first.p1(), second.p2()).length() <= tolerance
+	    || QLineF(first.p2(), second.p1()).length() <= tolerance
+	    || QLineF(first.p2(), second.p2()).length() <= tolerance;
+}
+
+bool BreadboardRouteGraph::collinearOverlap(const QLineF & first, const QLineF & second)
+{
+	const QPointF a = first.p2() - first.p1();
+	const QPointF b = second.p1() - first.p1();
+	const QPointF c = second.p2() - first.p1();
+	const double crossB = a.x() * b.y() - a.y() * b.x();
+	const double crossC = a.x() * c.y() - a.y() * c.x();
+	if (qAbs(crossB) > 0.5 || qAbs(crossC) > 0.5) return false;
+	const QRectF firstBounds = QRectF(first.p1(), first.p2()).normalized().adjusted(-0.5, -0.5, 0.5, 0.5);
+	const QRectF secondBounds = QRectF(second.p1(), second.p2()).normalized();
+	return firstBounds.intersects(secondBounds);
+}
+
+QString BreadboardRouteGraph::fallbackBusId(ConnectorItem * connectorItem)
+{
+	if (connectorItem == nullptr) return QString();
+	return QString("%1:%2")
+	        .arg(connectorItem->attachedToID())
+	        .arg(connectorItem->connectorSharedID());
+}

--- a/src/autoroute/breadboardroutegraph.h
+++ b/src/autoroute/breadboardroutegraph.h
@@ -88,7 +88,7 @@ private:
 	void buildStaticEdges();
 	QList<Edge> bestStaticJumpers(const QString & fromBus, const QString & toBus) const;
 	bool edgeAvailable(const Edge & edge, ConnectorItem * start, ConnectorItem * target) const;
-	bool holeAvailable(ConnectorItem * hole, ConnectorItem * start, ConnectorItem * target) const;
+	bool holeAvailable(ConnectorItem * hole, const ConnectorItem * start, const ConnectorItem * target) const;
 	static double manhattan(ConnectorItem * first, ConnectorItem * second);
 	double segmentPenalty(ConnectorItem * first, ConnectorItem * second) const;
 	static bool sharesEndpoint(const QLineF & first, const QLineF & second);

--- a/src/autoroute/breadboardroutegraph.h
+++ b/src/autoroute/breadboardroutegraph.h
@@ -1,0 +1,106 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#ifndef BREADBOARDROUTEGRAPH_H
+#define BREADBOARDROUTEGRAPH_H
+
+#include <QHash>
+#include <QList>
+#include <QLineF>
+#include <QSet>
+#include <QString>
+
+#include "breadboardroutingscore.h"
+
+class ConnectorItem;
+
+class BreadboardRouteGraph
+{
+public:
+	struct Options {
+		double maxJumperLength = 280.0;
+		double jumperPenalty = 240.0;
+		double crossingPenalty = 700.0;
+		double overlapPenalty = 1200.0;
+		int candidatesPerBusPair = 12;
+		QList<QLineF> existingSegments;
+
+		static Options fromEnvironment();
+	};
+
+	struct Segment {
+		ConnectorItem * from = nullptr;
+		ConnectorItem * to = nullptr;
+		double cost = 0.0;
+	};
+
+	struct Result {
+		bool found = false;
+		double cost = 0.0;
+		QList<Segment> segments;
+		BreadboardRoutingScore score;
+		QString reason;
+	};
+
+	BreadboardRouteGraph(const QList<ConnectorItem *> & holes,
+	                     const QSet<ConnectorItem *> & reservedHoles,
+	                     const Options & options = Options());
+
+	Result route(ConnectorItem * start, ConnectorItem * target) const;
+
+	QString busId(ConnectorItem * connectorItem) const;
+	int busCount() const;
+	int edgeCount() const;
+	static double congestionPenalty(const QLineF & candidate,
+	                                const QList<QLineF> & existingSegments,
+	                                double crossingPenalty,
+	                                double overlapPenalty);
+
+private:
+	struct Edge {
+		QString fromBus;
+		QString toBus;
+		ConnectorItem * fromHole = nullptr;
+		ConnectorItem * toHole = nullptr;
+		double cost = 0.0;
+		double length = 0.0;
+		double congestion = 0.0;
+	};
+
+	void buildBusIndex();
+	void buildStaticEdges();
+	QList<Edge> bestStaticJumpers(const QString & fromBus, const QString & toBus) const;
+	bool edgeAvailable(const Edge & edge, ConnectorItem * start, ConnectorItem * target) const;
+	bool holeAvailable(ConnectorItem * hole, ConnectorItem * start, ConnectorItem * target) const;
+	static double manhattan(ConnectorItem * first, ConnectorItem * second);
+	double segmentPenalty(ConnectorItem * first, ConnectorItem * second) const;
+	static bool sharesEndpoint(const QLineF & first, const QLineF & second);
+	static bool collinearOverlap(const QLineF & first, const QLineF & second);
+	static QString fallbackBusId(ConnectorItem * connectorItem);
+
+private:
+	QList<ConnectorItem *> m_holes;
+	QSet<ConnectorItem *> m_reservedHoles;
+	Options m_options;
+	QHash<QString, QList<ConnectorItem *> > m_holesByBus;
+	QHash<QString, QList<Edge> > m_edgesByBus;
+};
+
+#endif

--- a/src/autoroute/breadboardroutegraphcore.cpp
+++ b/src/autoroute/breadboardroutegraphcore.cpp
@@ -359,8 +359,7 @@ bool BreadboardRouteGraphCore::collinearOverlap(const QLineF & first, const QLin
 	const QPointF b = second.p1() - first.p1();
 	const QPointF c = second.p2() - first.p1();
 	const double crossB = a.x() * b.y() - a.y() * b.x();
-	const double crossC = a.x() * c.y() - a.y() * c.x();
-	if (qAbs(crossB) > 0.5 || qAbs(crossC) > 0.5) return false;
+	if (const double crossC = a.x() * c.y() - a.y() * c.x(); qAbs(crossB) > 0.5 || qAbs(crossC) > 0.5) return false;
 	// Inflate BOTH boxes: axis-aligned segments make zero-area rects, and Qt
 	// treats empty rects as never intersecting (this silently disabled the
 	// overlap penalty for horizontal/vertical wires in the original code).

--- a/src/autoroute/breadboardroutegraphcore.cpp
+++ b/src/autoroute/breadboardroutegraphcore.cpp
@@ -1,0 +1,370 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#include "breadboardroutegraphcore.h"
+
+#include <QRectF>
+#include <algorithm>
+#include <limits>
+
+namespace
+{
+	inline double manhattan(const QPointF & a, const QPointF & b)
+	{
+		return qAbs(a.x() - b.x()) + qAbs(a.y() - b.y());
+	}
+}
+
+BreadboardRouteGraphCore::BreadboardRouteGraphCore(const QVector<QPointF> & holePositions,
+												   const QVector<int> & holeBus,
+												   const Options & options)
+	: m_holePositions(holePositions)
+	, m_holeBus(holeBus)
+	, m_options(options)
+{
+	int busCount = 0;
+	Q_FOREACH (int bus, m_holeBus)
+		busCount = qMax(busCount, bus + 1);
+	m_holesByBus.resize(busCount);
+	for (int hole = 0; hole < m_holeBus.count() && hole < m_holePositions.count(); hole++)
+	{
+		const int bus = m_holeBus.at(hole);
+		if (bus >= 0)
+			m_holesByBus[bus].append(hole);
+	}
+	buildStaticEdges();
+}
+
+void BreadboardRouteGraphCore::buildStaticEdges()
+{
+	const int busCount = m_holesByBus.count();
+	m_edgesByBus.resize(busCount);
+
+	// Bounding box per bus lets distant bus pairs be rejected in O(1)
+	// before any hole-pair work.
+	QVector<QRectF> busBounds(busCount);
+	for (int bus = 0; bus < busCount; bus++)
+	{
+		QRectF bounds;
+		Q_FOREACH (int hole, m_holesByBus.at(bus))
+		{
+			const QRectF point(m_holePositions.at(hole), QSizeF(0.0, 0.0));
+			bounds = bounds.isNull() ? point : bounds | point;
+		}
+		busBounds[bus] = bounds;
+	}
+	auto boxManhattanGap = [](const QRectF & a, const QRectF & b) {
+		const double dx = qMax(0.0, qMax(b.left() - a.right(), a.left() - b.right()));
+		const double dy = qMax(0.0, qMax(b.top() - a.bottom(), a.top() - b.bottom()));
+		return dx + dy;
+	};
+
+	QVector<Edge> pairCandidates;
+	for (int fromBus = 0; fromBus < busCount; fromBus++)
+	{
+		for (int toBus = fromBus + 1; toBus < busCount; toBus++)
+		{
+			if (boxManhattanGap(busBounds.at(fromBus), busBounds.at(toBus)) > m_options.maxJumperLength)
+				continue;
+
+			pairCandidates.clear();
+			Q_FOREACH (int fromHole, m_holesByBus.at(fromBus))
+			{
+				const QPointF fromPos = m_holePositions.at(fromHole);
+				Q_FOREACH (int toHole, m_holesByBus.at(toBus))
+				{
+					const double length = manhattan(fromPos, m_holePositions.at(toHole));
+					if (length > m_options.maxJumperLength)
+						continue;
+					Edge edge;
+					edge.fromBus = fromBus;
+					edge.toBus = toBus;
+					edge.fromHole = fromHole;
+					edge.toHole = toHole;
+					edge.length = length;
+					pairCandidates.append(edge);
+				}
+			}
+			if (pairCandidates.isEmpty())
+				continue;
+
+			// Shortest candidates first; deterministic tie-break on indices.
+			std::sort(pairCandidates.begin(), pairCandidates.end(), [](const Edge & a, const Edge & b) {
+				if (!qFuzzyCompare(a.length + 1.0, b.length + 1.0)) return a.length < b.length;
+				if (a.fromHole != b.fromHole) return a.fromHole < b.fromHole;
+				return a.toHole < b.toHole;
+			});
+			const int keep = qMin(pairCandidates.count(), m_options.candidatesPerBusPair);
+			for (int i = 0; i < keep; i++)
+			{
+				const Edge & edge = pairCandidates.at(i);
+				m_edgesByBus[fromBus].append(m_edges.count());
+				m_edges.append(edge);
+
+				Edge reverse = edge;
+				reverse.fromBus = edge.toBus;
+				reverse.toBus = edge.fromBus;
+				reverse.fromHole = edge.toHole;
+				reverse.toHole = edge.fromHole;
+				m_edgesByBus[toBus].append(m_edges.count());
+				m_edges.append(reverse);
+			}
+		}
+	}
+}
+
+BreadboardRouteGraphCore::QueryContext BreadboardRouteGraphCore::prepareQuery(const QVector<bool> & holeBlocked,
+																			  const QVector<bool> & busBlocked,
+																			  const QList<QLineF> & congestionSegments) const
+{
+	QueryContext context;
+	context.holeBlocked = holeBlocked;
+	context.busBlocked = busBlocked;
+	context.edgeCongestion = QVector<double>(m_edges.count(), 0.0);
+
+	// Bounding boxes let most (edge, segment) pairs be rejected without the
+	// full intersection tests.
+	QVector<QRectF> segmentBounds(congestionSegments.count());
+	for (int i = 0; i < congestionSegments.count(); i++)
+	{
+		const QLineF & segment = congestionSegments.at(i);
+		segmentBounds[i] = QRectF(segment.p1(), segment.p2()).normalized().adjusted(-1.0, -1.0, 1.0, 1.0);
+	}
+
+	for (int edgeIndex = 0; edgeIndex < m_edges.count(); edgeIndex++)
+	{
+		const Edge & edge = m_edges.at(edgeIndex);
+		const QLineF candidate(m_holePositions.at(edge.fromHole), m_holePositions.at(edge.toHole));
+		const QRectF candidateBounds = QRectF(candidate.p1(), candidate.p2()).normalized().adjusted(-1.0, -1.0, 1.0, 1.0);
+		double congestion = 0.0;
+		for (int i = 0; i < congestionSegments.count(); i++)
+		{
+			if (!candidateBounds.intersects(segmentBounds.at(i)))
+				continue;
+			congestion += congestionPenalty(candidate, {congestionSegments.at(i)},
+											m_options.crossingPenalty, m_options.overlapPenalty);
+		}
+		context.edgeCongestion[edgeIndex] = congestion;
+	}
+	return context;
+}
+
+BreadboardRouteGraphCore::MultiResult BreadboardRouteGraphCore::routeFrom(int sourceHole,
+																		  const QueryContext & context) const
+{
+	MultiResult multi;
+	if (sourceHole < 0 || sourceHole >= m_holeBus.count())
+		return multi;
+	const int sourceBus = m_holeBus.at(sourceHole);
+	if (sourceBus < 0)
+		return multi;
+
+	// A source on a foreign-owned bus is a caller error: routing from it
+	// would already imply a schematic-breaking connection.
+	if (sourceBus < context.busBlocked.count() && context.busBlocked.at(sourceBus))
+		return multi;
+
+	multi.sourceHole = sourceHole;
+	multi.sourceBus = sourceBus;
+	const int busCount = m_holesByBus.count();
+	multi.bestByBus = QVector<BreadboardRoutingScore>(busCount);
+	multi.reachedByBus = QVector<bool>(busCount, false);
+	multi.cameFromEdge = QVector<int>(busCount, -1);
+	multi.edgeQueryCost = QVector<double>(busCount, 0.0);
+	multi.reachedByBus[sourceBus] = true;
+
+	auto holeAvailable = [&](int hole) {
+		if (hole == sourceHole)
+			return true;
+		return hole >= 0 && hole < context.holeBlocked.count() ? !context.holeBlocked.at(hole) : true;
+	};
+
+	QVector<bool> settled(busCount, false);
+	while (true)
+	{
+		int currentBus = -1;
+		for (int bus = 0; bus < busCount; bus++)
+		{
+			if (!multi.reachedByBus.at(bus) || settled.at(bus))
+				continue;
+			if (currentBus < 0 || multi.bestByBus.at(bus) < multi.bestByBus.at(currentBus))
+				currentBus = bus;
+		}
+		if (currentBus < 0)
+			break;
+		settled[currentBus] = true;
+
+		Q_FOREACH (int edgeIndex, m_edgesByBus.at(currentBus))
+		{
+			const Edge & edge = m_edges.at(edgeIndex);
+			// No endpoint exemption for buses: landing on or passing through
+			// a foreign-owned bus electrically breaks the schematic.
+			if (edge.toBus < context.busBlocked.count() && context.busBlocked.at(edge.toBus))
+				continue;
+			if (!holeAvailable(edge.fromHole) || !holeAvailable(edge.toHole))
+				continue;
+
+			const double congestion = context.edgeCongestion.value(edgeIndex, 0.0);
+
+			BreadboardRoutingScore nextScore = multi.bestByBus.at(currentBus);
+			nextScore.jumperCount++;
+			nextScore.jumperLength += edge.length;
+			nextScore.congestion += congestion;
+			if (multi.reachedByBus.at(edge.toBus) && !(nextScore < multi.bestByBus.at(edge.toBus)))
+				continue;
+			multi.bestByBus[edge.toBus] = nextScore;
+			multi.reachedByBus[edge.toBus] = true;
+			multi.cameFromEdge[edge.toBus] = edgeIndex;
+			multi.edgeQueryCost[edge.toBus] = edge.length + m_options.jumperPenalty + congestion;
+			settled[edge.toBus] = false;
+		}
+	}
+	return multi;
+}
+
+BreadboardRouteGraphCore::Result BreadboardRouteGraphCore::extractRoute(const MultiResult & multi,
+																		int targetHole) const
+{
+	Result result;
+	if (multi.sourceBus < 0)
+	{
+		result.reason = "invalid source";
+		return result;
+	}
+	if (targetHole < 0 || targetHole >= m_holeBus.count())
+	{
+		result.reason = "endpoint out of range";
+		return result;
+	}
+	const int targetBus = m_holeBus.at(targetHole);
+	if (targetBus < 0)
+	{
+		result.reason = "endpoint has no breadboard bus";
+		return result;
+	}
+	if (targetBus == multi.sourceBus)
+	{
+		result.found = true;
+		return result;
+	}
+	if (!multi.reachedByBus.at(targetBus) || multi.cameFromEdge.at(targetBus) < 0)
+	{
+		result.reason = QString("no route bus%1 -> bus%2").arg(multi.sourceBus).arg(targetBus);
+		return result;
+	}
+
+	int bus = targetBus;
+	while (bus != multi.sourceBus)
+	{
+		const int edgeIndex = multi.cameFromEdge.at(bus);
+		if (edgeIndex < 0)
+		{
+			result.reason = QString("broken route backtrace at bus%1").arg(bus);
+			result.segments.clear();
+			return result;
+		}
+		const Edge & edge = m_edges.at(edgeIndex);
+		Segment segment;
+		segment.fromHole = edge.fromHole;
+		segment.toHole = edge.toHole;
+		segment.cost = multi.edgeQueryCost.at(bus);
+		result.segments.prepend(segment);
+		result.cost += segment.cost;
+		bus = edge.fromBus;
+	}
+
+	result.found = true;
+	result.score = multi.bestByBus.at(targetBus);
+	result.cost = result.score.jumperLength + result.score.congestion;
+	return result;
+}
+
+BreadboardRouteGraphCore::Result BreadboardRouteGraphCore::route(int startHole, int targetHole,
+																 const QueryContext & context) const
+{
+	Result result;
+	if (startHole < 0 || startHole >= m_holeBus.count()
+		|| targetHole < 0 || targetHole >= m_holeBus.count())
+	{
+		result.reason = "endpoint out of range";
+		return result;
+	}
+	if (m_holeBus.at(startHole) < 0 || m_holeBus.at(targetHole) < 0)
+	{
+		result.reason = "endpoint has no breadboard bus";
+		return result;
+	}
+
+	// Pairwise routing rides the single-source machinery with the target
+	// hole additionally exempted from blocking (matching original
+	// semantics where both endpoints were always usable).
+	QueryContext exempted = context;
+	if (targetHole < exempted.holeBlocked.count())
+		exempted.holeBlocked[targetHole] = false;
+	const MultiResult multi = routeFrom(startHole, exempted);
+	return extractRoute(multi, targetHole);
+}
+
+double BreadboardRouteGraphCore::congestionPenalty(const QLineF & candidate,
+												   const QList<QLineF> & existingSegments,
+												   double crossingPenalty,
+												   double overlapPenalty)
+{
+	double penalty = 0.0;
+	Q_FOREACH (const QLineF & existing, existingSegments)
+	{
+		if (sharesEndpoint(candidate, existing))
+			continue;
+		if (collinearOverlap(candidate, existing))
+		{
+			penalty += overlapPenalty;
+			continue;
+		}
+		QPointF intersection;
+		if (candidate.intersects(existing, &intersection) == QLineF::BoundedIntersection)
+			penalty += crossingPenalty;
+	}
+	return penalty;
+}
+
+bool BreadboardRouteGraphCore::sharesEndpoint(const QLineF & first, const QLineF & second)
+{
+	constexpr double tolerance = 0.5;
+	return QLineF(first.p1(), second.p1()).length() <= tolerance
+		|| QLineF(first.p1(), second.p2()).length() <= tolerance
+		|| QLineF(first.p2(), second.p1()).length() <= tolerance
+		|| QLineF(first.p2(), second.p2()).length() <= tolerance;
+}
+
+bool BreadboardRouteGraphCore::collinearOverlap(const QLineF & first, const QLineF & second)
+{
+	const QPointF a = first.p2() - first.p1();
+	const QPointF b = second.p1() - first.p1();
+	const QPointF c = second.p2() - first.p1();
+	const double crossB = a.x() * b.y() - a.y() * b.x();
+	const double crossC = a.x() * c.y() - a.y() * c.x();
+	if (qAbs(crossB) > 0.5 || qAbs(crossC) > 0.5) return false;
+	// Inflate BOTH boxes: axis-aligned segments make zero-area rects, and Qt
+	// treats empty rects as never intersecting (this silently disabled the
+	// overlap penalty for horizontal/vertical wires in the original code).
+	const QRectF firstBounds = QRectF(first.p1(), first.p2()).normalized().adjusted(-0.5, -0.5, 0.5, 0.5);
+	const QRectF secondBounds = QRectF(second.p1(), second.p2()).normalized().adjusted(-0.25, -0.25, 0.25, 0.25);
+	return firstBounds.intersects(secondBounds);
+}

--- a/src/autoroute/breadboardroutegraphcore.h
+++ b/src/autoroute/breadboardroutegraphcore.h
@@ -1,0 +1,137 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#ifndef BREADBOARDROUTEGRAPHCORE_H
+#define BREADBOARDROUTEGRAPHCORE_H
+
+#include <QLineF>
+#include <QList>
+#include <QPointF>
+#include <QString>
+#include <QVector>
+
+#include "breadboardroutingscore.h"
+
+// Pure bus-graph router: plain data in (hole positions, dense bus ids),
+// route plans out. No scene or Qt-graphics types so it is unit-testable
+// and safe on worker threads.
+//
+// Static edges (hole pair, length) are built ONCE per instance; everything
+// that changes while routing proceeds - blocked holes and congestion from
+// already-planned segments - is supplied per route() query.
+class BreadboardRouteGraphCore
+{
+public:
+	struct Options {
+		double maxJumperLength = 280.0;
+		double jumperPenalty = 240.0;
+		double crossingPenalty = 700.0;
+		double overlapPenalty = 1200.0;
+		int candidatesPerBusPair = 12;
+	};
+
+	struct Segment {
+		int fromHole = -1;
+		int toHole = -1;
+		double cost = 0.0;
+	};
+
+	struct Result {
+		bool found = false;
+		double cost = 0.0;
+		QVector<Segment> segments;
+		BreadboardRoutingScore score;
+		QString reason;
+	};
+
+	// holeBus[i] is the dense bus id of hole i (>= 0); holes with negative
+	// bus ids are ignored.
+	BreadboardRouteGraphCore(const QVector<QPointF> & holePositions,
+							 const QVector<int> & holeBus,
+							 const Options & options = Options());
+
+	// Per-batch query state: blocked holes and per-edge congestion computed
+	// once, then any number of route() calls run pure Dijkstra against it.
+	// Rebuild the context whenever reserved holes or planned segments change.
+	struct QueryContext {
+		QVector<bool> holeBlocked;
+		QVector<bool> busBlocked;
+		QVector<double> edgeCongestion;
+	};
+
+	// holeBlocked[i]: hole may not be used (reserved/occupied); start and
+	// target holes are always usable. busBlocked[b]: the bus is owned by a
+	// foreign net (or a no-net pin) and must not be landed on or traversed -
+	// unlike hole blocking there is NO endpoint exemption, because touching
+	// a foreign bus electrically breaks the schematic. congestionSegments:
+	// already-planned wires; crossing or overlapping them penalizes an edge.
+	QueryContext prepareQuery(const QVector<bool> & holeBlocked,
+							  const QVector<bool> & busBlocked,
+							  const QList<QLineF> & congestionSegments) const;
+
+	Result route(int startHole, int targetHole, const QueryContext & context) const;
+
+	// Single-source variant: one Dijkstra from sourceHole settles every
+	// reachable bus; extractRoute then reads any target in O(path length).
+	// Turns entry x anchor scans (N x M Dijkstras) into M Dijkstras.
+	// Note: only the SOURCE hole is exempt from blocking; targets extracted
+	// later must be unblocked holes.
+	struct MultiResult {
+		int sourceHole = -1;
+		int sourceBus = -1;
+		QVector<BreadboardRoutingScore> bestByBus;
+		QVector<bool> reachedByBus;
+		QVector<int> cameFromEdge;
+		QVector<double> edgeQueryCost;
+	};
+	MultiResult routeFrom(int sourceHole, const QueryContext & context) const;
+	Result extractRoute(const MultiResult & multi, int targetHole) const;
+
+	int busCount() const { return m_holesByBus.count(); }
+	int edgeCount() const { return m_edges.count(); }
+
+	static double congestionPenalty(const QLineF & candidate,
+									const QList<QLineF> & existingSegments,
+									double crossingPenalty,
+									double overlapPenalty);
+
+private:
+	struct Edge {
+		int fromBus = -1;
+		int toBus = -1;
+		int fromHole = -1;
+		int toHole = -1;
+		double length = 0.0;
+	};
+
+	void buildStaticEdges();
+	static bool sharesEndpoint(const QLineF & first, const QLineF & second);
+	static bool collinearOverlap(const QLineF & first, const QLineF & second);
+
+private:
+	QVector<QPointF> m_holePositions;
+	QVector<int> m_holeBus;
+	Options m_options;
+	QVector<QVector<int> > m_holesByBus;          // bus id -> hole indices
+	QVector<Edge> m_edges;
+	QVector<QVector<int> > m_edgesByBus;          // bus id -> indices into m_edges
+};
+
+#endif

--- a/src/autoroute/breadboardroutingscore.cpp
+++ b/src/autoroute/breadboardroutingscore.cpp
@@ -1,0 +1,54 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+********************************************************************/
+
+#include "breadboardroutingscore.h"
+
+#include <QtMath>
+
+namespace
+{
+	constexpr double ScoreEpsilon = 0.0001;
+
+	int compareDouble(double first, double second)
+	{
+		if (qAbs(first - second) <= ScoreEpsilon) return 0;
+		return first < second ? -1 : 1;
+	}
+}
+
+bool BreadboardRoutingScore::operator<(const BreadboardRoutingScore &other) const
+{
+	if (failedNets != other.failedNets) return failedNets < other.failedNets;
+	if (jumperCount != other.jumperCount) return jumperCount < other.jumperCount;
+	if (const int comparison = compareDouble(jumperLength, other.jumperLength); comparison != 0) return comparison < 0;
+	if (const int comparison = compareDouble(componentLeadLength, other.componentLeadLength); comparison != 0) return comparison < 0;
+	return compareDouble(congestion, other.congestion) < 0;
+}
+
+bool BreadboardRoutingScore::operator==(const BreadboardRoutingScore &other) const
+{
+	return failedNets == other.failedNets
+	    && jumperCount == other.jumperCount
+	    && compareDouble(jumperLength, other.jumperLength) == 0
+	    && compareDouble(componentLeadLength, other.componentLeadLength) == 0
+	    && compareDouble(congestion, other.congestion) == 0;
+}
+
+QString BreadboardRoutingScore::toString() const
+{
+	return QString("failedNets=%1 jumperCount=%2 jumperLength=%3 componentLeadLength=%4 congestion=%5")
+	        .arg(failedNets)
+	        .arg(jumperCount)
+	        .arg(jumperLength, 0, 'f', 3)
+	        .arg(componentLeadLength, 0, 'f', 3)
+	        .arg(congestion, 0, 'f', 3);
+}

--- a/src/autoroute/breadboardroutingscore.h
+++ b/src/autoroute/breadboardroutingscore.h
@@ -1,0 +1,33 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+********************************************************************/
+
+#ifndef BREADBOARDROUTINGSCORE_H
+#define BREADBOARDROUTINGSCORE_H
+
+#include <QString>
+
+// Breadboard quality is deliberately lexicographic. A lower-priority
+// improvement must never compensate for a failed net or an extra jumper.
+struct BreadboardRoutingScore
+{
+	int failedNets = 0;
+	int jumperCount = 0;
+	double jumperLength = 0.0;
+	double componentLeadLength = 0.0;
+	double congestion = 0.0;
+
+	bool operator<(const BreadboardRoutingScore &other) const;
+	bool operator==(const BreadboardRoutingScore &other) const;
+	QString toString() const;
+};
+
+#endif

--- a/src/autoroute/breadboardtopology.cpp
+++ b/src/autoroute/breadboardtopology.cpp
@@ -23,6 +23,8 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QGraphicsItem>
 #include <QGraphicsScene>
 
+#include <algorithm>
+
 #include "../items/itembase.h"
 #include "../items/moduleidnames.h"
 
@@ -75,22 +77,38 @@ bool BreadboardTopology::discover(QGraphicsScene * scene, const QList<QGraphicsI
 	}
 
 	if (m_boards.isEmpty()) {
+		// Accept EVERY whitelisted breadboard with enough holes: multi-board
+		// sketches place parts on all of them and jumper between them. Visit
+		// owners in stable id order - hash iteration follows the per-process
+		// seed, and board order decides hole enumeration order downstream.
+		QList<ItemBase *> owners = holesByOwner.keys();
+		std::sort(owners.begin(), owners.end(), [](ItemBase * a, ItemBase * b) { return a->id() < b->id(); });
+
 		ItemBase * bestOwner = nullptr;
 		int bestHoleCount = 0;
-		for (auto it = holesByOwner.constBegin(); it != holesByOwner.constEnd(); ++it) {
-			ItemBase * owner = it.key();
-			int holeCount = it.value().count();
+		Q_FOREACH (ItemBase * owner, owners) {
+			int holeCount = holesByOwner.value(owner).count();
 			m_diagnosticLines << QString("topology owner candidate: holes=%1 connectors=%2 owner=%3")
 			                     .arg(holeCount)
 			                     .arg(connectorCountsByOwner.value(owner))
 			                     .arg(itemSummary(owner));
+			if (holeCount < MinimumBreadboardHoleCount) continue;
 			if (holeCount > bestHoleCount) {
 				bestOwner = owner;
 				bestHoleCount = holeCount;
 			}
+			if (!isBreadboardItem(owner)) continue;
+			addBoard(owner, holesByOwner.value(owner));
+			acceptedOwners.insert(owner);
+			m_diagnosticLines << QString("topology accepted board: holes=%1 owner=%2")
+			                     .arg(holeCount)
+			                     .arg(itemSummary(owner));
 		}
 
-		if (bestOwner != nullptr && bestHoleCount >= MinimumBreadboardHoleCount) {
+		// No whitelisted breadboard found: fall back to the single largest
+		// female-hole owner (the pre-multi-board behaviour), which keeps
+		// third-party boards with unrecognised moduleIDs routable.
+		if (m_boards.isEmpty() && bestOwner != nullptr) {
 			addBoard(bestOwner, holesByOwner.value(bestOwner));
 			acceptedOwners.insert(bestOwner);
 			m_diagnosticLines << QString("topology selected largest connector owner: holes=%1 owner=%2")

--- a/src/autoroute/breadboardtopology.cpp
+++ b/src/autoroute/breadboardtopology.cpp
@@ -1,0 +1,334 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#include "breadboardtopology.h"
+
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+
+#include "../items/itembase.h"
+#include "../items/moduleidnames.h"
+
+namespace {
+constexpr int MinimumBreadboardHoleCount = 10;
+}
+
+bool BreadboardTopology::discover(QGraphicsScene * scene, const QList<QGraphicsItem *> & selectedItems)
+{
+	clear();
+	if (scene == nullptr) return false;
+
+	QSet<ItemBase *> explicitTargets;
+	Q_FOREACH (QGraphicsItem * selectedItem, selectedItems) {
+		ItemBase * chief = itemChief(selectedItem);
+		if (chief == nullptr) continue;
+		if (isBreadboardItem(chief)) {
+			explicitTargets.insert(chief);
+			m_diagnosticLines << QString("selected topology target: %1").arg(itemSummary(chief));
+		}
+	}
+
+	QHash<ItemBase *, QList<ConnectorItem *> > holesByOwner;
+	QHash<ItemBase *, int> connectorCountsByOwner;
+	Q_FOREACH (QGraphicsItem * graphicsItem, scene->items()) {
+		auto * connectorItem = dynamic_cast<ConnectorItem *>(graphicsItem);
+		if (connectorItem == nullptr) continue;
+		m_sceneConnectorCount++;
+
+		ItemBase * owner = ownerChief(connectorItem);
+		if (owner == nullptr) continue;
+		connectorCountsByOwner[owner]++;
+
+		if (!isTargetBreadboardHole(connectorItem)) continue;
+		holesByOwner[owner].append(connectorItem);
+	}
+
+	QSet<ItemBase *> acceptedOwners;
+	Q_FOREACH (ItemBase * target, explicitTargets) {
+		QList<ConnectorItem *> holes = holesByOwner.value(target);
+		if (holes.count() >= MinimumBreadboardHoleCount) {
+			addBoard(target, holes);
+			acceptedOwners.insert(target);
+		}
+		else {
+			m_diagnosticLines << QString("selected topology target rejected: holes=%1 owner=%2")
+			                     .arg(holes.count())
+			                     .arg(itemSummary(target));
+		}
+	}
+
+	if (m_boards.isEmpty()) {
+		ItemBase * bestOwner = nullptr;
+		int bestHoleCount = 0;
+		for (auto it = holesByOwner.constBegin(); it != holesByOwner.constEnd(); ++it) {
+			ItemBase * owner = it.key();
+			int holeCount = it.value().count();
+			m_diagnosticLines << QString("topology owner candidate: holes=%1 connectors=%2 owner=%3")
+			                     .arg(holeCount)
+			                     .arg(connectorCountsByOwner.value(owner))
+			                     .arg(itemSummary(owner));
+			if (holeCount > bestHoleCount) {
+				bestOwner = owner;
+				bestHoleCount = holeCount;
+			}
+		}
+
+		if (bestOwner != nullptr && bestHoleCount >= MinimumBreadboardHoleCount) {
+			addBoard(bestOwner, holesByOwner.value(bestOwner));
+			acceptedOwners.insert(bestOwner);
+			m_diagnosticLines << QString("topology selected largest connector owner: holes=%1 owner=%2")
+			                     .arg(bestHoleCount)
+			                     .arg(itemSummary(bestOwner));
+		}
+	}
+
+	for (int boardIndex = 0; boardIndex < m_boards.count(); boardIndex++) {
+		Board & board = m_boards[boardIndex];
+		board.itemConnectorCount = connectorCountsByOwner.value(board.item);
+		m_itemConnectorCount += board.itemConnectorCount;
+	}
+
+	buildBusIndex();
+	m_diagnosticLines << QString("topology summary: boards=%1 holes=%2 reserved=%3 buses=%4 bounds=[%5,%6 %7x%8] sceneConnectors=%9 itemConnectors=%10")
+	                     .arg(m_boards.count())
+	                     .arg(m_holes.count())
+	                     .arg(m_reservedHoles.count())
+	                     .arg(m_busIndex.count())
+	                     .arg(m_bounds.x()).arg(m_bounds.y()).arg(m_bounds.width()).arg(m_bounds.height())
+	                     .arg(m_sceneConnectorCount)
+	                     .arg(m_itemConnectorCount);
+	return isValid();
+}
+
+bool BreadboardTopology::isValid() const
+{
+	return !m_boards.isEmpty() && !m_holes.isEmpty() && !m_bounds.isEmpty();
+}
+
+const QList<BreadboardTopology::Board> & BreadboardTopology::boards() const
+{
+	return m_boards;
+}
+
+QList<ItemBase *> BreadboardTopology::boardItems() const
+{
+	QList<ItemBase *> items;
+	Q_FOREACH (const Board & board, m_boards) {
+		if (board.item != nullptr && !items.contains(board.item)) items.append(board.item);
+	}
+	return items;
+}
+
+const QList<ConnectorItem *> & BreadboardTopology::holes() const
+{
+	return m_holes;
+}
+
+const QSet<ConnectorItem *> & BreadboardTopology::reservedHoles() const
+{
+	return m_reservedHoles;
+}
+
+const QRectF & BreadboardTopology::bounds() const
+{
+	return m_bounds;
+}
+
+int BreadboardTopology::sceneConnectorCount() const
+{
+	return m_sceneConnectorCount;
+}
+
+int BreadboardTopology::itemConnectorCount() const
+{
+	return m_itemConnectorCount;
+}
+
+int BreadboardTopology::busCount() const
+{
+	return m_busIndex.count();
+}
+
+QStringList BreadboardTopology::diagnosticLines() const
+{
+	QStringList lines = m_diagnosticLines;
+	for (auto it = m_busIndex.constBegin(); it != m_busIndex.constEnd(); ++it) {
+		QList<ConnectorItem *> busHoles = it.value();
+		if (busHoles.isEmpty()) continue;
+		lines << QString("topology bus: id=%1 holes=%2 sample=%3")
+		         .arg(it.key())
+		         .arg(busHoles.count())
+		         .arg(connectorSummary(busHoles.first()));
+	}
+	return lines;
+}
+
+bool BreadboardTopology::isBreadboardItem(ItemBase * itemBase)
+{
+	if (itemBase == nullptr) return false;
+
+	QString moduleID = itemBase->moduleID();
+	if (moduleID == ModuleIDNames::BreadboardModuleIDName) return true;
+	if (moduleID == ModuleIDNames::FullPlusBreadboardModuleIDName) return true;
+	if (moduleID == ModuleIDNames::PerfboardModuleIDName) return true;
+	if (moduleID == ModuleIDNames::StripboardModuleIDName) return true;
+	if (moduleID == ModuleIDNames::Stripboard2ModuleIDName) return true;
+	if (moduleID.endsWith(ModuleIDNames::BreadboardModuleIDName, Qt::CaseInsensitive)) return true;
+	if (moduleID.compare("HalfBreadboardModuleID", Qt::CaseInsensitive) == 0) return true;
+	if (moduleID.compare("HalfMinusBreadboardModuleID", Qt::CaseInsensitive) == 0) return true;
+	if (moduleID.compare("MiniBreadboardModuleID", Qt::CaseInsensitive) == 0) return true;
+	if (moduleID.compare("TinyBreadboardModuleID", Qt::CaseInsensitive) == 0) return true;
+
+	return false;
+}
+
+bool BreadboardTopology::isBreadboardDecorationItem(ItemBase * itemBase)
+{
+	if (itemBase == nullptr) return false;
+
+	QString moduleID = itemBase->moduleID();
+	return moduleID == ModuleIDNames::BreadboardLogoTextModuleIDName
+	    || moduleID == ModuleIDNames::BreadboardLogoImageModuleIDName;
+}
+
+bool BreadboardTopology::isTargetBreadboardHole(ConnectorItem * connectorItem)
+{
+	if (connectorItem == nullptr) return false;
+	return connectorItem->connectorType() == Connector::Female || connectorItem->bus() != nullptr;
+}
+
+bool BreadboardTopology::connectorsShareBus(ConnectorItem * first, ConnectorItem * second)
+{
+	if (first == nullptr || second == nullptr) return false;
+	if (first == second) return true;
+
+	ItemBase * firstItem = first->attachedTo();
+	ItemBase * secondItem = second->attachedTo();
+	if (firstItem == nullptr || secondItem == nullptr) return false;
+
+	QList<ConnectorItem *> firstBusHoles;
+	if (firstItem->busConnectorItems(first, firstBusHoles) && firstBusHoles.contains(second)) return true;
+
+	QList<ConnectorItem *> secondBusHoles;
+	if (secondItem->busConnectorItems(second, secondBusHoles) && secondBusHoles.contains(first)) return true;
+
+	return false;
+}
+
+void BreadboardTopology::clear()
+{
+	m_boards.clear();
+	m_holes.clear();
+	m_reservedHoles.clear();
+	m_busIndex.clear();
+	m_bounds = QRectF();
+	m_sceneConnectorCount = 0;
+	m_itemConnectorCount = 0;
+	m_diagnosticLines.clear();
+}
+
+ItemBase * BreadboardTopology::ownerChief(ConnectorItem * connectorItem)
+{
+	if (connectorItem == nullptr) return nullptr;
+	ItemBase * owner = connectorItem->attachedTo();
+	return owner == nullptr ? nullptr : owner->layerKinChief();
+}
+
+ItemBase * BreadboardTopology::itemChief(QGraphicsItem * graphicsItem)
+{
+	auto * itemBase = dynamic_cast<ItemBase *>(graphicsItem);
+	return itemBase == nullptr ? nullptr : itemBase->layerKinChief();
+}
+
+QString BreadboardTopology::itemSummary(ItemBase * itemBase)
+{
+	if (itemBase == nullptr) return QString("<null item>");
+	return QString("%1 id=%2 module=%3")
+	        .arg(itemBase->title())
+	        .arg(itemBase->id())
+	        .arg(itemBase->moduleID());
+}
+
+QString BreadboardTopology::connectorSummary(ConnectorItem * connectorItem)
+{
+	if (connectorItem == nullptr) return QString("<null connector>");
+	QPointF p = connectorItem->sceneAdjustedTerminalPoint(nullptr);
+	return QString("%1:%2 bus=%3 at=(%4,%5)")
+	        .arg(connectorItem->attachedToTitle())
+	        .arg(connectorItem->connectorSharedID())
+	        .arg(connectorItem->busID())
+	        .arg(p.x())
+	        .arg(p.y());
+}
+
+void BreadboardTopology::addBoard(ItemBase * boardItem, const QList<ConnectorItem *> & holes)
+{
+	if (boardItem == nullptr || holes.isEmpty()) return;
+
+	Board board;
+	board.item = boardItem;
+	Q_FOREACH (ConnectorItem * hole, holes) {
+		if (hole == nullptr) continue;
+		board.holes.append(hole);
+		addHole(hole);
+
+		QPointF p = hole->sceneAdjustedTerminalPoint(nullptr);
+		QRectF pointRect(p, QSizeF(1.0, 1.0));
+		board.bounds = board.bounds.isNull() ? pointRect : board.bounds | pointRect;
+	}
+
+	if (board.holes.isEmpty()) return;
+	board.bounds = board.bounds.adjusted(-24.0, -24.0, 24.0, 24.0);
+	m_bounds = m_bounds.isNull() ? board.bounds : m_bounds | board.bounds;
+	m_boards.append(board);
+}
+
+void BreadboardTopology::addHole(ConnectorItem * hole)
+{
+	if (hole == nullptr) return;
+	if (!m_holes.contains(hole)) m_holes.append(hole);
+	if (hole->connectionsCount() > 0) m_reservedHoles.insert(hole);
+}
+
+void BreadboardTopology::buildBusIndex()
+{
+	QSet<ConnectorItem *> visited;
+	Q_FOREACH (ConnectorItem * hole, m_holes) {
+		if (hole == nullptr || visited.contains(hole)) continue;
+
+		QList<ConnectorItem *> busHoles;
+		ItemBase * owner = hole->attachedTo();
+		if (owner != nullptr) owner->busConnectorItems(hole, busHoles);
+		if (busHoles.isEmpty()) busHoles.append(hole);
+
+		QList<ConnectorItem *> filtered;
+		Q_FOREACH (ConnectorItem * candidate, busHoles) {
+			if (candidate == nullptr) continue;
+			if (!m_holes.contains(candidate)) continue;
+			if (!filtered.contains(candidate)) filtered.append(candidate);
+			visited.insert(candidate);
+		}
+
+		if (filtered.isEmpty()) continue;
+		QString key = hole->busID();
+		if (key.isEmpty()) key = QString("%1:%2").arg(hole->attachedToID()).arg(hole->connectorSharedID());
+		m_busIndex.insert(key, filtered);
+	}
+}

--- a/src/autoroute/breadboardtopology.cpp
+++ b/src/autoroute/breadboardtopology.cpp
@@ -32,7 +32,7 @@ namespace {
 constexpr int MinimumBreadboardHoleCount = 10;
 }
 
-bool BreadboardTopology::discover(QGraphicsScene * scene, const QList<QGraphicsItem *> & selectedItems)
+bool BreadboardTopology::discover(const QGraphicsScene * scene, const QList<QGraphicsItem *> & selectedItems)
 {
 	clear();
 	if (scene == nullptr) return false;
@@ -82,7 +82,7 @@ bool BreadboardTopology::discover(QGraphicsScene * scene, const QList<QGraphicsI
 		// owners in stable id order - hash iteration follows the per-process
 		// seed, and board order decides hole enumeration order downstream.
 		QList<ItemBase *> owners = holesByOwner.keys();
-		std::sort(owners.begin(), owners.end(), [](ItemBase * a, ItemBase * b) { return a->id() < b->id(); });
+		std::sort(owners.begin(), owners.end(), [](const ItemBase * a, const ItemBase * b) { return a->id() < b->id(); });
 
 		ItemBase * bestOwner = nullptr;
 		int bestHoleCount = 0;
@@ -241,11 +241,8 @@ bool BreadboardTopology::connectorsShareBus(ConnectorItem * first, ConnectorItem
 	ItemBase * secondItem = second->attachedTo();
 	if (firstItem == nullptr || secondItem == nullptr) return false;
 
-	QList<ConnectorItem *> firstBusHoles;
-	if (firstItem->busConnectorItems(first, firstBusHoles) && firstBusHoles.contains(second)) return true;
-
-	QList<ConnectorItem *> secondBusHoles;
-	if (secondItem->busConnectorItems(second, secondBusHoles) && secondBusHoles.contains(first)) return true;
+	if (QList<ConnectorItem *> firstBusHoles; firstItem->busConnectorItems(first, firstBusHoles) && firstBusHoles.contains(second)) return true;
+	if (QList<ConnectorItem *> secondBusHoles; secondItem->busConnectorItems(second, secondBusHoles) && secondBusHoles.contains(first)) return true;
 
 	return false;
 }
@@ -262,7 +259,7 @@ void BreadboardTopology::clear()
 	m_diagnosticLines.clear();
 }
 
-ItemBase * BreadboardTopology::ownerChief(ConnectorItem * connectorItem)
+ItemBase * BreadboardTopology::ownerChief(const ConnectorItem * connectorItem)
 {
 	if (connectorItem == nullptr) return nullptr;
 	ItemBase * owner = connectorItem->attachedTo();
@@ -332,8 +329,7 @@ void BreadboardTopology::buildBusIndex()
 		if (hole == nullptr || visited.contains(hole)) continue;
 
 		QList<ConnectorItem *> busHoles;
-		ItemBase * owner = hole->attachedTo();
-		if (owner != nullptr) owner->busConnectorItems(hole, busHoles);
+		if (ItemBase * owner = hole->attachedTo(); owner != nullptr) owner->busConnectorItems(hole, busHoles);
 		if (busHoles.isEmpty()) busHoles.append(hole);
 
 		QList<ConnectorItem *> filtered;

--- a/src/autoroute/breadboardtopology.h
+++ b/src/autoroute/breadboardtopology.h
@@ -44,7 +44,7 @@ public:
 		int itemConnectorCount = 0;
 	};
 
-	bool discover(QGraphicsScene * scene, const QList<QGraphicsItem *> & selectedItems);
+	bool discover(const QGraphicsScene * scene, const QList<QGraphicsItem *> & selectedItems);
 
 	bool isValid() const;
 	const QList<Board> & boards() const;
@@ -64,7 +64,7 @@ public:
 
 private:
 	void clear();
-	static ItemBase * ownerChief(ConnectorItem * connectorItem);
+	static ItemBase * ownerChief(const ConnectorItem * connectorItem);
 	static ItemBase * itemChief(QGraphicsItem * graphicsItem);
 	static QString itemSummary(ItemBase * itemBase);
 	static QString connectorSummary(ConnectorItem * connectorItem);

--- a/src/autoroute/breadboardtopology.h
+++ b/src/autoroute/breadboardtopology.h
@@ -1,0 +1,86 @@
+/*******************************************************************
+
+Part of the Fritzing project - http://fritzing.org
+Copyright (c) 2007-2019 Fritzing
+
+Fritzing is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fritzing is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
+
+********************************************************************/
+
+#ifndef BREADBOARDTOPOLOGY_H
+#define BREADBOARDTOPOLOGY_H
+
+#include <QHash>
+#include <QList>
+#include <QRectF>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+#include "../connectors/connectoritem.h"
+
+class ItemBase;
+class QGraphicsItem;
+class QGraphicsScene;
+
+class BreadboardTopology
+{
+public:
+	struct Board {
+		ItemBase * item = nullptr;
+		QList<ConnectorItem *> holes;
+		QRectF bounds;
+		int itemConnectorCount = 0;
+	};
+
+	bool discover(QGraphicsScene * scene, const QList<QGraphicsItem *> & selectedItems);
+
+	bool isValid() const;
+	const QList<Board> & boards() const;
+	QList<ItemBase *> boardItems() const;
+	const QList<ConnectorItem *> & holes() const;
+	const QSet<ConnectorItem *> & reservedHoles() const;
+	const QRectF & bounds() const;
+	int sceneConnectorCount() const;
+	int itemConnectorCount() const;
+	int busCount() const;
+	QStringList diagnosticLines() const;
+
+	static bool isBreadboardItem(ItemBase * itemBase);
+	static bool isBreadboardDecorationItem(ItemBase * itemBase);
+	static bool isTargetBreadboardHole(ConnectorItem * connectorItem);
+	static bool connectorsShareBus(ConnectorItem * first, ConnectorItem * second);
+
+private:
+	void clear();
+	static ItemBase * ownerChief(ConnectorItem * connectorItem);
+	static ItemBase * itemChief(QGraphicsItem * graphicsItem);
+	static QString itemSummary(ItemBase * itemBase);
+	static QString connectorSummary(ConnectorItem * connectorItem);
+	void addBoard(ItemBase * boardItem, const QList<ConnectorItem *> & holes);
+	void addHole(ConnectorItem * hole);
+	void buildBusIndex();
+
+private:
+	QList<Board> m_boards;
+	QList<ConnectorItem *> m_holes;
+	QSet<ConnectorItem *> m_reservedHoles;
+	QHash<QString, QList<ConnectorItem *> > m_busIndex;
+	QRectF m_bounds;
+	int m_sceneConnectorCount = 0;
+	int m_itemConnectorCount = 0;
+	QStringList m_diagnosticLines;
+};
+
+#endif

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -39,6 +39,11 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include <QFontMetrics>
 #include <QApplication>
 #include <QStyleFactory>
+#include <QSlider>
+#include <QToolButton>
+#include <QFrame>
+#include <QVBoxLayout>
+#include <functional>
 
 
 #include "mainwindow.h"
@@ -967,6 +972,159 @@ SketchToolButton *MainWindow::createAutorouteButton(SketchAreaWidget *parent) {
 	return autorouteButton;
 }
 
+QWidget *MainWindow::createBreadboardRouterTuning(SketchAreaWidget *parent) {
+	struct Knob {
+		const char * settingsKey;
+		QString label;
+		QString toolTip;
+		int minimum;
+		int maximum;
+		double defaultValue;
+		double factor;   // real value = slider value * factor
+	};
+
+	const QList<Knob> knobs = {
+		{ "breadboardAutorouter/leadStretchLimit",
+		  tr("Stretch"),
+		  tr("<b>Lead stretch limit</b><br>"
+		     "How far a component leg may stretch from the body to reach a hole "
+		     "(scene units; one breadboard pitch is 9).<br>"
+		     "Lower values keep parts compact but may force extra jumpers."),
+		  18, 180, 120.0, 1.0 },
+		{ "breadboardAutorouter/jumperPenalty",
+		  tr("Jumpers"),
+		  tr("<b>Jumper penalty</b><br>"
+		     "Cost of landing a net on a bus that needs one more jumper wire.<br>"
+		     "High: avoid jumpers even if leads stretch and bend. "
+		     "Low: spend jumpers freely to keep component leads short and tidy."),
+		  0, 200, 100000.0, 1000.0 },
+		{ "breadboardAutorouter/leadLengthWeight",
+		  tr("Length"),
+		  tr("<b>Lead length weight</b><br>"
+		     "How strongly shorter component leads are preferred.<br>"
+		     "Raise to pull parts tight against their holes; lower to let other "
+		     "goals (fewer jumpers, straighter leads) win."),
+		  0, 50, 1.0, 0.1 },
+		{ "breadboardAutorouter/leadAngleWeight",
+		  tr("Angle"),
+		  tr("<b>Lead angle penalty</b><br>"
+		     "Penalty for leads leaving the body diagonally instead of along "
+		     "its axis.<br>Raise for straight, readable leads; lower to allow "
+		     "diagonal reaches."),
+		  0, 40, 4.0, 0.5 },
+		{ "breadboardAutorouter/foldbackWeight",
+		  tr("Foldback"),
+		  tr("<b>Fold-back penalty</b><br>"
+		     "Penalty for hole pairs closer together than the part's pins, "
+		     "which folds the leads back under the body.<br>"
+		     "Raise to forbid folded leads; lower to allow very compact placements."),
+		  0, 40, 6.0, 0.5 },
+	};
+
+	auto *container = new QFrame(parent);
+	container->setObjectName("breadboardRouterTuning");
+	container->setStyleSheet(
+		"#breadboardRouterTuning QLabel {"
+		"    color: white; font-size: 10px; font-weight: bold; background: transparent;"
+		"}"
+		"#breadboardRouterTuning QSlider {"
+		"    min-height: 24px; background: transparent;"
+		"}"
+		// No sub-page/add-page styling: their rects don't reliably track the
+		// groove and render as full-height blocks. A plain trench + handle
+		// stays crisp.
+		"#breadboardRouterTuning QSlider::groove:horizontal {"
+		"    height: 6px; background: rgba(0, 0, 0, 90); border-radius: 3px;"
+		"}"
+		// Handle height derives from groove height plus the negative margins
+		// (6 + 3 + 3 = 12); an explicit height is ignored for horizontal
+		// handles. A compact near-square avoids Qt's border-radius clipping
+		// quirks entirely.
+		"#breadboardRouterTuning QSlider::handle:horizontal {"
+		"    background: white; border: none;"
+		"    width: 10px; margin: -3px 0; border-radius: 2px;"
+		"}"
+		"#breadboardRouterTuning QToolButton {"
+		"    color: white; font-size: 11px;"
+		"    border: 1px solid rgba(255, 255, 255, 170); border-radius: 3px;"
+		"    padding: 4px 10px; background: transparent;"
+		"}"
+		"#breadboardRouterTuning QToolButton:hover {"
+		"    background: rgba(255, 255, 255, 40);"
+		"}");
+	auto *containerLayout = new QHBoxLayout(container);
+	containerLayout->setContentsMargins(6, 0, 6, 0);
+	containerLayout->setSpacing(10);
+
+	QSettings settings;
+	QList<std::function<void()>> resetters;
+
+	Q_FOREACH (const Knob &knob, knobs) {
+		auto *knobWidget = new QWidget(container);
+		// Fixed height keeps label and slider packed together and vertically
+		// centered in the toolbar instead of spread to its edges. Tall enough
+		// that the round handle is not clipped.
+		knobWidget->setFixedHeight(50);
+		auto *knobLayout = new QVBoxLayout(knobWidget);
+		knobLayout->setContentsMargins(0, 0, 0, 0);
+		knobLayout->setSpacing(3);
+
+		auto *label = new QLabel(knobWidget);
+		label->setAlignment(Qt::AlignHCenter);
+
+		auto *slider = new QSlider(Qt::Horizontal, knobWidget);
+		slider->setRange(knob.minimum, knob.maximum);
+		slider->setFixedWidth(72);
+		// QSlider's vertical size policy is Fixed, so the stylesheet
+		// min-height loses to its native sizeHint and the 16px handle gets
+		// clipped inside the slider's own rect. Force the height in code.
+		slider->setFixedHeight(26);
+		// Keep keyboard focus on the sketch so shortcuts (Ctrl+Z, Ctrl+Shift+A)
+		// are not swallowed by a focused slider.
+		slider->setFocusPolicy(Qt::NoFocus);
+		slider->setToolTip(knob.toolTip);
+		label->setToolTip(knob.toolTip);
+
+		const QString settingsKey = QLatin1String(knob.settingsKey);
+		const QString labelText = knob.label;
+		const double factor = knob.factor;
+		auto updateLabel = [label, labelText, factor](int value) {
+			label->setText(QString("%1 %2").arg(labelText).arg(value * factor));
+		};
+
+		const double storedValue = settings.value(settingsKey, knob.defaultValue).toDouble();
+		slider->setValue(qRound(storedValue / knob.factor));
+		updateLabel(slider->value());
+
+		connect(slider, &QSlider::valueChanged, this, [settingsKey, factor, updateLabel](int value) {
+			QSettings settings;
+			settings.setValue(settingsKey, value * factor);
+			updateLabel(value);
+		});
+
+		const int defaultSliderValue = qRound(knob.defaultValue / knob.factor);
+		resetters.append([slider, defaultSliderValue]() {
+			slider->setValue(defaultSliderValue);
+		});
+
+		knobLayout->addWidget(label);
+		knobLayout->addWidget(slider);
+		containerLayout->addWidget(knobWidget);
+	}
+
+	auto *resetButton = new QToolButton(container);
+	resetButton->setText(tr("Reset"));
+	resetButton->setToolTip(tr("Reset all router tuning sliders to their default values."));
+	resetButton->setFocusPolicy(Qt::NoFocus);
+	resetButton->setFixedHeight(26);
+	connect(resetButton, &QToolButton::clicked, this, [resetters]() {
+		Q_FOREACH (const auto &reset, resetters) reset();
+	});
+	containerLayout->addWidget(resetButton);
+
+	return container;
+}
+
 void MainWindow::updateOrderFabMenu(SketchToolButton* orderFabButton) {
 	if (!orderFabButton) return;
 
@@ -1223,6 +1381,7 @@ QList<QWidget*> MainWindow::getButtonsForView(ViewLayer::ViewID viewId) {
 	case ViewLayer::BreadboardView:
 		retval << createFlipButton(parent)
 			   << createAutorouteButton(parent)
+			   << createBreadboardRouterTuning(parent)
 			   << createRoutingStatusLabel(parent)
 			   << createSimulationButton(parent);
 		break;

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -1221,7 +1221,9 @@ QList<QWidget*> MainWindow::getButtonsForView(ViewLayer::ViewID viewId) {
 	retval << createRotateButton(parent);
 	switch (viewId) {
 	case ViewLayer::BreadboardView:
-		retval << createFlipButton(parent) << createRoutingStatusLabel(parent)
+		retval << createFlipButton(parent)
+			   << createAutorouteButton(parent)
+			   << createRoutingStatusLabel(parent)
 			   << createSimulationButton(parent);
 		break;
 	case ViewLayer::SchematicView:

--- a/src/mainwindow/mainwindow.cpp
+++ b/src/mainwindow/mainwindow.cpp
@@ -233,7 +233,8 @@ struct MissingSvgInfo {
 bool byConnectorCount(MissingSvgInfo & m1, MissingSvgInfo & m2)
 {
 	if (m1.connectorSvgIds.count() == m2.connectorSvgIds.count() && m1.modelPart != m2.modelPart) {
-		m1.equal = m2.equal = true;
+		m1.equal = true;
+		m2.equal = true;
 	}
 
 	return (m1.connectorSvgIds.count() > m2.connectorSvgIds.count());
@@ -268,7 +269,9 @@ MainWindow::MainWindow(ReferenceModel *referenceModel, QWidget * parent) :
 	this->initializeTitle(MainWindow::untitledFileName(),
 						 MainWindow::untitledFileCount(),
 						 MainWindow::fileExtension());
-	m_noSchematicConversion = m_useOldSchematic = m_convertedSchematic = false;
+	m_noSchematicConversion = false;
+	m_useOldSchematic = false;
+	m_convertedSchematic = false;
 	m_initialTab = 1;
 	m_rolloverQuoteDialog = nullptr;
 	setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
@@ -280,8 +283,24 @@ MainWindow::MainWindow(ReferenceModel *referenceModel, QWidget * parent) :
 	m_dontKeepMargins = true;
 
 	m_settingsPrefix = "main/";
-	m_showWelcomeAct = m_showProgramAct = m_raiseWindowAct = m_showPartsBinIconViewAct = m_showAllLayersAct = m_hideAllLayersAct = m_rotate90cwAct = m_showBreadboardAct = m_showSchematicAct = m_showPCBAct = nullptr;
-	m_fileMenu = m_editMenu = m_partMenu = m_windowMenu = m_pcbTraceMenu = m_schematicTraceMenu = m_breadboardTraceMenu = m_viewMenu = nullptr;
+	m_showWelcomeAct = nullptr;
+	m_showProgramAct = nullptr;
+	m_raiseWindowAct = nullptr;
+	m_showPartsBinIconViewAct = nullptr;
+	m_showAllLayersAct = nullptr;
+	m_hideAllLayersAct = nullptr;
+	m_rotate90cwAct = nullptr;
+	m_showBreadboardAct = nullptr;
+	m_showSchematicAct = nullptr;
+	m_showPCBAct = nullptr;
+	m_fileMenu = nullptr;
+	m_editMenu = nullptr;
+	m_partMenu = nullptr;
+	m_windowMenu = nullptr;
+	m_pcbTraceMenu = nullptr;
+	m_schematicTraceMenu = nullptr;
+	m_breadboardTraceMenu = nullptr;
+	m_viewMenu = nullptr;
 	m_infoView = nullptr;
 	m_addedToTemp = false;
 	setAcceptDrops(true);
@@ -290,18 +309,22 @@ MainWindow::MainWindow(ReferenceModel *referenceModel, QWidget * parent) :
 
 	m_closeSilently = false;
 	m_orderFabAct = nullptr;
-	m_viewFromButtonWidget = m_activeLayerButtonWidget = nullptr;
-	m_programView = m_programWindow = nullptr;
+	m_viewFromButtonWidget = nullptr;
+	m_activeLayerButtonWidget = nullptr;
+	m_programView = nullptr;
+	m_programWindow = nullptr;
 	m_welcomeView = nullptr;
 	m_windowMenuSeparator = nullptr;
-	m_schematicWireColorMenu = m_breadboardWireColorMenu = nullptr;
+	m_schematicWireColorMenu = nullptr;
+	m_breadboardWireColorMenu = nullptr;
 	m_checkForUpdatesAct = nullptr;
 	m_fileProgressDialog = nullptr;
 	m_currentGraphicsView = nullptr;
 	m_comboboxChanged = false;
 
 	// Add a timer for autosaving
-	m_backingUp = m_autosaveNeeded = false;
+	m_backingUp = false;
+	m_autosaveNeeded = false;
 	connect(&m_autosaveTimer, SIGNAL(timeout()), this, SLOT(backupSketch()));
 	m_autosaveTimer.start(AutosaveTimeoutMinutes * 60 * 1000);
 
@@ -344,7 +367,8 @@ MainWindow::MainWindow(ReferenceModel *referenceModel, QWidget * parent) :
 #ifdef Q_OS_MACOS
 	//setAttribute(Qt::WA_QuitOnClose, false);					// restoring this temporarily (2008.12.19)
 #endif
-	m_dontClose = m_closing = false;
+	m_dontClose = false;
+	m_closing = false;
 
 	m_referenceModel = referenceModel;
 	m_sketchModel = new SketchModel(true);

--- a/src/mainwindow/mainwindow.h
+++ b/src/mainwindow/mainwindow.h
@@ -553,6 +553,7 @@ protected:
 	SketchToolButton *createShareButton(SketchAreaWidget *parent);
 	SketchToolButton *createFlipButton(SketchAreaWidget *parent);
 	SketchToolButton *createAutorouteButton(SketchAreaWidget *parent);
+	QWidget *createBreadboardRouterTuning(SketchAreaWidget *parent);
 	SketchToolButton *createOrderFabButton(SketchAreaWidget *parent);
 	void updateOrderFabMenu(SketchToolButton* orderFabButton);
 	QWidget *createActiveLayerButton(SketchAreaWidget *parent);

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -4506,7 +4506,7 @@ void MainWindow::orderFab()
 			box.setWindowTitle(tr("Missing copper fill"));
 			box.setText(tr("It is recommended to add copper/ground fill to your circuit to reduce acid usage during production.\n\nContinue upload?"));
 			box.setIcon(QMessageBox::Icon::Question);
-			QPushButton* cancelButton = box.addButton(QMessageBox::Cancel);
+			box.addButton(QMessageBox::Cancel);
 			box.addButton(QMessageBox::Ok);
 			box.setDefaultButton(QMessageBox::Cancel);
 			box.setCheckBox(notAgain);

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -1910,7 +1910,8 @@ void MainWindow::updatePartMenu() {
 	bool zenable = true;
 
 	if (itemCount.selCount <= 0) {
-		zenable = enable = false;
+		zenable = false;
+		enable = false;
 	}
 	else {
 		if (itemCount.itemsCount == itemCount.selCount) {
@@ -3238,7 +3239,8 @@ void MainWindow::enableAddBendpointAct(QGraphicsItem * graphicsItem) {
 		bendpointAction->setLastHoverEnterItem(nullptr);
 		convertToViaAction->setLastHoverEnterConnectorItem(m_currentGraphicsView->lastHoverEnterConnectorItem());
 		convertToViaAction->setLastHoverEnterItem(nullptr);
-		ctvEnabled = enabled = true;
+		enabled = true;
+		ctvEnabled = true;
 	}
 	else if (m_currentGraphicsView->lastHoverEnterItem()) {
 		bendpointAction->setText(tr("Add Bendpoint"));
@@ -3686,17 +3688,21 @@ void MainWindow::obsoleteSMDOrientationSlot() {
 }
 
 void MainWindow::oldSchematicsSlot(const QString &filename, bool & useOldSchematics) {
-	useOldSchematics = m_convertedSchematic = m_useOldSchematic = false;
+	m_convertedSchematic = false;
+	m_useOldSchematic = false;
+	useOldSchematics = false;
 	if (m_noSchematicConversion) return;
 
 	if (m_readOnly) {
-		useOldSchematics = m_useOldSchematic = true;
+		m_useOldSchematic = true;
+		useOldSchematics = true;
 		return;
 	}
 
 	QMessageBox::StandardButton answer = oldSchematicMessage(filename);
 	if (answer == QMessageBox::No) {
-		useOldSchematics = m_useOldSchematic = true;
+		m_useOldSchematic = true;
+		useOldSchematics = true;
 		this->setReadOnly(true);
 	}
 	else {

--- a/src/mainwindow/mainwindow_menu.cpp
+++ b/src/mainwindow/mainwindow_menu.cpp
@@ -36,6 +36,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "../partseditor/pemainwindow.h"
 #include "../help/aboutbox.h"
 #include "../autoroute/mazerouter/mazerouter.h"
+#include "../autoroute/breadboardautorouter.h"
 #include "../autoroute/autorouteprogressdialog.h"
 #include "../autoroute/drc.h"
 #include "../items/resizableboard.h"
@@ -3006,6 +3007,38 @@ void MainWindow::createOrderFabAct() {
 
 
 void MainWindow::newAutoroute() {
+	auto * breadboardSketchWidget = qobject_cast<BreadboardSketchWidget *>(m_currentGraphicsView);
+	if (breadboardSketchWidget != nullptr) {
+		dynamic_cast<SketchAreaWidget *>(breadboardSketchWidget->parent())->routingStatusLabel()->setText(tr("Autorouting..."));
+
+		AutorouteProgressDialog progress(tr("Breadboard Autorouting Progress..."), true, false, false, false, breadboardSketchWidget, this);
+		progress.setModal(true);
+		progress.show();
+		QRect pr = progress.frameGeometry();
+		QRect wr = this->frameGeometry();
+		progress.move(wr.right() - pr.width(), pr.top());
+
+		breadboardSketchWidget->setIgnoreSelectionChangeEvents(true);
+
+		BreadboardAutorouter autorouter(breadboardSketchWidget);
+		connect(&autorouter, SIGNAL(setMaximumProgress(int)), &progress, SLOT(setMaximum(int)), Qt::DirectConnection);
+		connect(&autorouter, SIGNAL(setProgressValue(int)), &progress, SLOT(setValue(int)), Qt::DirectConnection);
+		connect(&autorouter, SIGNAL(setProgressMessage(const QString &)), &progress, SLOT(setMessage(const QString &)));
+		connect(&autorouter, SIGNAL(setProgressMessage2(const QString &)), &progress, SLOT(setMessage2(const QString &)));
+
+		ProcessEventBlocker::processEvents();
+		ProcessEventBlocker::block();
+
+		autorouter.start();
+		breadboardSketchWidget->setIgnoreSelectionChangeEvents(false);
+
+		ProcessEventBlocker::unblock();
+		RoutingStatus routingStatus;
+		routingStatus.zero();
+		Q_EMIT breadboardSketchWidget->routingStatusSignal(breadboardSketchWidget, routingStatus);
+		return;
+	}
+
 	auto * pcbSketchWidget = qobject_cast<PCBSketchWidget *>(m_currentGraphicsView);
 	if (pcbSketchWidget == nullptr) return;
 

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,3 +1,3 @@
 TEMPLATE = subdirs
 
-SUBDIRS = test_gerber test_svg test_textutils test_svg2gerber test_ngspice_simulator test_project_properties test_breadboard_routing_score
+SUBDIRS = test_gerber test_svg test_textutils test_svg2gerber test_ngspice_simulator test_project_properties test_breadboard_routing_score test_breadboard_route_graph

--- a/tests/auto/auto.pro
+++ b/tests/auto/auto.pro
@@ -1,3 +1,3 @@
 TEMPLATE = subdirs
 
-SUBDIRS = test_gerber test_svg test_textutils test_svg2gerber test_ngspice_simulator test_project_properties
+SUBDIRS = test_gerber test_svg test_textutils test_svg2gerber test_ngspice_simulator test_project_properties test_breadboard_routing_score

--- a/tests/auto/test_breadboard_route_graph/test_breadboard_route_graph.cpp
+++ b/tests/auto/test_breadboard_route_graph/test_breadboard_route_graph.cpp
@@ -1,0 +1,253 @@
+#define BOOST_TEST_MODULE Breadboard route graph core tests
+#include <boost/test/included/unit_test.hpp>
+
+#include "autoroute/breadboardroutegraphcore.h"
+#include "autoroute/breadboardplacementkernel.h"
+
+#include <algorithm>
+
+// Fixture: a tiny synthetic board. Three vertical 3-hole "column" buses at
+// x = 0, 30, 300 (bus 0, 1, 2), holes 9 apart vertically. Bus 2 is out of
+// jumper reach (maxJumperLength = 100) from bus 0 but reachable from bus 1
+// only when maxJumperLength allows 270.
+struct TinyBoard
+{
+	QVector<QPointF> positions;
+	QVector<int> buses;
+	BreadboardRouteGraphCore::Options options;
+
+	TinyBoard()
+	{
+		const double columnsX[3] = {0.0, 30.0, 300.0};
+		for (int bus = 0; bus < 3; bus++)
+			for (int row = 0; row < 3; row++)
+			{
+				positions.append(QPointF(columnsX[bus], row * 9.0));
+				buses.append(bus);
+			}
+		options.maxJumperLength = 100.0;
+		options.candidatesPerBusPair = 4;
+	}
+
+	int hole(int bus, int row) const { return bus * 3 + row; }
+	QVector<bool> noneBlocked() const { return QVector<bool>(positions.count(), false); }
+};
+
+BOOST_AUTO_TEST_CASE(spatial_index_matches_brute_force_and_preserves_order)
+{
+	QVector<QPointF> positions;
+	QVector<int> boardIds;
+	for (int board = 0; board < 2; board++)
+	{
+		const double originX = board == 0 ? -45.0 : 200.0;
+		for (int y = 0; y < 8; y++)
+		{
+			for (int x = 0; x < 12; x++)
+			{
+				positions.append(QPointF(originX + x * 9.0, -27.0 + y * 9.0));
+				boardIds.append(board);
+			}
+		}
+	}
+
+	BreadboardPlacementKernel::HoleSpatialIndex index(positions, boardIds, 36.0);
+	const QPointF centers[] = {QPointF(-12.0, 0.0), QPointF(240.0, 18.0), QPointF(0.0, -27.0)};
+	const double radii[] = {0.0, 9.0, 40.5, 100.0};
+	for (const QPointF &center : centers)
+	{
+		for (double radius : radii)
+		{
+			for (int boardId = -1; boardId <= 1; boardId++)
+			{
+				QVector<int> expected;
+				for (int hole = 0; hole < positions.count(); hole++)
+				{
+					if (boardId >= 0 && boardIds.at(hole) != boardId)
+						continue;
+					if (QLineF(center, positions.at(hole)).length() <= radius)
+						expected.append(hole);
+				}
+				const QVector<int> actual = index.withinRadius(center, radius, boardId);
+				BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+				BOOST_CHECK(std::is_sorted(actual.begin(), actual.end()));
+			}
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(spatial_index_includes_radius_boundary_and_handles_bad_board_vector)
+{
+	const QVector<QPointF> positions = {QPointF(0, 0), QPointF(3, 4), QPointF(6, 8), QPointF(-3, -4)};
+	BreadboardPlacementKernel::HoleSpatialIndex index(positions, {}, 3.0);
+	const QVector<int> actual = index.withinRadius(QPointF(0, 0), 5.0);
+	const QVector<int> expected = {0, 1, 3};
+	BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+	BOOST_CHECK(index.withinRadius(QPointF(), -1.0).isEmpty());
+}
+
+BOOST_FIXTURE_TEST_CASE(same_bus_needs_no_jumper, TinyBoard)
+{
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	const auto result = graph.route(hole(0, 0), hole(0, 2), graph.prepareQuery(noneBlocked(), {}, {}));
+	BOOST_REQUIRE(result.found);
+	BOOST_CHECK_EQUAL(result.segments.count(), 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(adjacent_buses_get_one_shortest_jumper, TinyBoard)
+{
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	const auto result = graph.route(hole(0, 0), hole(1, 2), graph.prepareQuery(noneBlocked(), {}, {}));
+	BOOST_REQUIRE(result.found);
+	BOOST_REQUIRE_EQUAL(result.segments.count(), 1);
+	// Shortest hole pair between the buses is any same-row pair (length 30).
+	BOOST_CHECK_CLOSE(result.score.jumperLength, 30.0, 1e-6);
+	BOOST_CHECK_EQUAL(result.score.jumperCount, 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(unreachable_bus_reports_no_route, TinyBoard)
+{
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	const auto result = graph.route(hole(0, 0), hole(2, 0), graph.prepareQuery(noneBlocked(), {}, {}));
+	BOOST_CHECK(!result.found);
+	BOOST_CHECK(!result.reason.isEmpty());
+}
+
+BOOST_FIXTURE_TEST_CASE(longer_reach_routes_multi_hop, TinyBoard)
+{
+	options.maxJumperLength = 280.0;
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	const auto result = graph.route(hole(0, 0), hole(2, 0), graph.prepareQuery(noneBlocked(), {}, {}));
+	BOOST_REQUIRE(result.found);
+	// 0 -> 2 directly is 300 (too long); 0 -> 1 -> 2 is 30 + 270.
+	BOOST_CHECK_EQUAL(result.score.jumperCount, 2);
+	BOOST_CHECK_CLOSE(result.score.jumperLength, 300.0, 1e-6);
+}
+
+BOOST_FIXTURE_TEST_CASE(blocked_holes_are_avoided, TinyBoard)
+{
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	QVector<bool> blocked = noneBlocked();
+	// Block every bus-1 hole except row 2: the jumper must land there.
+	blocked[hole(1, 0)] = true;
+	blocked[hole(1, 1)] = true;
+	const auto result = graph.route(hole(0, 0), hole(1, 2), graph.prepareQuery(noneBlocked(), {}, {}));
+	BOOST_REQUIRE(result.found);
+
+	const auto constrained = graph.route(hole(0, 0), hole(1, 2), graph.prepareQuery(blocked, {}, {}));
+	BOOST_REQUIRE(constrained.found);
+	Q_FOREACH (const auto & segment, constrained.segments)
+	{
+		BOOST_CHECK(segment.fromHole != hole(1, 0) && segment.toHole != hole(1, 0));
+		BOOST_CHECK(segment.fromHole != hole(1, 1) && segment.toHole != hole(1, 1));
+	}
+}
+
+BOOST_FIXTURE_TEST_CASE(fully_blocked_bus_is_unroutable, TinyBoard)
+{
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	QVector<bool> blocked = noneBlocked();
+	for (int row = 0; row < 3; row++)
+		blocked[hole(1, row)] = true;
+	// Target holes stay usable even when flagged, so aim at bus 1 row 0 but
+	// block the whole bus: routing TO it still works (endpoint exemption)...
+	const auto toBlocked = graph.route(hole(0, 0), hole(1, 0), graph.prepareQuery(blocked, {}, {}));
+	BOOST_CHECK(toBlocked.found);
+	// ...but THROUGH it (0 -> 2 multi-hop with reach 280) must fail.
+	options.maxJumperLength = 280.0;
+	BreadboardRouteGraphCore farGraph(positions, buses, options);
+	QVector<bool> blockedFar = blocked;
+	const auto throughBlocked = farGraph.route(hole(0, 0), hole(2, 0), farGraph.prepareQuery(blockedFar, {}, {}));
+	// Direct 0->2 is 300 > 280 and the only intermediate bus is blocked.
+	BOOST_CHECK(!throughBlocked.found);
+}
+
+BOOST_FIXTURE_TEST_CASE(congestion_diverts_to_uncrossed_candidate, TinyBoard)
+{
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	// A planned segment lies across the row-0 corridor between bus 0 and 1.
+	QList<QLineF> planned;
+	planned.append(QLineF(QPointF(15.0, -9.0), QPointF(15.0, 4.5)));
+	const auto result = graph.route(hole(0, 0), hole(1, 0), graph.prepareQuery(noneBlocked(), {}, planned));
+	BOOST_REQUIRE(result.found);
+	// The crossing-free row exists, so no congestion should be paid.
+	BOOST_CHECK_SMALL(result.score.congestion, 1e-9);
+}
+
+BOOST_FIXTURE_TEST_CASE(results_are_deterministic, TinyBoard)
+{
+	options.maxJumperLength = 280.0;
+	BreadboardRouteGraphCore graph(positions, buses, options);
+	const auto first = graph.route(hole(0, 0), hole(2, 2), graph.prepareQuery(noneBlocked(), {}, {}));
+	for (int i = 0; i < 5; i++)
+	{
+		const auto again = graph.route(hole(0, 0), hole(2, 2), graph.prepareQuery(noneBlocked(), {}, {}));
+		BOOST_REQUIRE_EQUAL(again.found, first.found);
+		BOOST_REQUIRE_EQUAL(again.segments.count(), first.segments.count());
+		for (int s = 0; s < again.segments.count(); s++)
+		{
+			BOOST_CHECK_EQUAL(again.segments.at(s).fromHole, first.segments.at(s).fromHole);
+			BOOST_CHECK_EQUAL(again.segments.at(s).toHole, first.segments.at(s).toHole);
+		}
+	}
+}
+
+BOOST_FIXTURE_TEST_CASE(foreign_bus_is_never_touched, TinyBoard)
+{
+	// Bus 1 belongs to another net (e.g. hosts a foreign or no-net pin).
+	// The router must not land on it or pass through it - EVEN when that
+	// leaves only a longer direct jumper or no route at all.
+	QVector<bool> busBlocked(3, false);
+	busBlocked[1] = true;
+
+	// Reach 310: direct 0 -> 2 (length 300) is legal; the "cheaper looking"
+	// two-hop through bus 1 is forbidden.
+	options.maxJumperLength = 310.0;
+	BreadboardRouteGraphCore longGraph(positions, buses, options);
+	const auto direct = longGraph.route(hole(0, 0), hole(2, 0),
+										longGraph.prepareQuery(noneBlocked(), busBlocked, {}));
+	BOOST_REQUIRE(direct.found);
+	BOOST_CHECK_EQUAL(direct.score.jumperCount, 1);
+	Q_FOREACH (const auto & segment, direct.segments)
+	{
+		BOOST_CHECK(buses.at(segment.fromHole) != 1);
+		BOOST_CHECK(buses.at(segment.toHole) != 1);
+	}
+
+	// Reach 280: direct is too long and the only intermediate bus is
+	// foreign -> the net must FAIL rather than break the schematic.
+	options.maxJumperLength = 280.0;
+	BreadboardRouteGraphCore shortGraph(positions, buses, options);
+	const auto blockedRoute = shortGraph.route(hole(0, 0), hole(2, 0),
+											   shortGraph.prepareQuery(noneBlocked(), busBlocked, {}));
+	BOOST_CHECK(!blockedRoute.found);
+
+	// Routing TO a foreign bus is a caller error and must not be exempted.
+	const auto ontoForeign = shortGraph.route(hole(0, 0), hole(1, 0),
+											  shortGraph.prepareQuery(noneBlocked(), busBlocked, {}));
+	BOOST_CHECK(!ontoForeign.found);
+}
+
+BOOST_AUTO_TEST_CASE(congestion_penalty_cases)
+{
+	const double crossing = 700.0;
+	const double overlap = 1200.0;
+	const QLineF candidate(QPointF(0, 0), QPointF(100, 0));
+
+	// Bounded crossing pays the crossing penalty.
+	BOOST_CHECK_CLOSE(BreadboardRouteGraphCore::congestionPenalty(
+						  candidate, {QLineF(QPointF(50, -10), QPointF(50, 10))}, crossing, overlap),
+					  crossing, 1e-9);
+	// Collinear overlap pays the overlap penalty.
+	BOOST_CHECK_CLOSE(BreadboardRouteGraphCore::congestionPenalty(
+						  candidate, {QLineF(QPointF(40, 0), QPointF(140, 0))}, crossing, overlap),
+					  overlap, 1e-9);
+	// Sharing an endpoint is free (wires meeting at a hole).
+	BOOST_CHECK_SMALL(BreadboardRouteGraphCore::congestionPenalty(
+						  candidate, {QLineF(QPointF(100, 0), QPointF(100, 50))}, crossing, overlap),
+					  1e-9);
+	// Disjoint segments are free.
+	BOOST_CHECK_SMALL(BreadboardRouteGraphCore::congestionPenalty(
+						  candidate, {QLineF(QPointF(0, 20), QPointF(100, 20))}, crossing, overlap),
+					  1e-9);
+}
+

--- a/tests/auto/test_breadboard_route_graph/test_breadboard_route_graph.cpp
+++ b/tests/auto/test_breadboard_route_graph/test_breadboard_route_graph.cpp
@@ -5,6 +5,7 @@
 #include "autoroute/breadboardplacementkernel.h"
 
 #include <algorithm>
+#include <array>
 
 // Fixture: a tiny synthetic board. Three vertical 3-hole "column" buses at
 // x = 0, 30, 300 (bus 0, 1, 2), holes 9 apart vertically. Bus 2 is out of
@@ -18,7 +19,7 @@ struct TinyBoard
 
 	TinyBoard()
 	{
-		const double columnsX[3] = {0.0, 30.0, 300.0};
+		const std::array<double, 3> columnsX = {0.0, 30.0, 300.0};
 		for (int bus = 0; bus < 3; bus++)
 			for (int row = 0; row < 3; row++)
 			{
@@ -51,8 +52,8 @@ BOOST_AUTO_TEST_CASE(spatial_index_matches_brute_force_and_preserves_order)
 	}
 
 	BreadboardPlacementKernel::HoleSpatialIndex index(positions, boardIds, 36.0);
-	const QPointF centers[] = {QPointF(-12.0, 0.0), QPointF(240.0, 18.0), QPointF(0.0, -27.0)};
-	const double radii[] = {0.0, 9.0, 40.5, 100.0};
+	const std::array<QPointF, 3> centers = {QPointF(-12.0, 0.0), QPointF(240.0, 18.0), QPointF(0.0, -27.0)};
+	const std::array<double, 4> radii = {0.0, 9.0, 40.5, 100.0};
 	for (const QPointF &center : centers)
 	{
 		for (double radius : radii)
@@ -77,10 +78,10 @@ BOOST_AUTO_TEST_CASE(spatial_index_matches_brute_force_and_preserves_order)
 
 BOOST_AUTO_TEST_CASE(spatial_index_includes_radius_boundary_and_handles_bad_board_vector)
 {
-	const QVector<QPointF> positions = {QPointF(0, 0), QPointF(3, 4), QPointF(6, 8), QPointF(-3, -4)};
+	const QList positions = {QPointF(0, 0), QPointF(3, 4), QPointF(6, 8), QPointF(-3, -4)};
 	BreadboardPlacementKernel::HoleSpatialIndex index(positions, {}, 3.0);
 	const QVector<int> actual = index.withinRadius(QPointF(0, 0), 5.0);
-	const QVector<int> expected = {0, 1, 3};
+	const QList expected = {0, 1, 3};
 	BOOST_CHECK_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
 	BOOST_CHECK(index.withinRadius(QPointF(), -1.0).isEmpty());
 }

--- a/tests/auto/test_breadboard_route_graph/test_breadboard_route_graph.pro
+++ b/tests/auto/test_breadboard_route_graph/test_breadboard_route_graph.pro
@@ -1,0 +1,18 @@
+CONFIG += c++17 console
+QT += core
+
+absolute_boost = 1
+include($$absolute_path(../../../pri/boostdetect.pri))
+
+INCLUDEPATH += $$absolute_path(../../../src)
+
+SOURCES += \
+    test_breadboard_route_graph.cpp \
+	../../../src/autoroute/breadboardplacementkernel.cpp \
+    ../../../src/autoroute/breadboardroutegraphcore.cpp \
+    ../../../src/autoroute/breadboardroutingscore.cpp
+
+HEADERS += \
+	../../../src/autoroute/breadboardplacementkernel.h \
+    ../../../src/autoroute/breadboardroutegraphcore.h \
+    ../../../src/autoroute/breadboardroutingscore.h

--- a/tests/auto/test_breadboard_routing_score/test_breadboard_routing_score.cpp
+++ b/tests/auto/test_breadboard_routing_score/test_breadboard_routing_score.cpp
@@ -1,0 +1,82 @@
+#define BOOST_TEST_MODULE Breadboard routing score tests
+#include <boost/test/included/unit_test.hpp>
+
+#include "autoroute/breadboardroutingscore.h"
+
+#include <algorithm>
+#include <vector>
+
+BOOST_AUTO_TEST_CASE(completion_is_mandatory)
+{
+	BreadboardRoutingScore complete;
+	complete.jumperCount = 20;
+	complete.jumperLength = 2000;
+
+	BreadboardRoutingScore incomplete;
+	incomplete.failedNets = 1;
+	incomplete.jumperCount = 1;
+	incomplete.jumperLength = 10;
+
+	BOOST_CHECK(complete < incomplete);
+}
+
+BOOST_AUTO_TEST_CASE(jumper_count_precedes_all_lengths)
+{
+	BreadboardRoutingScore fewerJumpers;
+	fewerJumpers.jumperCount = 2;
+	fewerJumpers.jumperLength = 1000;
+	fewerJumpers.componentLeadLength = 1000;
+
+	BreadboardRoutingScore moreJumpers;
+	moreJumpers.jumperCount = 3;
+	moreJumpers.jumperLength = 1;
+	moreJumpers.componentLeadLength = 1;
+
+	BOOST_CHECK(fewerJumpers < moreJumpers);
+}
+
+BOOST_AUTO_TEST_CASE(jumper_length_precedes_component_lead_length)
+{
+	BreadboardRoutingScore shorterJumpers;
+	shorterJumpers.jumperCount = 4;
+	shorterJumpers.jumperLength = 100;
+	shorterJumpers.componentLeadLength = 500;
+
+	BreadboardRoutingScore shorterLeads = shorterJumpers;
+	shorterLeads.jumperLength = 101;
+	shorterLeads.componentLeadLength = 1;
+
+	BOOST_CHECK(shorterJumpers < shorterLeads);
+}
+
+BOOST_AUTO_TEST_CASE(component_lead_length_precedes_congestion)
+{
+	BreadboardRoutingScore shorterLeads;
+	shorterLeads.jumperCount = 4;
+	shorterLeads.jumperLength = 100;
+	shorterLeads.componentLeadLength = 20;
+	shorterLeads.congestion = 10000;
+
+	BreadboardRoutingScore cleanerDrawing = shorterLeads;
+	cleanerDrawing.componentLeadLength = 21;
+	cleanerDrawing.congestion = 0;
+
+	BOOST_CHECK(shorterLeads < cleanerDrawing);
+}
+
+BOOST_AUTO_TEST_CASE(parameter_sweep_sorts_by_the_required_objective)
+{
+	std::vector<BreadboardRoutingScore> results(4);
+	results[0] = { 0, 8, 400, 80, 0 };
+	results[1] = { 0, 7, 900, 90, 1000 };
+	results[2] = { 1, 2, 40, 10, 0 };
+	results[3] = { 0, 7, 700, 120, 2000 };
+
+	std::sort(results.begin(), results.end());
+
+	BOOST_CHECK_EQUAL(results[0].jumperCount, 7);
+	BOOST_CHECK_EQUAL(results[0].jumperLength, 700);
+	BOOST_CHECK_EQUAL(results[1].jumperCount, 7);
+	BOOST_CHECK_EQUAL(results[2].jumperCount, 8);
+	BOOST_CHECK_EQUAL(results[3].failedNets, 1);
+}

--- a/tests/auto/test_breadboard_routing_score/test_breadboard_routing_score.pro
+++ b/tests/auto/test_breadboard_routing_score/test_breadboard_routing_score.pro
@@ -1,0 +1,13 @@
+CONFIG += c++17 console
+QT += core
+
+absolute_boost = 1
+include($$absolute_path(../../../pri/boostdetect.pri))
+
+INCLUDEPATH += $$absolute_path(../../../src)
+
+SOURCES += \
+    test_breadboard_routing_score.cpp \
+    ../../../src/autoroute/breadboardroutingscore.cpp
+
+HEADERS += ../../../src/autoroute/breadboardroutingscore.h

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,21 @@
+# Breadboard autoroute benchmarks
+
+The sweep runner opens every input sketch from a clean Fritzing process and ranks
+results using the required objective:
+
+1. zero failed nets;
+2. minimum jumper count;
+3. minimum total jumper length;
+4. minimum component-lead length;
+5. congestion and elapsed time as diagnostics only.
+
+Example:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\tests\benchmarks\breadboard_autoroute_sweep.ps1 `
+  -FzzFiles F:\docs\Fritzing\fuzz.fzz,F:\docs\Fritzing\another-circuit.fzz
+```
+
+The runner writes `artifacts/breadboard-autoroute-sweep.csv`. Each run starts from
+the saved `.fzz`; generated wires and placement from an earlier run cannot leak
+into the next result.

--- a/tests/benchmarks/breadboard_autoroute_sweep.ps1
+++ b/tests/benchmarks/breadboard_autoroute_sweep.ps1
@@ -1,0 +1,220 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$FzzFiles,
+    [string]$ExePath = "F:\src\fritzing-app\release64\Fritzing.exe",
+    [string[]]$MaxJumperLengths = @("180", "240", "320"),
+    [string[]]$CandidatesPerBusPair = @("4", "8", "12"),
+    [string[]]$CrossingPenalties = @("0", "700"),
+    [int]$LoadTimeoutSeconds = 45,
+    [string]$OutputCsv = "F:\src\fritzing-app\artifacts\breadboard-autoroute-sweep.csv",
+    [string]$ScreenshotDirectory = "F:\src\fritzing-app\artifacts\breadboard-autoroute-screenshots"
+)
+
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+
+function Stop-Fritzing {
+    Get-Process Fritzing -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
+function Wait-MainWindow([System.Diagnostics.Process]$Process, [int]$TimeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $Process.Refresh()
+        if ($Process.HasExited) { throw "Fritzing exited before its window opened." }
+        if ($Process.MainWindowHandle -ne 0) { return }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+    throw "Timed out waiting for Fritzing to load."
+}
+
+function Wait-DocumentLoaded([System.Diagnostics.Process]$Process, [string]$DocumentPath, [int]$TimeoutSeconds) {
+    $expectedName = [IO.Path]::GetFileName($DocumentPath)
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        $Process.Refresh()
+        if ($Process.HasExited) { throw "Fritzing exited before the document loaded." }
+        if ($Process.MainWindowTitle -like "*$expectedName*") {
+            Start-Sleep -Seconds 2
+            return
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+    throw "Timed out waiting for Fritzing to load $expectedName."
+}
+
+function Find-AutorouteButton([System.Diagnostics.Process]$Process, [int]$TimeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $condition = New-Object System.Windows.Automation.PropertyCondition(
+        [System.Windows.Automation.AutomationElement]::NameProperty,
+        "Autoroute")
+    do {
+        $Process.Refresh()
+        if ($Process.HasExited) { throw "Fritzing exited before Autoroute became available." }
+        $root = [System.Windows.Automation.AutomationElement]::FromHandle($Process.MainWindowHandle)
+        $button = $root.FindFirst([System.Windows.Automation.TreeScope]::Descendants, $condition)
+        if ($button) { break }
+        Start-Sleep -Milliseconds 500
+    } while ((Get-Date) -lt $deadline)
+    if (-not $button) { throw "Timed out waiting for the Autoroute button." }
+    return $button
+}
+
+function Invoke-Autoroute([System.Diagnostics.Process]$Process, [int]$TimeoutSeconds) {
+    $button = Find-AutorouteButton $Process $TimeoutSeconds
+    $invoke = $button.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
+    $invoke.Invoke()
+}
+
+function Save-WindowScreenshot([System.Diagnostics.Process]$Process, [string]$Path) {
+    $Process.Refresh()
+    if ($Process.HasExited -or $Process.MainWindowHandle -eq 0) {
+        throw "Cannot capture a Fritzing window that is not open."
+    }
+
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class BreadboardBenchmarkWindow {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdc, uint flags);
+}
+"@ -ErrorAction SilentlyContinue
+
+    [BreadboardBenchmarkWindow]::SetForegroundWindow($Process.MainWindowHandle) | Out-Null
+    Start-Sleep -Milliseconds 250
+    $rect = New-Object BreadboardBenchmarkWindow+RECT
+    if (-not [BreadboardBenchmarkWindow]::GetWindowRect($Process.MainWindowHandle, [ref]$rect)) {
+        throw "GetWindowRect failed for Fritzing."
+    }
+    $width = [Math]::Max(1, $rect.Right - $rect.Left)
+    $height = [Math]::Max(1, $rect.Bottom - $rect.Top)
+    $bitmap = New-Object System.Drawing.Bitmap $width, $height
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+        $hdc = $graphics.GetHdc()
+        try {
+            [BreadboardBenchmarkWindow]::PrintWindow($Process.MainWindowHandle, $hdc, 2) | Out-Null
+        }
+        finally {
+            $graphics.ReleaseHdc($hdc)
+        }
+        $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    }
+    finally {
+        $graphics.Dispose()
+        $bitmap.Dispose()
+    }
+}
+
+function Wait-Benchmark([string]$LogPath, [int]$TimeoutSeconds) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (Test-Path -LiteralPath $LogPath) {
+            $line = Get-Content -LiteralPath $LogPath |
+                Where-Object { $_ -match " benchmark: " } |
+                Select-Object -Last 1
+            if ($line) { return }
+        }
+        Start-Sleep -Milliseconds 250
+    } while ((Get-Date) -lt $deadline)
+    throw "Timed out waiting for the autoroute benchmark result."
+}
+
+function Invoke-Undo([System.Diagnostics.Process]$Process) {
+    [BreadboardBenchmarkWindow]::SetForegroundWindow($Process.MainWindowHandle) | Out-Null
+    Start-Sleep -Milliseconds 200
+    [System.Windows.Forms.SendKeys]::SendWait("^z")
+    Start-Sleep -Seconds 2
+}
+
+function Parse-Benchmark([string]$LogPath) {
+    $line = Get-Content -LiteralPath $LogPath |
+        Where-Object { $_ -match " benchmark: " } |
+        Select-Object -Last 1
+    if (-not $line) { throw "Autoroute did not emit a benchmark result." }
+
+    $pattern = 'failedNets=(\d+) jumperCount=(\d+) jumperLength=([0-9.]+) componentLeadLength=([0-9.]+) congestion=([0-9.]+) elapsedMs=(\d+)'
+    if ($line -notmatch $pattern) { throw "Unrecognized benchmark line: $line" }
+    return @{
+        FailedNets = [int]$Matches[1]
+        JumperCount = [int]$Matches[2]
+        JumperLength = [double]$Matches[3]
+        ComponentLeadLength = [double]$Matches[4]
+        Congestion = [double]$Matches[5]
+        ElapsedMs = [int]$Matches[6]
+    }
+}
+
+if (-not (Test-Path -LiteralPath $ExePath)) { throw "Fritzing executable not found: $ExePath" }
+$results = [System.Collections.Generic.List[object]]::new()
+$logPath = Join-Path $env:TEMP "fritzing-breadboard-autorouter.log"
+$expandedFzzFiles = @($FzzFiles | ForEach-Object { $_ -split ',' } | Where-Object { $_ })
+$expandedMaxLengths = @($MaxJumperLengths | ForEach-Object { $_ -split ',' } | ForEach-Object { [double]$_ })
+$expandedCandidateCounts = @($CandidatesPerBusPair | ForEach-Object { $_ -split ',' } | ForEach-Object { [int]$_ })
+$expandedCrossingPenalties = @($CrossingPenalties | ForEach-Object { $_ -split ',' } | ForEach-Object { [double]$_ })
+New-Item -ItemType Directory -Force -Path $ScreenshotDirectory | Out-Null
+Get-ChildItem -LiteralPath $ScreenshotDirectory -Filter "*.png" -ErrorAction SilentlyContinue | Remove-Item -Force
+
+try {
+    foreach ($fzz in $expandedFzzFiles) {
+        if (-not (Test-Path -LiteralPath $fzz)) { throw "FZZ file not found: $fzz" }
+        foreach ($maxLength in $expandedMaxLengths) {
+            foreach ($candidateCount in $expandedCandidateCounts) {
+                foreach ($crossingPenalty in $expandedCrossingPenalties) {
+                    Stop-Fritzing
+                    Remove-Item -LiteralPath $logPath -Force -ErrorAction SilentlyContinue
+                    $env:FRITZING_BB_MAX_JUMPER_LENGTH = $maxLength
+                    $env:FRITZING_BB_CANDIDATES_PER_BUS_PAIR = $candidateCount
+                    $env:FRITZING_BB_CROSSING_PENALTY = $crossingPenalty
+
+                    $process = Start-Process -FilePath $ExePath -ArgumentList @("`"$fzz`"") -PassThru
+                    Wait-MainWindow $process $LoadTimeoutSeconds
+                    Wait-DocumentLoaded $process $fzz $LoadTimeoutSeconds
+                    Find-AutorouteButton $process $LoadTimeoutSeconds | Out-Null
+                    $caseName = "{0}-L{1}-C{2}-X{3}" -f ([IO.Path]::GetFileNameWithoutExtension($fzz)), $maxLength, $candidateCount, $crossingPenalty
+                    Save-WindowScreenshot $process (Join-Path $ScreenshotDirectory "$caseName-before.png")
+                    Invoke-Autoroute $process $LoadTimeoutSeconds
+                    Wait-Benchmark $logPath $LoadTimeoutSeconds
+                    $metrics = Parse-Benchmark $logPath
+                    Save-WindowScreenshot $process (Join-Path $ScreenshotDirectory "$caseName-autorouted.png")
+                    Invoke-Undo $process
+                    Save-WindowScreenshot $process (Join-Path $ScreenshotDirectory "$caseName-undo.png")
+
+                    $results.Add([pscustomobject]@{
+                        Fzz = (Resolve-Path -LiteralPath $fzz).Path
+                        MaxJumperLength = $maxLength
+                        CandidatesPerBusPair = $candidateCount
+                        CrossingPenalty = $crossingPenalty
+                        FailedNets = $metrics.FailedNets
+                        JumperCount = $metrics.JumperCount
+                        JumperLength = $metrics.JumperLength
+                        ComponentLeadLength = $metrics.ComponentLeadLength
+                        Congestion = $metrics.Congestion
+                        ElapsedMs = $metrics.ElapsedMs
+                    })
+                }
+            }
+        }
+    }
+}
+finally {
+    Stop-Fritzing
+    Remove-Item Env:FRITZING_BB_MAX_JUMPER_LENGTH -ErrorAction SilentlyContinue
+    Remove-Item Env:FRITZING_BB_CANDIDATES_PER_BUS_PAIR -ErrorAction SilentlyContinue
+    Remove-Item Env:FRITZING_BB_CROSSING_PENALTY -ErrorAction SilentlyContinue
+}
+
+$ranked = $results | Sort-Object Fzz, FailedNets, JumperCount, JumperLength, ComponentLeadLength, Congestion, ElapsedMs
+$outputDirectory = Split-Path -Parent $OutputCsv
+New-Item -ItemType Directory -Force -Path $outputDirectory | Out-Null
+$ranked | Export-Csv -LiteralPath $OutputCsv -NoTypeInformation
+$ranked | Format-Table -AutoSize
+Write-Host "Results: $OutputCsv"


### PR DESCRIPTION
## Summary

Adds automatic component placement and jumper-wire routing to Fritzing's Breadboard view.

The autorouter:

- discovers breadboard buses from actual connector topology;
- supports mini, full-size, and multiple breadboards;
- places compatible components while leaving peripherals off-board;
- rejects overlaps and same-bus shorts;
- routes external parts through breadboard connection points;
- prioritizes completed nets, fewer jumpers, shorter jumpers, then shorter component leads;
- provides progress and cancellation;
- records the operation as a single Undo action.

## Implementation

- `BreadboardTopology` models holes and electrically connected buses.
- `BreadboardPartPolicy` classifies placeable, peripheral, and ignored parts.
- `BreadboardPlacementKernel` uses spatial indexing to reduce placement-search cost.
- `BreadboardRouteGraphCore` provides deterministic graph routing independent of the GUI.
- Placement ownership is reseeded after component movement.
- Routing supports multiple target breadboards.
- The Breadboard toolbar exposes autorouting and placement-tuning controls.

## Validation

- Added route-graph unit and conformance tests.
- Added routing-score tests and benchmark tooling.
- Built successfully with MSVC 2022 and Qt 6.5.3.
- Tested with mini and multiple breadboards.
- Tested rerouting, cancellation, Undo, peripheral wiring, and saved Fritzing sketches.
- Verified that breadboard autorouting does not alter schematic connectivity.

## Optimization priorities

1. Complete all electrical nets.
2. Minimize jumper count.
3. Minimize total jumper length.
4. Minimize component-lead length and improve lead geometry.

## Limitations

Placement and routing use deterministic heuristics and do not guarantee a globally optimal result. Parts with incomplete or unusual breadboard connector geometry may remain unplaced.