### PR TITLE
Do not store the random PartFactory folder in the parts database

### DIFF
--- a/src/referencemodel/sqlitereferencemodel.cpp
+++ b/src/referencemodel/sqlitereferencemodel.cpp
@@ -1004,6 +1004,8 @@ bool SqliteReferenceModel::insertPart(ModelPart * modelPart, bool fullLoad) {
 				ModelPartShared * mps = modelPart->modelPartShared();
 				if ((mps != nullptr) && (mps->superpart() != nullptr) && mps->superpart()->path().startsWith(prefix)) {
 					bail = false;
+					// drop the random per-session PartFactory folder so parts.db is reproducible
+					path = QFileInfo(path).fileName();
 				}
 			}
 


### PR DESCRIPTION
When the parts database is generated with

    Fritzing -platform minimal -f ./parts -db ./parts/parts.db

the schematic subparts that Fritzing synthesizes on the fly are written into the PartFactory folder.  That folder is named after TextUtils::getRandText() (LockManager::initLockedFiles), so its absolute path differs on every run and gets baked into the parts table, which makes parts.db unreproducible.

The path is dead weight for subparts anyway: a subpart is reloaded through its superpart (ModelPartShared::initConnectors) and the only other user, ModelPart::saveInstance, takes just the file name.  So store the file name instead of the random absolute path.

This cannot regress any consumer of the generated database: the PartFactory folder belongs to the generating session and is removed at exit (PartFactory::cleanup), so the stored absolute path was already dangling for every later session.

See https://reproducible-builds.org/ for why this matters.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).