### PR TITLE
Fix Windows MSVC build: quazip path typo, missing system/zlib libs

### DIFF
--- a/pri/libgit2detect.pri
+++ b/pri/libgit2detect.pri
@@ -52,6 +52,7 @@ win32 {
 
 	INCLUDEPATH += $$LIBGIT2INCLUDE
     LIBS += -L$$LIBGIT2LIB -lgit2
+    LIBS += -lwinhttp -lrpcrt4 -lcrypt32 -lole32 -lsecur32 -lws2_32 -ladvapi32
 }
 
 unix {

--- a/pri/quazipdetect.pri
+++ b/pri/quazipdetect.pri
@@ -11,7 +11,7 @@ message("Using Fritzing quazip detect script.")
 # If you are well versed in # Qt and C/C++ please start helping around
 # and check https://github.com/stachenov/quazip/issues/185
 QUAZIP_VERSION=1.4
-QUAZIP_PATH=$$absolute_path($$PWD/../../quazip-$$QT_VERSION-$$QUAZIP_VERSION)intuisphere
+QUAZIP_PATH=$$absolute_path($$PWD/../../quazip-$$QT_VERSION-$$QUAZIP_VERSION)
 QUAZIP_INCLUDE_PATH=$$QUAZIP_PATH/include/QuaZip-Qt6-$$QUAZIP_VERSION
 QUAZIP_LIB_PATH=$$QUAZIP_PATH/lib
 
@@ -34,4 +34,9 @@ unix {
 
 macx {
 	LIBS += -lz
+}
+
+win32 {
+	ZLIB_PATH = $$absolute_path($$PWD/../../zlib-1.3.1)
+	LIBS += -L$$ZLIB_PATH/lib -lzlibstatic
 }


### PR DESCRIPTION
## Summary
While building Fritzing from source on Windows (Qt 6.10.3, MSVC 2022, x64), I ran into two build-breaking issues in the qmake `pri/` files:

- `pri/quazipdetect.pri` appends a stray `intuisphere` suffix onto `QUAZIP_PATH`, so qmake looks for a folder like `quazip-6.10.3-1.4intuisphere` instead of `quazip-6.10.3-1.4`, and always fails with `"quazip could not be found at ..."`.
- On `win32`, the link step fails with unresolved externals:
  - From `git2.lib`: `WinHttpOpen`, `RegOpenKeyExW`, `CryptAcquireContextA`, etc. — libgit2 (built as a static lib with the WinHTTP backend) needs `winhttp`, `rpcrt4`, `crypt32`, `ole32`, `secur32`, `ws2_32`, `advapi32`, none of which `pri/libgit2detect.pri` links on Windows.
  - From `quazip1-qt6.lib`: `gzopen`, `gzread`, `gzwrite`, etc. — `QuaGzipFile` needs zlib's gzip-file API, which isn't exported by Qt's bundled/private zlib. A real zlib build needs to be linked on win32 (I built zlib 1.3.1 from source and placed it as a sibling `zlib-1.3.1` folder, matching this project's existing convention for `libgit2-*`/`quazip-*`/`Clipper1-*`).

With both fixes, `qmake && jom` produces a working `Fritzing.exe` on Windows 10/11 x64, and I've verified it launches correctly and loads the parts library.

## Test plan
- [x] `qmake phoenix.pro` succeeds and finds quazip at the correct path
- [x] `jom -f Makefile.Release` compiles and links `Fritzing.exe` without unresolved externals
- [x] Launched the resulting `Fritzing.exe`, confirmed the Parts panel and Inspector load real parts from a freshly generated `parts.db`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>