### PR TITLE
Add Redo DRC button to DRC results dialog

### DIFF
--- a/src/autoroute/drc.cpp
+++ b/src/autoroute/drc.cpp
@@ -21,6 +21,7 @@ along with Fritzing.  If not, see <http://www.gnu.org/licenses/>.
 #include "drc.h"
 #include "../connectors/svgidlayer.h"
 #include "../sketch/pcbsketchwidget.h"
+#include "../mainwindow/mainwindow.h"
 #include "../debugdialog.h"
 #include "../utils/graphicsutils.h"
 #include "../utils/folderutils.h"
@@ -165,6 +166,12 @@ DRCResultsDialog::DRCResultsDialog(const QString & message, const QStringList & 
 
 	auto * buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
 	connect(buttonBox, SIGNAL(accepted()), this, SLOT(close()));
+	
+	QAbstractButton * redoButton = buttonBox->addButton(tr("Redo DRC"), QDialogButtonBox::ActionRole);
+	connect(redoButton, &QAbstractButton::clicked, this, [this]() {
+		Q_EMIT redoRequested();
+		close();
+	});
 
 	vLayout->addWidget(buttonBox);
 	this->setLayout(vLayout);
@@ -285,7 +292,16 @@ QStringList DRC::start(bool showOkMessage, double keepoutMils) {
 		}
 		else {
 			auto * dialog = new DRCResultsDialog(message, messages, collidingThings, m_displayItem, m_displayImage, m_sketchWidget, m_sketchWidget->window());
-			dialog->show();
+            QPointer<PCBSketchWidget> sketchWidgetPtr = m_sketchWidget;
+            connect(dialog, &DRCResultsDialog::redoRequested, dialog, [sketchWidgetPtr]() {
+                if (sketchWidgetPtr.isNull()) return;
+                auto * mw = qobject_cast<MainWindow *>(sketchWidgetPtr->window());
+                if (mw != nullptr) {
+                    mw->newDesignRulesCheck(true);
+                }
+            });
+
+            dialog->show();
 		}
 	}
 	else {}

--- a/src/autoroute/drc.h
+++ b/src/autoroute/drc.h
@@ -119,6 +119,9 @@ class DRCResultsDialog : public QDialog
 public:
 	DRCResultsDialog(const QString & message, const QStringList & messages, const QList<CollidingThing *> &, QGraphicsPixmapItem * displayItem,  QImage * displayImage, class PCBSketchWidget * sketchWidget, QWidget *parent = 0);
 	~DRCResultsDialog();
+	
+Q_SIGNALS:
+	void redoRequested();
 
 protected Q_SLOTS:
 	void pressedSlot(QListWidgetItem *);


### PR DESCRIPTION
## What

Adds a **Redo DRC** button next to **OK** in the DRC results dialog for the PCB view.

## Why

Fixes #3247. Previously, after reviewing DRC results and correcting any issues, users had to close the dialog and manually reopen **Routing > Design Rules Check** to run the check again. This change makes that workflow much quicker by allowing the check to be rerun directly from the results dialog.

## How

- Added a `redoRequested()` signal to `DRCResultsDialog`.
- Added a **Redo DRC** button to the dialog. When clicked, it emits the signal and closes the dialog.
- Updated `DRC::start()` to connect the signal to `MainWindow::newDesignRulesCheck()`, allowing the same sketch to be checked again immediately.
- Used a `QPointer` guard to ensure the sketch widget is still valid before rerunning the check.

## Testing

Built and tested locally on Ubuntu 24.04 with Qt 6.5.3.

Verified the following:
- Created a PCB sketch with overlapping parts to trigger DRC errors.
- Ran the Design Rules Check and confirmed the **Redo DRC** button appears next to **OK**.
- Repositioned the components and clicked **Redo DRC**.
- Confirmed the check ran again immediately and the results dialog updated with the new DRC results.

<img width="1028" height="573" alt="redo_drc" src="https://github.com/user-attachments/assets/62c9bdf7-4a36-46c7-8942-fd0a0f2879c6" />
