### PR TITLE
Drop the random per-session PartFactory folder from parts.db

### DIFF
--- a/src/referencemodel/sqlitereferencemodel.cpp
+++ b/src/referencemodel/sqlitereferencemodel.cpp
@@ -1004,6 +1004,8 @@ bool SqliteReferenceModel::insertPart(ModelPart * modelPart, bool fullLoad) {
 				ModelPartShared * mps = modelPart->modelPartShared();
 				if ((mps != nullptr) && (mps->superpart() != nullptr) && mps->superpart()->path().startsWith(prefix)) {
 					bail = false;
+					// drop the random per-session PartFactory folder so parts.db is reproducible
+					path = QFileInfo(path).fileName();
 				}
 			}
 


### PR DESCRIPTION
So that package builds become reproducible.

Without this change, openSUSE's `fritzing-parts-1.0.7` package produced a different result in every build because `/usr/share/fritzing/parts/parts.db` varied.

See https://reproducible-builds.org/ for why this matters.

Reported earlier at https://bugzilla.opensuse.org/show_bug.cgi?id=1239967
_(sorry for leaving ClaudeAI's writeup on #4335. The change is manually reviewed and tested (only build) by me)_